### PR TITLE
fix: stack.ps1 runtime bugs and UX improvements

### DIFF
--- a/setup/lib/profiles.ps1
+++ b/setup/lib/profiles.ps1
@@ -208,10 +208,10 @@ function Get-ProfileFromFile {
         })
     }
 
-    # Normalize string arrays (default to empty)
-    $requires        = if ($parsed.ContainsKey('requires'))         { @($parsed['requires']) }         else { @() }
-    $vsCodeExt       = if ($parsed.ContainsKey('vscode-extensions')){ @($parsed['vscode-extensions']) } else { @() }
-    $claudeSkills    = if ($parsed.ContainsKey('claude-skills'))    { @($parsed['claude-skills']) }    else { @() }
+    # Normalize string arrays (default to empty, filter out nulls)
+    $requires        = @(if ($parsed.ContainsKey('requires')          -and $null -ne $parsed['requires'])         { @($parsed['requires']) }         else { @() })
+    $vsCodeExt       = @(if ($parsed.ContainsKey('vscode-extensions') -and $null -ne $parsed['vscode-extensions']){ @($parsed['vscode-extensions']) } else { @() })
+    $claudeSkills    = @(if ($parsed.ContainsKey('claude-skills')     -and $null -ne $parsed['claude-skills'])    { @($parsed['claude-skills']) }    else { @() })
 
     return @{
         Name             = if ($parsed.ContainsKey('name'))        { $parsed['name'] }        else { '' }

--- a/setup/lib/ui.ps1
+++ b/setup/lib/ui.ps1
@@ -119,6 +119,46 @@ function Write-Fail {
     Write-Host "  ${script:Red}${script:CrossMark}${script:Reset} $Message"
 }
 
+# ============================ Progress Spinner ===============================
+
+function Wait-ProcessWithSpinner {
+    <#
+    .SYNOPSIS
+        Waits for a process to exit while showing an animated spinner with elapsed time.
+    .PARAMETER Process
+        The System.Diagnostics.Process object (from Start-Process -PassThru).
+    .PARAMETER Label
+        Text shown next to the spinner.
+    .OUTPUTS
+        Nothing. Returns when the process exits.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [System.Diagnostics.Process]$Process,
+
+        [Parameter(Mandatory)]
+        [string]$Label
+    )
+
+    $frames = @('|', '/', '-', '\')
+    $i = 0
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+
+    while (-not $Process.HasExited) {
+        $elapsed = $sw.Elapsed.ToString('mm\:ss')
+        $frame = $frames[$i % $frames.Count]
+        Write-Host -NoNewline "`r  $frame $Label ($elapsed) "
+        Start-Sleep -Milliseconds 250
+        $i++
+    }
+    $sw.Stop()
+
+    $elapsed = $sw.Elapsed.ToString('mm\:ss')
+    # Clear the spinner line
+    Write-Host -NoNewline "`r$(' ' * ($Label.Length + 20))`r"
+}
+
 # ============================ Verify Table ==================================
 
 function Write-VerifyTable {


### PR DESCRIPTION
## Summary

- Fix `param()` placement before `Set-StrictMode` in stack.ps1
- Add null guards for profile arrays that can be `$null` under strict mode
- Add 5-second timeout to `_ExtractVersion` to prevent hangs on Windows Store Python aliases
- Auto-execute manual install commands (`go install`, `uv tool install`) instead of displaying copy-paste box
- Add animated progress spinner (`Wait-ProcessWithSpinner`) for all long-running operations
- Redirect stdin/stdout/stderr on all VS Code CLI calls to prevent `code-stdin-*` editor tabs

## Test plan

- [x] Run `pwsh -File setup/setup.ps1 -Kit stack`, select iot-embedded (option 3)
- [x] Verify Python skip, uv install, esphome/esptool auto-install with spinners
- [x] Verify no VS Code editor tabs open during execution
- [x] Verify VS Code extension install works with spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)