### PR TITLE
feat: add /plan-review and /code-review skill wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Setup copies rules, skills, agents, and hooks to `~/.claude/`, installs workspac
 | Component | Count | Location |
 |-----------|-------|----------|
 | Rules (auto-loaded every session) | 5 files | `claude/rules/` |
-| Skills (invoke with `/skill-name`) | 15 skills | `claude/skills/` |
+| Skills (invoke with `/skill-name`) | 17 skills | `claude/skills/` |
 | Agent templates | 6 agents | `claude/agents/` |
 | SessionStart hook | 1 | `claude/hooks/` |
 | Setup + verification scripts | 3 | `setup/legacy/` |
@@ -54,7 +54,7 @@ Setup copies rules, skills, agents, and hooks to `~/.claude/`, installs workspac
 
 | Directory | Purpose |
 |-----------|---------|
-| `claude/` | Global Claude Code config — CLAUDE.md, 5 rules files (70+ patterns), 15 skills, 6 agent templates, hooks |
+| `claude/` | Global Claude Code config — CLAUDE.md, 5 rules files (70+ patterns), 17 skills, 6 agent templates, hooks |
 | `devspace/` | Workspace shared configs — .editorconfig, .markdownlint.json, VS Code fragments |
 | `docs/` | Human-readable guides — architecture decisions, profile format spec |
 | `machine/` | Machine state snapshots — VS Code extensions, tool versions |

--- a/claude/skills/code-review/SKILL.md
+++ b/claude/skills/code-review/SKILL.md
@@ -51,7 +51,7 @@ Use the Task tool to launch the `review-code` agent. Pass:
 
 Prompt to pass to the agent:
 
-```
+```text
 Review the following changed files before they are committed.
 
 Changed files:
@@ -92,13 +92,13 @@ for a deeper security pass before allowing the commit to proceed.
 
 After an APPROVE verdict, note in the session:
 
-```
+```text
 Code review: APPROVE (round N) — [files reviewed, one-line summary]
 ```
 
 After addressing REQUEST_CHANGES:
 
-```
+```text
 Code review: APPROVE after revision (round N) — [findings addressed]
 ```
 

--- a/claude/skills/plan-review/SKILL.md
+++ b/claude/skills/plan-review/SKILL.md
@@ -51,7 +51,7 @@ Use the Task tool to launch the `plan-reviewer` agent. Pass:
 
 Prompt to pass to the agent:
 
-```
+```text
 Review the implementation plan at [PLAN_FILE_PATH].
 
 Relevant source files for context (read these to understand existing code the plan builds on):
@@ -78,13 +78,13 @@ resolved before implementation. Do not proceed until either:
 
 After an APPROVE verdict, note in the session:
 
-```
+```text
 Plan review: APPROVE (round N) — [one-line summary of what was checked]
 ```
 
 After a user override of REJECT:
 
-```
+```text
 Plan review: OVERRIDE by user — [reason provided]
 ```
 


### PR DESCRIPTION
## Summary

Adds the two skill wrappers that make the independent review pipeline functional end-to-end.

- **`claude/skills/plan-review/SKILL.md`** (#50) — Invokes the `plan-reviewer` agent with fresh context and a scoped file list. Captures the current plan, limits context to directly referenced files (max 10), spawns the agent via Task tool, and handles the APPROVE/REVISE/REJECT loop up to 3 rounds before escalating to the user.
- **`claude/skills/code-review/SKILL.md`** (#51) — Invokes the `review-code` agent with fresh context scoped to changed files and their direct dependencies (max 15). Critical/High findings block the commit; security category findings escalate to `security-analyzer` for a deeper pass. Supports the `chore(no-review):` bypass for trivial commits per `review-policy.md`.

## What this completes

With this PR merged, the full independent review pipeline is functional:

| Skill | Agent | Trigger |
|-------|-------|---------|
| `/plan-review` | `plan-reviewer` | Before implementation |
| `/code-review` | `review-code` + `security-analyzer` | Before commit |

The `review-policy.md` rule (already on main) auto-loads and mandates both.

## Remaining backlog

- #54 — End-to-end test validating the full assembled pipeline

## Test plan

- [ ] Verify `/plan-review` appears in Claude Code skill list
- [ ] Verify `/code-review` appears in Claude Code skill list
- [ ] Confirm both SKILL.md files pass markdownlint
- [ ] Manually invoke `/plan-review` against a sample plan and confirm agent is spawned
- [ ] Manually invoke `/code-review` against a staged change and confirm agent is spawned

Closes #50, #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)