### PR TITLE
feat: CI accuracy checks for skill count and verify alignment

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,3 +38,35 @@ jobs:
             exit 1
           fi
           echo "All skill routing targets exist"
+
+  verify-skill-count:
+    name: Verify skill counts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: README skill count matches directory count
+        run: |
+          ACTUAL=$(ls -d claude/skills/*/ | wc -l | tr -d ' ')
+          README_COUNT=$(grep -oP '\d+(?= skills)' README.md | head -1)
+          if [ "$ACTUAL" != "$README_COUNT" ]; then
+            echo "::error file=README.md::README says $README_COUNT skills but claude/skills/ has $ACTUAL directories. Update README."
+            exit 1
+          fi
+          echo "OK: $ACTUAL skills match README"
+
+      - name: Verify script skill list matches directories
+        run: |
+          LISTED=$(grep 'for skill in' setup/legacy/verify.sh | sed 's/.*for skill in //;s/;.*//' | tr ' ' '\n' | sort)
+          PRESENT=$(ls claude/skills/ | sort)
+
+          MISSING=$(comm -23 <(echo "$LISTED") <(echo "$PRESENT"))
+          if [ -n "$MISSING" ]; then
+            echo "::error file=setup/legacy/verify.sh::Skills listed in verify.sh but not found in claude/skills/: $MISSING"
+            exit 1
+          fi
+
+          UNLISTED=$(comm -13 <(echo "$LISTED") <(echo "$PRESENT"))
+          if [ -n "$UNLISTED" ]; then
+            echo "::warning::Skills in claude/skills/ not listed in verify.sh: $UNLISTED"
+          fi
+          echo "OK: verify.sh skill list is accurate"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 - Cross-references to gotcha numbers updated in autolearn-patterns.md and workflow-preferences.md
 - AGENT-WORKFLOW-GUIDE.md: replaced Python pseudo-code agent examples with correct `.claude/agents/*.md` format
 
+### Added
+
+- CI: README skill count accuracy check (fails if count doesn't match `claude/skills/` directories)
+- CI: verify.sh skill list accuracy check (fails on missing directories, warns on unlisted skills)
+
 ### Changed
 
 - Bash setup scripts moved to `setup/legacy/` with deprecation headers (PowerShell primary)


### PR DESCRIPTION
## Summary

- Adds README skill count validation: fails CI if the stated count doesn't match `claude/skills/` directory count
- Adds verify.sh skill list validation: fails if a listed skill has no directory, warns if a directory isn't listed
- Both checks run as a new `verify-skill-count` job alongside existing lint and routing checks

Closes #24

## Test plan

- [ ] All three CI jobs pass (markdown lint, skill routing, skill counts)
- [ ] Manually verify: `ls -d claude/skills/*/ | wc -l` matches README count (15)
- [ ] Manually verify: verify.sh skill list matches directory listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)