### PR TITLE
fix: bootstrap runtime bugs and curate winget manifest

### DIFF
--- a/machine/vscode-extensions.txt
+++ b/machine/vscode-extensions.txt
@@ -10,8 +10,6 @@ codeflow-studio.claude-code-extension
 davidanson.vscode-markdownlint
 dbaeumer.vscode-eslint
 docker.docker
-docker.docker-vscode-extension
-docker.labs-ai-tools-vscode
 drblury.protobuf-vsc
 dunstontc.vscode-go-syntax
 eamodio.gitlens

--- a/machine/winget.json
+++ b/machine/winget.json
@@ -1,437 +1,76 @@
 {
 	"$schema" : "https://aka.ms/winget-packages.schema.2.0.json",
-	"CreationDate" : "2026-02-21T17:03:32.545-00:00",
-	"Sources" : 
+	"CreationDate" : "2026-02-21T21:00:00.000-00:00",
+	"Sources" :
 	[
 		{
-			"Packages" : 
+			"Packages" :
 			[
 				{
-					"PackageIdentifier" : "7zip.7zip",
-					"Version" : "24.08"
+					"PackageIdentifier" : "7zip.7zip"
 				},
 				{
-					"PackageIdentifier" : "CPUID.CPU-Z.ROG",
-					"Version" : "1.91"
+					"PackageIdentifier" : "Canonical.Ubuntu.2404"
 				},
 				{
-					"PackageIdentifier" : "Docker.DockerDesktop",
-					"Version" : "4.60.1"
+					"PackageIdentifier" : "Docker.DockerDesktop"
 				},
 				{
-					"PackageIdentifier" : "FreeCAD.FreeCAD",
-					"Version" : "0.19.2"
+					"PackageIdentifier" : "GitHub.cli"
 				},
 				{
-					"PackageIdentifier" : "Notepad++.Notepad++",
-					"Version" : "8.9.1"
+					"PackageIdentifier" : "GoLang.Go"
 				},
 				{
-					"PackageIdentifier" : "Microsoft.Office",
-					"Version" : "16.0.19628.20204"
+					"PackageIdentifier" : "Graphviz.Graphviz"
 				},
 				{
-					"PackageIdentifier" : "Unity.Unity.6000",
-					"Version" : "6000.3.8f1"
+					"PackageIdentifier" : "KDE.KDiff3"
 				},
 				{
-					"PackageIdentifier" : "Unity.UnityHub",
-					"Version" : "> 3.15.2"
+					"PackageIdentifier" : "Kitware.CMake"
 				},
 				{
-					"PackageIdentifier" : "LimeTechnology.UnraidUSBCreator",
-					"Version" : "1.1.0"
+					"PackageIdentifier" : "Microsoft.DotNet.SDK.10"
 				},
 				{
-					"PackageIdentifier" : "RARLab.WinRAR",
-					"Version" : "5.71.0"
+					"PackageIdentifier" : "Microsoft.VisualStudio.2022.Community"
 				},
 				{
-					"PackageIdentifier" : "Obsidian.Obsidian",
-					"Version" : "1.11.7"
+					"PackageIdentifier" : "Microsoft.PowerShell"
 				},
 				{
-					"PackageIdentifier" : "DimitriVanHeesch.Doxygen",
-					"Version" : "1.9.2"
+					"PackageIdentifier" : "Microsoft.VisualStudioCode"
 				},
 				{
-					"PackageIdentifier" : "Microsoft.OpenJDK.11",
-					"Version" : "11.0.12.7"
+					"PackageIdentifier" : "Microsoft.WSL"
 				},
 				{
-					"PackageIdentifier" : "Microsoft.msodbcsql.17",
-					"Version" : "17.10.6.1"
+					"PackageIdentifier" : "Microsoft.WindowsSDK.10.0.26100"
 				},
 				{
-					"PackageIdentifier" : "Tailscale.Tailscale",
-					"Version" : "1.94.1"
+					"PackageIdentifier" : "Microsoft.WindowsTerminal"
 				},
 				{
-					"PackageIdentifier" : "Microsoft.VCRedist.2010.x64",
-					"Version" : "10.0.40219"
+					"PackageIdentifier" : "Notepad++.Notepad++"
 				},
 				{
-					"PackageIdentifier" : "GitHub.cli",
-					"Version" : "2.85.0"
+					"PackageIdentifier" : "Python.PythonInstallManager"
 				},
 				{
-					"PackageIdentifier" : "Logitech.GHUB",
-					"Version" : "2026.1.828335"
+					"PackageIdentifier" : "Rustlang.Rustup"
 				},
 				{
-					"PackageIdentifier" : "Microsoft.CLRTypesSQLServer.2019",
-					"Version" : "15.0.2000.5"
+					"PackageIdentifier" : "SourceGear.DiffMerge"
 				},
 				{
-					"PackageIdentifier" : "Microsoft.VCRedist.2008.x64",
-					"Version" : "9.0.30729.6161"
+					"PackageIdentifier" : "Unity.Unity.6000"
 				},
 				{
-					"PackageIdentifier" : "Microsoft.WindowsPCHealthCheck",
-					"Version" : "3.6.2204.08001"
-				},
-				{
-					"PackageIdentifier" : "GoLang.Go",
-					"Version" : "1.25.6"
-				},
-				{
-					"PackageIdentifier" : "Oracle.JDK.19",
-					"Version" : "19.0.0.0"
-				},
-				{
-					"PackageIdentifier" : "Corsair.iCUE.5",
-					"Version" : "5.18.106"
-				},
-				{
-					"PackageIdentifier" : "Adobe.Acrobat.Reader.64-bit",
-					"Version" : "25.001.21223"
-				},
-				{
-					"PackageIdentifier" : "Nvidia.PhysX",
-					"Version" : "9.23.1019"
-				},
-				{
-					"PackageIdentifier" : "Kitware.CMake",
-					"Version" : "3.20.6"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.WebDeploy",
-					"Version" : "10.0.9419"
-				},
-				{
-					"PackageIdentifier" : "BlenderFoundation.Blender",
-					"Version" : "4.3.2"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.PowerShell",
-					"Version" : "7.5.4.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.GameInput",
-					"Version" : "10.1.26100.6879"
-				},
-				{
-					"PackageIdentifier" : "SourceGear.DiffMerge",
-					"Version" : "4.2.0.697"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.VisualStudio.2022.Community",
-					"Version" : "< 17.14.27"
-				},
-				{
-					"PackageIdentifier" : "Adobe.CreativeCloud",
-					"Version" : "6.8.1.865"
-				},
-				{
-					"PackageIdentifier" : "Creality.CrealityPrint",
-					"Version" : "7.0.1"
-				},
-				{
-					"PackageIdentifier" : "Arm.GnuArmEmbeddedToolchain",
-					"Version" : "< 14.2.Rel1"
-				},
-				{
-					"PackageIdentifier" : "Google.Chrome.EXE",
-					"Version" : "145.0.7632.76"
-				},
-				{
-					"PackageIdentifier" : "Graphviz.Graphviz",
-					"Version" : "2.49.3"
-				},
-				{
-					"PackageIdentifier" : "KDE.KDiff3",
-					"Version" : "1.9.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.Edge",
-					"Version" : "145.0.3800.65"
-				},
-				{
-					"PackageIdentifier" : "ElectronicArts.Origin",
-					"Version" : "10.5.122.52971"
-				},
-				{
-					"PackageIdentifier" : "Plex.Plex",
-					"Version" : "1.112.0.359"
-				},
-				{
-					"PackageIdentifier" : "RockstarGames.Launcher",
-					"Version" : "1.0.46.448"
-				},
-				{
-					"PackageIdentifier" : "Valve.Steam",
-					"Version" : "2.10.91.91"
-				},
-				{
-					"PackageIdentifier" : "Ultimaker.Cura",
-					"Version" : "4.12.1"
-				},
-				{
-					"PackageIdentifier" : "Unity.Unity.2022",
-					"Version" : "2022.3.44f1"
-				},
-				{
-					"PackageIdentifier" : "Ubisoft.Connect",
-					"Version" : "< 169.6.0.13045"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.VisualStudio.Community",
-					"Version" : "18.3.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.VCRedist.2013.x64",
-					"Version" : "12.0.40664.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.DotNet.SDK.5",
-					"Version" : "5.0.408"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.DotNet.DesktopRuntime.6",
-					"Version" : "6.0.36"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.DotNet.DesktopRuntime.5",
-					"Version" : "5.0.17"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.DotNet.SDK.10",
-					"Version" : "10.0.103"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.VCRedist.2015+.x86",
-					"Version" : "14.50.35719.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.DotNet.DesktopRuntime.8",
-					"Version" : "8.0.24"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.DotNet.Runtime.6",
-					"Version" : "6.0.36"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.DotNet.AspNetCore.6",
-					"Version" : "6.0.36"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.VCRedist.2012.x86",
-					"Version" : "11.0.61030.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.DotNet.DesktopRuntime.3_1",
-					"Version" : "3.1.32"
-				},
-				{
-					"PackageIdentifier" : "Python.Launcher",
-					"Version" : "< 3.9.8"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.DotNet.HostingBundle.8",
-					"Version" : "8.0.24"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.VCRedist.2005.x86",
-					"Version" : "8.0.61001"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.VCRedist.2015+.x64",
-					"Version" : "14.50.35719.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.VCRedist.2008.x86",
-					"Version" : "9.0.30729.6161"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.VCRedist.2013.x86",
-					"Version" : "12.0.40664.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.XNARedist",
-					"Version" : "4.0.30901.0"
-				},
-				{
-					"PackageIdentifier" : "Futuremark.FuturemarkSystemInfo",
-					"Version" : "5.50.1092.0"
-				},
-				{
-					"PackageIdentifier" : "GNE.DualMonitorTools",
-					"Version" : "2.11.0.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.VCRedist.2010.x86",
-					"Version" : "10.0.40219"
-				},
-				{
-					"PackageIdentifier" : "EpicGames.EpicGamesLauncher",
-					"Version" : "1.3.23.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.DotNet.HostingBundle.6",
-					"Version" : "6.0.36"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.DotNet.AspNetCore.3_1",
-					"Version" : "3.1.32"
-				},
-				{
-					"PackageIdentifier" : "Brother.iPrintScan",
-					"Version" : "14.0.1.3"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.WindowsSDK.10.0.26100",
-					"Version" : "10.0.26100.7705"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.VCRedist.2012.x64",
-					"Version" : "11.0.61030.0"
-				},
-				{
-					"PackageIdentifier" : "UnlimitedBacon.STL-Thumb",
-					"Version" : "0.5.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.DotNet.AspNetCore.5",
-					"Version" : "5.0.17"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.DotNet.Runtime.3_1",
-					"Version" : "< 3.1.25"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.DotNet.SDK.6",
-					"Version" : "6.0.203"
-				},
-				{
-					"PackageIdentifier" : "ElectronicArts.EADesktop",
-					"Version" : "13.121.0.5634"
-				},
-				{
-					"PackageIdentifier" : "3Dconnexion.3DxWare.10",
-					"Version" : "10.9.10.725"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.DotNet.SDK.3_1",
-					"Version" : "3.1.426"
-				},
-				{
-					"PackageIdentifier" : "Plex.Plexamp",
-					"Version" : "4.12.3"
-				},
-				{
-					"PackageIdentifier" : "Notion.Notion",
-					"Version" : "7.2.1"
-				},
-				{
-					"PackageIdentifier" : "ArduinoSA.IDE.beta",
-					"Version" : "> 2.0.0.0"
-				},
-				{
-					"PackageIdentifier" : "Amazon.Music",
-					"Version" : "9.5.2.2478"
-				},
-				{
-					"PackageIdentifier" : "Amazon.Kindle",
-					"Version" : "1.33.0.62002"
-				},
-				{
-					"PackageIdentifier" : "GitHub.GitHubDesktop",
-					"Version" : "2.8.1"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.OneDrive",
-					"Version" : "26.017.0126.0002"
-				},
-				{
-					"PackageIdentifier" : "Rustlang.Rustup",
-					"Version" : "1.28.2"
-				},
-				{
-					"PackageIdentifier" : "AivarAnnamaa.Thonny",
-					"Version" : "3.3.13"
-				},
-				{
-					"PackageIdentifier" : "Balena.Etcher",
-					"Version" : "2.1.4"
-				},
-				{
-					"PackageIdentifier" : "Comfy.ComfyUI-Desktop",
-					"Version" : "0.8.0"
-				},
-				{
-					"PackageIdentifier" : "ParadoxInteractive.ParadoxLauncher",
-					"Version" : "1.0.0.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.VisualStudioCode",
-					"Version" : "1.109.5"
-				},
-				{
-					"PackageIdentifier" : "Canonical.Ubuntu.2404",
-					"Version" : "2404.1.26.0"
-				},
-				{
-					"PackageIdentifier" : "Canonical.Ubuntu",
-					"Version" : "2404.1.68.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.Teams",
-					"Version" : "26032.206.4355.6508"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.AppInstaller",
-					"Version" : "1.27.460.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.DirectX",
-					"Version" : "9.29.1974.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.UI.Xaml.2.7",
-					"Version" : "7.2409.9001.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.UI.Xaml.2.8",
-					"Version" : "8.2501.31001.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.VCLibs.Desktop.14",
-					"Version" : "14.0.33728.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.WindowsTerminal",
-					"Version" : "1.23.20211.0"
-				},
-				{
-					"PackageIdentifier" : "Microsoft.WSL",
-					"Version" : "2.6.3.0"
-				},
-				{
-					"PackageIdentifier" : "Python.PythonInstallManager",
-					"Version" : "25.2.240.0"
+					"PackageIdentifier" : "Unity.UnityHub"
 				}
 			],
-			"SourceDetails" : 
+			"SourceDetails" :
 			{
 				"Argument" : "https://cdn.winget.microsoft.com/cache",
 				"Identifier" : "Microsoft.Winget.Source_8wekyb3d8bbwe",

--- a/setup/lib/checks.ps1
+++ b/setup/lib/checks.ps1
@@ -239,12 +239,13 @@ function Test-ClaudeAuth {
         }
     }
 
-    # Check ~/.claude/auth* or credentials files
+    # Check ~/.claude/ for auth or credentials files (including dotfiles)
     $claudeDir = Join-Path $userHome '.claude'
     if (Test-Path $claudeDir) {
-        $authFiles = Get-ChildItem -Path $claudeDir -Filter 'auth*' -File -ErrorAction SilentlyContinue
-        $credFiles = Get-ChildItem -Path $claudeDir -Filter 'credentials*' -File -ErrorAction SilentlyContinue
-        if ($authFiles -or $credFiles) {
+        $authFiles = Get-ChildItem -Path $claudeDir -Filter 'auth*' -File -Force -ErrorAction SilentlyContinue
+        $credFiles = Get-ChildItem -Path $claudeDir -Filter 'credentials*' -File -Force -ErrorAction SilentlyContinue
+        $dotCredFiles = Get-ChildItem -Path $claudeDir -Filter '.credentials*' -File -Force -ErrorAction SilentlyContinue
+        if ($authFiles -or $credFiles -or $dotCredFiles) {
             return @{ Met = $true }
         }
     }
@@ -401,7 +402,7 @@ function Get-PreflightStatus {
     $results = [System.Collections.ArrayList]::new()
 
     # Core tools
-    $coreTools = @('git', 'node', 'npm', 'gh', 'docker', 'claude', 'winget', 'code')
+    $coreTools = @('git', 'gh', 'docker', 'winget', 'code')
     foreach ($tool in $coreTools) {
         $check = Test-Tool $tool
         $null = $results.Add(@{


### PR DESCRIPTION
## Summary

- Fixed 8 runtime bugs discovered during first bootstrap run on a new Windows PC
- Curated `winget.json` from 106 full-machine packages down to 21 dev essentials
- Removed 2 dead VS Code extensions from machine snapshot

### Bootstrap fixes

- `[AllowEmptyString()]` on `_CheckManualRequirement` — empty strings in instruction arrays caused parameter binding failure
- Hyper-V fallback for virtualization check — `Win32_Processor.VirtualizationFirmwareEnabled` returns false when hypervisor is already running
- Winget exit code `-1978335189` (already installed, no upgrade) treated as success instead of failure
- Claude auth detection finds `.credentials.json` dotfiles (added `-Force` flag and `.credentials*` filter)
- Removed `node`/`claude` from preflight checks — Claude Code runs via VS Code extension with bundled Node.js
- PATH refresh from registry before Phase 6 verification — newly installed tools weren't visible
- `Start-Process` for VS Code extension installs — prevents temp editor tabs from opening
- `$null = Invoke-Bootstrap` suppresses hash table return value leak

## Test plan

- [x] Run `pwsh -File setup/setup.ps1 -Kit bootstrap` on clean Windows machine
- [ ] Verify all 6 phases complete without errors
- [ ] Verify Phase 6 tool checks all pass
- [ ] Verify no temp editor tabs open during VS Code extension installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)