### PR TITLE
feat: add sync manifest for multi-machine file scoping

### DIFF
--- a/.sync-manifest.json
+++ b/.sync-manifest.json
@@ -1,0 +1,63 @@
+{
+  "version": 1,
+  "description": "Defines which DevKit files are shared (symlinked to ~/.claude/) vs local-only (never synced).",
+  "shared": {
+    "files": [
+      "claude/CLAUDE.md",
+      "claude/claude-functions.sh",
+      "claude/settings.template.json"
+    ],
+    "rules": [
+      "claude/rules/autolearn-patterns.md",
+      "claude/rules/known-gotchas.md",
+      "claude/rules/markdown-style.md",
+      "claude/rules/subagent-ci-checklist.md",
+      "claude/rules/workflow-preferences.md"
+    ],
+    "skills": [
+      "claude/skills/autolearn",
+      "claude/skills/bash-linux",
+      "claude/skills/docker-containerization",
+      "claude/skills/go-development",
+      "claude/skills/manage-github-issues",
+      "claude/skills/powershell-windows",
+      "claude/skills/quality-control",
+      "claude/skills/react-frontend-development",
+      "claude/skills/requirements-generator",
+      "claude/skills/security-review",
+      "claude/skills/server-management",
+      "claude/skills/setup-github-actions",
+      "claude/skills/systematic-debugging",
+      "claude/skills/webapp-testing",
+      "claude/skills/windows-development"
+    ],
+    "agents": [
+      "claude/agents/go-test-writer.md",
+      "claude/agents/portfolio-analyzer.md",
+      "claude/agents/review-code.md",
+      "claude/agents/security-analyzer.md",
+      "claude/agents/vscode-test-writer.md",
+      "claude/agents/vscode-translation-manager.md"
+    ],
+    "hooks": [
+      "claude/hooks/SessionStart.sh"
+    ]
+  },
+  "local_only_patterns": [
+    "claude/rules/*.local.md",
+    "claude/CLAUDE.local.md",
+    "claude/settings.local.json",
+    ".credentials*",
+    "projects/",
+    "plans/",
+    "memory/",
+    "history.jsonl",
+    "stats-cache.json",
+    ".machine-id",
+    ".devkit-config.json"
+  ],
+  "append_only_files": [
+    "claude/rules/autolearn-patterns.md",
+    "claude/rules/known-gotchas.md"
+  ]
+}


### PR DESCRIPTION
## Summary

- Creates `.sync-manifest.json` at repo root defining which DevKit files are shared (symlinked to `~/.claude/`) vs local-only (never synced)
- Enumerates all 5 rule files, 15 skills, 6 agents, 1 hook, and 3 top-level files as shared
- Defines local-only patterns for credentials, session state, machine config, and `*.local.md` files
- Identifies append-only files that support the split-file pattern (#59)

Foundation for the entire sync system (Wave 1).

## Test plan

- [ ] Verify `.sync-manifest.json` is valid JSON
- [ ] Verify all listed files/directories exist in the repo
- [ ] Verify local-only patterns match `.gitignore` conventions

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)