### PR TITLE
feat: split append-only rule files into shared + local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Personal Claude overrides (machine-specific)
 CLAUDE.local.md
+*.local.md
 
 # Machine-specific devkit config (written by bootstrap.ps1)
 .devkit-config.json

--- a/claude/rules/autolearn-patterns.local.md.template
+++ b/claude/rules/autolearn-patterns.local.md.template
@@ -1,0 +1,18 @@
+# Project-Specific Learned Patterns (Local)
+
+This file contains patterns specific to the current project or machine.
+It is NOT synced to DevKit. See `autolearn-patterns.md` for shared generic patterns.
+
+Claude Code loads all `*.md` files from `~/.claude/rules/` automatically,
+so both the shared file and this local file are active simultaneously.
+
+## How to Use
+
+When `/reflect` discovers a new pattern, decide:
+
+- **Generic** (useful in any project): add to `autolearn-patterns.md` (shared)
+- **Project-specific** (references project paths, types, or APIs): add here
+
+## Entries
+
+(add project-specific entries below)

--- a/claude/rules/known-gotchas.local.md.template
+++ b/claude/rules/known-gotchas.local.md.template
@@ -1,0 +1,18 @@
+# Project-Specific Gotchas (Local)
+
+This file contains gotchas specific to the current project or machine.
+It is NOT synced to DevKit. See `known-gotchas.md` for shared generic gotchas.
+
+Claude Code loads all `*.md` files from `~/.claude/rules/` automatically,
+so both the shared file and this local file are active simultaneously.
+
+## How to Use
+
+When you discover a platform or tool gotcha, decide:
+
+- **Generic** (affects any project using that tool): add to `known-gotchas.md` (shared)
+- **Project-specific** (references project paths, APIs, or config): add here
+
+## Entries
+
+(add project-specific entries below)

--- a/claude/rules/subagent-ci-checklist.local.md.template
+++ b/claude/rules/subagent-ci-checklist.local.md.template
@@ -1,0 +1,46 @@
+# Project-Specific CI Checklist (Local)
+
+This file contains CI checklist items specific to the current project.
+It is NOT synced to DevKit. See `subagent-ci-checklist.md` for shared generic checklists.
+
+Claude Code loads all `*.md` files from `~/.claude/rules/` automatically,
+so both the shared file and this local file are active simultaneously.
+
+## How to Use
+
+Add project-specific CI checklist sections here. These supplement the
+shared checklists with paths, tools, and patterns unique to this project.
+
+## Example: SubNetree Project Additions
+
+Below are example entries for a Go + React project (SubNetree). Adapt for your project.
+
+### Frontend Extras (append to Frontend Agent Checklist)
+
+```text
+Additional frontend CI checks:
+- pnpm-lock.yaml drift: CI uses `--frozen-lockfile`. If you added shadcn/ui components or new deps, `pnpm install` MUST run to update the lockfile.
+- Auth API mocks: When mocking `@/api/auth`, use the shared factory: `vi.mock('@/api/auth', async () => { const { authMockFactory } = await import('@/test/mocks/auth'); return authMockFactory() })`. This includes all 8 exports with correct `isMFAChallenge` type guard. Missing exports cause "X is not a function" runtime errors.
+- Union return type narrowing: `loginApi` returns `TokenPair | MFAChallengeResponse`. Every call site must use `isMFAChallenge()` to narrow before accessing `.access_token`. Applies to both production code and test mocks.
+```
+
+### Go Extras (append to Go Agent Checklist)
+
+```text
+Additional Go CI checks:
+5. If you added/modified HTTP handlers with swagger annotations (@Summary, @Router, @Param, etc.):
+   `go run github.com/swaggo/swag/cmd/swag@v1.16.4 init -g cmd/subnetree/main.go -o api/swagger --parseDependency --parseInternal`
+   Then remove any `x-enum-descriptions` blocks from the 3 generated files (Linux CI drops them).
+   Include the regenerated api/swagger/ files with your other changes.
+
+Additional Go CI failures to watch for:
+- exhaustive: Switch on enum types MUST list ALL cases, even with a default return. Group non-matching cases on 2-3 lines.
+- prealloc: `var slice []T` in a loop body should be `make([]T, 0, len(source))`.
+```
+
+### Cross-Language Extras (append to Combined Agent Checklist)
+
+```text
+Cross-Language:
+- If adding new enum values (e.g., DeviceType), audit ALL Record<Type, ...> maps in frontend AND all switch statements in Go. Both languages enforce exhaustiveness.
+```


### PR DESCRIPTION
## Summary

- Creates `*.local.md.template` files for the 3 append-only rule files, enabling clean separation of generic (shared) and project-specific (local-only) learnings
- `autolearn-patterns.local.md.template` — empty with usage header
- `known-gotchas.local.md.template` — empty with usage header
- `subagent-ci-checklist.local.md.template` — populated with SubNetree-specific examples (auth mocks, swagger paths, enum audit)
- Genericizes shared `subagent-ci-checklist.md` by removing SubNetree-specific swagger paths
- Adds `*.local.md` to `.gitignore` (templates use `.local.md.template` extension, so they're tracked)

The split-file pattern works because Claude Code loads all `*.md` files from `~/.claude/rules/` automatically — both the shared file and the local file are active simultaneously.

## Test plan

- [ ] Verify `*.local.md.template` files are tracked by git (not caught by gitignore)
- [ ] Verify `*.local.md` files would be ignored by git
- [ ] Verify shared `subagent-ci-checklist.md` no longer contains project-specific paths

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)