### PR TITLE
feat: new-project.ps1 steps 3-4 — CLAUDE.md generation and workspace open (issue #20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - `profiles/iot-embedded.md`: ESP32/ESPHome profile (uv-managed tools, OTA/serial flashing, sensor patterns)
 - `setup/stack.ps1`: Kit 2 profile selection and installer (-List, -ShowProfile, -Install, -Force flags)
 - `setup/new-project.ps1` steps 1-2: concept collection (interactive + file), project scaffolding (git, GitHub, directories, labels, workspace)
+- `setup/new-project.ps1` steps 3-4: Claude-generated CLAUDE.md (with template fallback), Phase 0 issue creation, workspace open
 
 ### Changed
 


### PR DESCRIPTION
## Summary

- Adds Steps 3-4 to `setup/new-project.ps1`, completing the Kit 3 scaffolder
- **Step 3a — Claude-generated CLAUDE.md**: builds prompt from concept brief + profile body + global CLAUDE.md format, calls `claude --print`, shows preview with Y/n/edit loop (n regenerates, edit opens VS Code with `code --wait`)
- **Step 3b — Template fallback**: when Claude not authenticated, substitutes `{{PROJECT_NAME}}`, `{{PROJECT_DESCRIPTION}}`, `{{PROFILE}}`, `{{DEVSPACE}}`, `{{AUTHOR}}`, `{{MACHINE}}`, `{{PROFILE_EXT}}` in claude-md-template.md
- **Phase 0 issue**: creates GitHub issue #1 with concept sections, acceptance criteria, and labels (`chore`, `phase-1`)
- **Step 4 — Workspace open**: summary with location/GitHub/issue URLs, opens `.code-workspace`, shows next steps
- Updates header comment from "Steps 1-2" to "Steps 1-4"
- Updates CHANGELOG.md

Closes #20

## Test plan

- [ ] With Claude auth: `claude --print` generates CLAUDE.md, Y/n/edit prompt works
- [ ] Without Claude auth: template fallback substitutes all placeholders
- [ ] Phase 0 issue created with correct body and labels
- [ ] VS Code workspace opens automatically
- [ ] `-NoGitHub` skips issue creation gracefully
- [ ] CI lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)