### PR TITLE
feat: add Go CLI and Go Web stack profiles (issue #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 - `project-templates/concept-brief.md`: project vision capture template for Kit 3 scaffolding
 - `project-templates/claude-md-template.md`: fallback CLAUDE.md template for new projects
 - `project-templates/github-labels.json`: standard label set (13 labels) for new GitHub repos
+- `profiles/go-cli.md`: base Go profile (winget, linters, VS Code extensions, cross-compilation)
+- `profiles/go-web.md`: extended Go+Web profile (buf, gRPC, REST client, Docker deployment)
 
 ### Changed
 

--- a/profiles/go-cli.md
+++ b/profiles/go-cli.md
@@ -1,0 +1,176 @@
+---
+name: go-cli
+version: 1.0
+description: Go CLI and daemon development (toolchain, linters, static analysis)
+requires: []
+winget:
+  - id: GoLang.Go
+    check: go
+manual:
+  - id: golangci-lint
+    check: golangci-lint
+    install: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+  - id: staticcheck
+    check: staticcheck
+    install: go install honnef.co/go/tools/cmd/staticcheck@latest
+  - id: govulncheck
+    check: govulncheck
+    install: go install golang.org/x/vuln/cmd/govulncheck@latest
+  - id: swag
+    check: swag
+    install: go install github.com/swaggo/swag/cmd/swag@latest
+    note: Swagger spec generation -- see known-gotchas.md for drift issues
+vscode-extensions:
+  - golang.go
+  - eamodio.gitlens
+  - streetsidesoftware.code-spell-checker
+claude-skills:
+  - go-development
+  - systematic-debugging
+  - security-review
+---
+
+# Go CLI Profile
+
+Use this profile for Go CLI tools, daemons, and background services. These are standalone binaries with no HTTP handlers or gRPC services.
+
+## When to Use This
+
+- Command-line tools (CLI arguments parsing, exit codes)
+- System daemons (background processes, signal handling)
+- Workers and job processors (batch operations, scheduling)
+- Anything that compiles to a single binary without web endpoints
+
+If your project has HTTP handlers or gRPC services, use the **go-web** profile instead.
+
+## Windows Setup
+
+### GOPATH
+
+Go defaults to `%USERPROFILE%\go` (usually `C:\Users\YourName\go`) on Windows. Binaries install to `%GOPATH%\bin`.
+
+Add `%GOPATH%\bin` to your PATH:
+
+```powershell
+[Environment]::SetEnvironmentVariable('Path', $env:Path + ';' + $env:USERPROFILE + '\go\bin', 'User')
+# Restart terminal to pick up the change
+```
+
+Verify:
+
+```bash
+go env GOPATH
+echo $env:Path | grep -o '[^;]*go[^;]*'
+```
+
+### Linter Configuration
+
+Create a `.golangci.yml` at the project root. Start with:
+
+```yaml
+run:
+  timeout: 5m
+  skip-dirs:
+    - testdata
+
+linters:
+  enable:
+    - gosimple
+    - govet
+    - gocritic
+    - gosec
+    - staticcheck
+    - revive
+
+issues:
+  exclude-rules:
+    - linters: [gosec]
+      text: "G101"
+```
+
+## Cross-Compilation
+
+Go makes cross-compilation straightforward. Set `GOOS` and `GOARCH` to build for other platforms:
+
+```bash
+# Build for Linux on Windows
+GOOS=linux GOARCH=amd64 go build ./...
+
+# Build for macOS
+GOOS=darwin GOARCH=arm64 go build -o dist/app-macos-arm64 ./cmd/app
+
+# Windows: must include .exe
+GOOS=windows GOARCH=amd64 go build -o dist/app.exe ./cmd/app
+```
+
+**Important gotcha**: On Windows, local `go build ./...` produces `.exe` files (e.g., `myapp.exe`). CI running on Linux will NOT produce `.exe`. If your tests or build scripts assume `.exe` exists, they will fail in CI. Always use `GOOS=linux GOARCH=amd64` for explicit Linux builds.
+
+## Linter and Analysis Tools
+
+### golangci-lint
+
+Runs multiple linters in parallel. Configure which linters to use in `.golangci.yml`:
+
+```bash
+golangci-lint run ./...
+```
+
+Common issues (see known-gotchas.md for detailed fixes):
+
+- **G101** (gosec): Flags constants with "password", "credential", etc. in the name or value. Add `//nolint:gosec // G101: <reason>` on the line.
+- **gocritic**: Catches code quality issues (paramTypeCombine, rangeValCopy, etc.). Fix individually per linter feedback.
+- **staticcheck**: Static analysis for unreachable code, unused variables, logic errors.
+
+### govulncheck
+
+Scans for known vulnerabilities in dependencies:
+
+```bash
+go mod download
+govulncheck ./...
+```
+
+### swag (Swagger)
+
+Generates OpenAPI spec from Go handler comments. See known-gotchas.md sections 15-16 for drift issues.
+
+```bash
+swag init -g cmd/myapp/main.go -o api/swagger --parseDependency --parseInternal
+```
+
+## VS Code Extensions
+
+- **golang.go** (official) — language server, debugging, test runner
+- **eamodio.gitlens** — git blame, history, branches
+- **streetsidesoftware.code-spell-checker** — catch typos in comments and strings
+
+## Testing
+
+```bash
+go test ./...         # all tests in current package and subdirs
+go test -race ./...   # with race detector (not available on Windows MSYS)
+go test -v ./...      # verbose output
+go test -cover ./...  # coverage report
+```
+
+## Build and Release
+
+Use `Makefile` or `just` for common tasks. Typical targets:
+
+```makefile
+build:
+  go build -o dist/app ./cmd/app
+
+test:
+  go test -race ./...
+
+lint:
+  golangci-lint run ./...
+
+clean:
+  rm -rf dist/
+```
+
+## Related Profiles
+
+- **go-web** — if your project has HTTP handlers or gRPC services

--- a/profiles/go-web.md
+++ b/profiles/go-web.md
@@ -1,0 +1,267 @@
+---
+name: go-web
+version: 1.0
+description: Go web server and API development (extends go-cli with HTTP/gRPC tooling)
+requires:
+  - go-cli
+winget: []
+manual:
+  - id: buf
+    check: buf
+    install: go install github.com/bufbuild/buf/cmd/buf@latest
+    note: Protobuf/gRPC toolchain
+  - id: grpc-health-probe
+    check: grpc-health-probe
+    install: go install github.com/grpc-ecosystem/grpc-health-probe@latest
+vscode-extensions:
+  - zxh404.vscode-proto3
+  - humao.rest-client
+claude-skills:
+  - go-development
+  - webapp-testing
+  - security-review
+---
+
+# Go Web Profile
+
+Use this profile for Go web servers, REST APIs, and gRPC services. This profile extends **go-cli** with HTTP and protocol buffer tooling.
+
+## When to Use This
+
+- REST APIs and HTTP services
+- gRPC microservices
+- Web servers with request handlers
+- Anything with `http.Handler` or protocol buffers
+
+If your project is a standalone CLI tool with no network endpoints, use **go-cli** instead.
+
+## Prerequisites
+
+This profile requires **go-cli** to be installed first. The go-cli profile includes the Go toolchain and linters.
+
+## Protobuf and gRPC Workflow
+
+### buf: Protocol Buffer Toolchain
+
+`buf` is the modern replacement for raw `protoc`. It handles code generation, linting, and breaking change detection.
+
+#### Configuration
+
+Create `buf.yaml` at the project root:
+
+```yaml
+version: v1
+build:
+  roots:
+    - proto
+lint:
+  use:
+    - DEFAULT
+breaking:
+  use:
+    - FILE
+```
+
+#### Common Commands
+
+```bash
+# Generate Go code from .proto files
+buf generate
+
+# Lint .proto files for style issues
+buf lint
+
+# Check for breaking changes compared to main branch
+buf breaking --against "https://github.com/owner/repo.git#branch=main"
+
+# Format all .proto files
+buf format -w
+```
+
+#### Generated Code Location
+
+By convention, generated files go into `pkg/api/` or a similar package directory:
+
+```text
+proto/
+├── example.proto
+└── buf.yaml
+
+pkg/api/
+├── example.pb.go
+└── example_grpc.pb.go
+```
+
+### gRPC Health Check Pattern
+
+For gRPC services, implement the health check protocol so clients can verify service readiness:
+
+```go
+import "google.golang.org/grpc/health"
+
+healthCheck := health.NewServer()
+grpc.RegisterService(&grpc.ServiceDesc{ServiceName: "example.Example"}, &exampleServer{})
+healthpb.RegisterHealthServer(grpcServer, healthCheck)
+
+// Mark service as SERVING when ready
+healthCheck.SetServingStatus("example.Example", healthpb.HealthCheckResponse_SERVING)
+```
+
+Test with `grpc-health-probe`:
+
+```bash
+grpc-health-probe -addr=localhost:50051 -service=example.Example
+```
+
+## REST API Development
+
+### Swagger/OpenAPI Documentation
+
+The **go-cli** profile includes `swag` for generating OpenAPI specs from handler comments:
+
+```bash
+swag init -g cmd/myserver/main.go -o api/swagger --parseDependency --parseInternal
+```
+
+Annotate handlers with swagger comments:
+
+```go
+// GetUser retrieves a user by ID.
+//
+// @Summary Get user
+// @Description Get a user by their ID
+// @ID get-user
+// @Produce json
+// @Param id path int true "User ID"
+// @Success 200 {object} User
+// @Router /users/{id} [get]
+func GetUser(w http.ResponseWriter, r *http.Request) {
+    // implementation
+}
+```
+
+See known-gotchas.md sections 15-17 for swagger drift issues and platform-specific gotchas.
+
+### REST Client Testing
+
+Use VS Code's **REST Client** extension (`humao.rest-client`) to test APIs without external tools:
+
+Create `.http` or `.rest` files in your project:
+
+```http
+@base = http://localhost:8080
+@token = your-token-here
+
+### Get a user
+GET {{base}}/api/v1/users/123
+Authorization: Bearer {{token}}
+
+### Create a user
+POST {{base}}/api/v1/users
+Content-Type: application/json
+
+{
+  "name": "Alice",
+  "email": "alice@example.com"
+}
+```
+
+Click the "Send Request" link above each request to execute it. The response appears in a side panel.
+
+## HTTP Handler Best Practices
+
+### Middleware Pattern
+
+Use a middleware wrapper for cross-cutting concerns (logging, auth, CORS):
+
+```go
+func withLogging(next http.HandlerFunc) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        log.Info("request", "method", r.Method, "path", r.URL.Path)
+        next(w, r)
+    }
+}
+
+// Register with middleware
+mux.HandleFunc("/api/users", withLogging(getUsers))
+```
+
+### Request/Response JSON Encoding
+
+Always validate and encode safely:
+
+```go
+var req CreateUserRequest
+if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+    http.Error(w, "invalid request", http.StatusBadRequest)
+    return
+}
+
+// Write response
+w.Header().Set("Content-Type", "application/json")
+json.NewEncoder(w).Encode(resp)
+```
+
+### Error Handling
+
+Return HTTP status codes that reflect the error condition:
+
+```go
+if err := validate(req); err != nil {
+    http.Error(w, err.Error(), http.StatusBadRequest) // 400
+    return
+}
+
+if errors.Is(err, ErrNotFound) {
+    http.Error(w, "not found", http.StatusNotFound)   // 404
+    return
+}
+
+http.Error(w, "internal error", http.StatusInternalServerError) // 500
+```
+
+## VS Code Extensions
+
+- **golang.go** (from go-cli) — language server, debugging
+- **zxh404.vscode-proto3** — syntax highlighting and linting for .proto files
+- **humao.rest-client** — test REST APIs directly in VS Code with .http files
+
+## Testing HTTP Handlers
+
+Use the standard `net/http/httptest` package:
+
+```go
+func TestGetUser(t *testing.T) {
+    req := httptest.NewRequest("GET", "/users/123", nil)
+    w := httptest.NewRecorder()
+
+    GetUser(w, req)
+
+    if w.Code != http.StatusOK {
+        t.Errorf("expected 200, got %d", w.Code)
+    }
+}
+```
+
+## Docker Deployment
+
+Common Dockerfile pattern for Go web services:
+
+```dockerfile
+FROM golang:1.22 as builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o app ./cmd/server
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+COPY --from=builder /app/app /app
+EXPOSE 8080
+CMD ["/app"]
+```
+
+## Related Profiles
+
+- **go-cli** — for standalone CLI tools without HTTP handlers (required dependency)


### PR DESCRIPTION
## Summary

- Adds `profiles/go-cli.md`: base Go profile with winget GoLang.Go, golangci-lint/staticcheck/govulncheck/swag manual installs, VS Code extensions, GOPATH Windows setup, cross-compilation, and linter config
- Adds `profiles/go-web.md`: extends go-cli with buf/grpc-health-probe, REST client extension, proto3 support, gRPC health check patterns, and Docker deployment guidance
- Updates CHANGELOG.md

Closes #15

## Test plan

- [ ] Both files parse correctly through `Get-ProfileFromFile` (profiles.ps1)
- [ ] go-web.md `requires: go-cli` resolves via `Resolve-ProfileDeps`
- [ ] Markdown lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)