### PR TITLE
feat: auto-push DevKit changes via /reflect integration

### DIFF
--- a/claude/skills/autolearn/workflows/quick-reflect.md
+++ b/claude/skills/autolearn/workflows/quick-reflect.md
@@ -88,3 +88,24 @@ Present a brief summary to the user:
 Rules file updates suggested: [Yes/No]
 - If yes, recommend running `/reflect` with "update knowledge" option
 ```
+
+### 6. DevKit Sync Check
+
+After storing learnings, check if the DevKit clone has uncommitted changes (rules files were likely modified via symlinks):
+
+```bash
+# Find DevKit clone
+DEVKIT=$(python3 -c "import json; c=json.load(open('$HOME/.devkit-config.json')); print(c['devspace']+'/devkit')" 2>/dev/null)
+# Fallback paths
+[ -z "$DEVKIT" ] && for d in "$HOME/DevSpace/devkit" "/d/DevSpace/devkit"; do [ -f "$d/.sync-manifest.json" ] && DEVKIT="$d" && break; done
+
+if [ -n "$DEVKIT" ] && [ -n "$(git -C "$DEVKIT" status --porcelain -- claude/ 2>/dev/null)" ]; then
+    echo "DevKit has uncommitted changes. Run /devkit-sync push to share them."
+fi
+```
+
+If changes exist, append to the summary:
+
+```text
+**DevKit sync:** Uncommitted changes detected. Run `/devkit-sync push` to commit and share.
+```

--- a/claude/skills/autolearn/workflows/session-review.md
+++ b/claude/skills/autolearn/workflows/session-review.md
@@ -141,4 +141,23 @@ Present a comprehensive summary:
 
 ### Recommendations
 - [Suggested follow-up actions]
+
+### DevKit Sync
+- [If uncommitted DevKit changes exist: "Run `/devkit-sync push` to share session learnings"]
 ```
+
+### 8. DevKit Sync Check
+
+After the summary, check if the DevKit clone has uncommitted changes:
+
+```bash
+# Find DevKit clone (same logic as quick-reflect step 6)
+DEVKIT=$(python3 -c "import json; c=json.load(open('$HOME/.devkit-config.json')); print(c['devspace']+'/devkit')" 2>/dev/null)
+[ -z "$DEVKIT" ] && for d in "$HOME/DevSpace/devkit" "/d/DevSpace/devkit"; do [ -f "$d/.sync-manifest.json" ] && DEVKIT="$d" && break; done
+
+if [ -n "$DEVKIT" ] && [ -n "$(git -C "$DEVKIT" status --porcelain -- claude/ 2>/dev/null)" ]; then
+    echo "DevKit has uncommitted changes. Run /devkit-sync push to share them."
+fi
+```
+
+If changes exist, offer to run the push workflow automatically.


### PR DESCRIPTION
## Summary
- Adds Step 6 to `quick-reflect.md`: checks for uncommitted DevKit changes after storing learnings, suggests `/devkit-sync push`
- Adds Step 8 to `session-review.md`: same sync check in comprehensive reviews, offers to run push workflow automatically

## Test plan
- [ ] Run `/reflect` after making rule changes — verify sync suggestion appears
- [ ] Run full session review — verify DevKit Sync section in summary

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)