### PR TITLE
feat: bootstrap.ps1 phases 3-4 -- git config, devspace setup, credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `machine/manual-requirements.md`: reference for non-automatable setup steps (Hyper-V, WSL2, Docker config, Dev Mode)
 - `setup/backup.ps1`: refresh machine snapshot files from current state with diff summary
 - `setup/bootstrap.ps1` phases 1-2: pre-flight checks (Windows version, Hyper-V, WSL2, virtualization, Developer Mode) and core tool installs from machine/winget.json + vscode-extensions.txt
+- `setup/bootstrap.ps1` phases 3-4: git config from template, devspace directory setup with ~/.devkit-config.json, PowerShell profile alias, credentials collection via Windows Credential Manager
 
 ### Changed
 


### PR DESCRIPTION
## Summary

Adds phases 3-4 to bootstrap.ps1:

- **Phase 3**: Interactive git configuration (writes `~/.gitconfig` from `machine/git-config.template` with user values), devspace directory creation (stores path in `~/.devkit-config.json`), PowerShell profile alias (with diff preview and confirmation)
- **Phase 4**: Credential collection via `Invoke-CredentialCollection` -- GitHub PAT (with prefix validation), Anthropic API key, optional Docker Hub token. All stored in Windows Credential Manager.

Also dot-sources `credentials.ps1` and updates the main `Invoke-Bootstrap` orchestrator to include phases 3-4.

## Test plan

- [ ] `pwsh -File setup/bootstrap.ps1 -Phase 3` configures git and devspace
- [ ] `pwsh -File setup/bootstrap.ps1 -Phase 4` collects credentials
- [ ] Phase 3 skips git config if `user.name` and `user.email` already set
- [ ] Phase 4 skips already-stored credentials
- [ ] CI passes (markdown lint)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)