### PR TITLE
test: end-to-end review pipeline validation

### DIFF
--- a/tests/review-pipeline/README.md
+++ b/tests/review-pipeline/README.md
@@ -1,0 +1,56 @@
+# Review Pipeline E2E Test
+
+Validates that the independent review pipeline (plan-reviewer + review-code agents) correctly identifies security and design flaws in test artifacts.
+
+## Prerequisites
+
+- Claude Code CLI installed and authenticated (`claude --version` works)
+- PowerShell 7+ (`pwsh`)
+
+## Running
+
+```powershell
+pwsh -File tests/review-pipeline/run-review-test.ps1
+```
+
+Add `-Verbose` to see detail on passing tests:
+
+```powershell
+pwsh -File tests/review-pipeline/run-review-test.ps1 -Verbose
+```
+
+## Test Structure
+
+```text
+tests/review-pipeline/
+├── README.md                  # This file
+├── run-review-test.ps1        # Test runner
+├── test-plan.md               # Flawed plan (Critical: plaintext passwords, no token expiry)
+├── test-plan-fixed.md         # Corrected plan (should APPROVE)
+├── test-code/
+│   ├── handler.go             # Flawed code (Critical: SQL injection, command injection)
+│   └── handler-fixed.go       # Corrected code (should APPROVE)
+└── expected-findings.md       # Documents what reviewers should catch
+```
+
+## What It Tests
+
+| Test | Input | Expected Verdict | Key Findings |
+|------|-------|-----------------|--------------|
+| 1. Plan review (flawed) | `test-plan.md` | REVISE or REJECT | Plaintext password storage, no token expiration |
+| 2. Plan review (fixed) | `test-plan-fixed.md` | APPROVE | No Critical/High findings |
+| 3. Code review (flawed) | `handler.go` | REQUEST_CHANGES | SQL injection, command injection |
+| 4. Code review (fixed) | `handler-fixed.go` | APPROVE | No Critical findings |
+
+## Intentional Flaws
+
+See [expected-findings.md](expected-findings.md) for the full list of intentional flaws and where they appear.
+
+## Using as a Template
+
+Copy this directory into any project to validate its review pipeline. Replace the test artifacts with project-relevant examples:
+
+1. Replace `test-plan.md` with a plan containing domain-specific flaws
+2. Replace `handler.go` with code in the project's primary language
+3. Update `expected-findings.md` with the new expected findings
+4. Keep `run-review-test.ps1` as-is (it uses Claude CLI generically)

--- a/tests/review-pipeline/expected-findings.md
+++ b/tests/review-pipeline/expected-findings.md
@@ -1,0 +1,60 @@
+# Expected Findings
+
+What the reviewers should catch in the intentionally flawed test artifacts.
+
+## Plan Review (`test-plan.md`)
+
+### Critical
+
+| Finding | Section | Description |
+|---------|---------|-------------|
+| Plaintext password storage | Step 1, Step 2 | Column is `password TEXT`, step says "store password directly" -- no hashing |
+| No token expiration | Step 3 | "Token never expires" is an explicit security flaw |
+
+### High
+
+| Finding | Section | Description |
+|---------|---------|-------------|
+| SQL injection risk | Step 1 | Schema stores password as TEXT with no indication of parameterized queries |
+| No input validation | Step 2 | No mention of username/password validation rules |
+| No rate limiting | Step 3 | Login endpoint has no brute-force protection |
+| User enumeration | Implied | No mention of generic error messages |
+
+### Medium
+
+| Finding | Section | Description |
+|---------|---------|-------------|
+| Missing refresh token flow | All | No mechanism to refresh expired tokens (if expiry were added) |
+| Vague acceptance criteria | Acceptance Criteria | "Users can register and log in" has no measurable definition |
+
+## Code Review (`test-code/handler.go`)
+
+### Critical
+
+| Finding | Location | Description |
+|---------|----------|-------------|
+| SQL injection | `handler.go:19` | `fmt.Sprintf` with user input in SQL query |
+| Command injection | `handler.go:35` | `exec.Command("ping", ... host)` with unsanitized user input |
+
+### High
+
+| Finding | Location | Description |
+|---------|----------|-------------|
+| Credentials in query string | `handler.go:13-14` | Username and password via `r.URL.Query().Get()` -- logged in access logs, browser history |
+| Plaintext password comparison | `handler.go:25` | Direct string comparison, not bcrypt |
+| Hardcoded secret in token | `handler.go:42` | Static secret key in source code |
+| User enumeration | `handler.go:21` | Error message reveals whether username exists |
+
+### Medium
+
+| Finding | Location | Description |
+|---------|----------|-------------|
+| No Content-Type on response | `handler.go:29` | Returns `text/plain` for auth token, should be `application/json` |
+| Missing method check | `handler.go:12` | No validation that request is POST |
+
+## Fixed Versions
+
+- `test-plan-fixed.md` addresses all Critical and High findings from the plan review
+- `test-code/handler-fixed.go` addresses all Critical and High findings from the code review
+
+Reviewers should return APPROVE (or REQUEST_CHANGES with only Medium/Low findings) on the fixed versions.

--- a/tests/review-pipeline/run-review-test.ps1
+++ b/tests/review-pipeline/run-review-test.ps1
@@ -1,0 +1,325 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    End-to-end test for the independent review pipeline.
+
+.DESCRIPTION
+    Validates that the plan-reviewer and review-code agents correctly identify
+    intentional flaws in test artifacts, and approve corrected versions.
+
+    Requires Claude Code CLI (`claude`) to be installed and authenticated.
+
+.EXAMPLE
+    pwsh -File tests/review-pipeline/run-review-test.ps1
+#>
+
+param(
+    [switch]$Verbose
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$TestDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$Results = @{ Passed = 0; Failed = 0; Skipped = 0 }
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+function Write-TestResult {
+    param([string]$Name, [string]$Status, [string]$Detail)
+    $symbol = switch ($Status) {
+        'PASS' { '[PASS]' }
+        'FAIL' { '[FAIL]' }
+        'SKIP' { '[SKIP]' }
+    }
+    $color = switch ($Status) {
+        'PASS' { 'Green' }
+        'FAIL' { 'Red' }
+        'SKIP' { 'Yellow' }
+    }
+    Write-Host "$symbol $Name" -ForegroundColor $color
+    if ($Detail -and ($Verbose -or $Status -eq 'FAIL')) {
+        Write-Host "       $Detail" -ForegroundColor DarkGray
+    }
+}
+
+function Test-ClaudeCLI {
+    try {
+        $version = & claude --version 2>&1
+        return $null -ne $version
+    }
+    catch {
+        return $false
+    }
+}
+
+function Invoke-ClaudeReview {
+    param([string]$Prompt, [int]$TimeoutSeconds = 120)
+
+    $tempPrompt = Join-Path ([IO.Path]::GetTempPath()) "review-test-$([guid]::NewGuid().ToString('N').Substring(0,8)).txt"
+    Set-Content -Path $tempPrompt -Value $Prompt
+
+    try {
+        $output = & claude --print --prompt (Get-Content $tempPrompt -Raw) 2>&1 | Out-String
+        return $output
+    }
+    finally {
+        Remove-Item $tempPrompt -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Prerequisite check
+# ---------------------------------------------------------------------------
+
+Write-Host ''
+Write-Host '=== Review Pipeline E2E Test ===' -ForegroundColor Cyan
+Write-Host ''
+
+if (-not (Test-ClaudeCLI)) {
+    Write-TestResult 'Prerequisite: Claude CLI' 'SKIP' 'claude command not found or not authenticated'
+    Write-Host ''
+    Write-Host "Install Claude Code and authenticate before running this test." -ForegroundColor Yellow
+    Write-Host "See: https://docs.anthropic.com/en/docs/claude-code" -ForegroundColor Yellow
+    exit 0
+}
+
+Write-TestResult 'Prerequisite: Claude CLI' 'PASS' 'claude command available'
+
+# ---------------------------------------------------------------------------
+# Test 1: Plan review catches flaws in test-plan.md
+# ---------------------------------------------------------------------------
+
+Write-Host ''
+Write-Host '--- Test 1: Plan review (flawed plan) ---' -ForegroundColor Cyan
+
+$planPath = Join-Path $TestDir 'test-plan.md'
+$planContent = Get-Content $planPath -Raw
+
+$planPrompt = @"
+You are a plan reviewer. Review this implementation plan and identify security and design flaws.
+
+Return your response in this exact format:
+- Start with VERDICT: followed by APPROVE, REVISE, or REJECT
+- Then list findings with SEVERITY: (Critical/High/Medium/Low) and FINDING: description
+
+Plan to review:
+
+$planContent
+"@
+
+try {
+    $planResult = Invoke-ClaudeReview -Prompt $planPrompt
+    $hasRejectOrRevise = $planResult -match '(?i)(REJECT|REVISE)'
+    $findsPlaintextPassword = $planResult -match '(?i)(plaintext|plain.text|unhashed|not.hash|store.password.directly|no.hash)'
+    $findsNoExpiry = $planResult -match '(?i)(never.expire|no.expir|token.*expir|expir.*token)'
+
+    if ($hasRejectOrRevise) {
+        Write-TestResult 'Plan review: verdict is REVISE or REJECT' 'PASS'
+        $Results.Passed++
+    }
+    else {
+        Write-TestResult 'Plan review: verdict is REVISE or REJECT' 'FAIL' "Expected REVISE/REJECT, got: $($planResult.Substring(0, [Math]::Min(200, $planResult.Length)))"
+        $Results.Failed++
+    }
+
+    if ($findsPlaintextPassword) {
+        Write-TestResult 'Plan review: identifies plaintext password storage' 'PASS'
+        $Results.Passed++
+    }
+    else {
+        Write-TestResult 'Plan review: identifies plaintext password storage' 'FAIL' 'Reviewer did not flag password storage issue'
+        $Results.Failed++
+    }
+
+    if ($findsNoExpiry) {
+        Write-TestResult 'Plan review: identifies missing token expiration' 'PASS'
+        $Results.Passed++
+    }
+    else {
+        Write-TestResult 'Plan review: identifies missing token expiration' 'FAIL' 'Reviewer did not flag token expiry issue'
+        $Results.Failed++
+    }
+}
+catch {
+    Write-TestResult 'Plan review (flawed plan)' 'FAIL' "Error: $_"
+    $Results.Failed += 3
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: Plan review approves fixed plan
+# ---------------------------------------------------------------------------
+
+Write-Host ''
+Write-Host '--- Test 2: Plan review (fixed plan) ---' -ForegroundColor Cyan
+
+$fixedPlanPath = Join-Path $TestDir 'test-plan-fixed.md'
+$fixedPlanContent = Get-Content $fixedPlanPath -Raw
+
+$fixedPlanPrompt = @"
+You are a plan reviewer. Review this implementation plan and identify any remaining security or design flaws.
+
+Return your response in this exact format:
+- Start with VERDICT: followed by APPROVE, REVISE, or REJECT
+- Then list findings with SEVERITY: (Critical/High/Medium/Low) and FINDING: description
+
+Plan to review:
+
+$fixedPlanContent
+"@
+
+try {
+    $fixedPlanResult = Invoke-ClaudeReview -Prompt $fixedPlanPrompt
+    $hasApprove = $fixedPlanResult -match '(?i)APPROVE'
+    $hasCritical = $fixedPlanResult -match '(?i)Critical'
+
+    if ($hasApprove -and -not $hasCritical) {
+        Write-TestResult 'Fixed plan review: verdict is APPROVE' 'PASS'
+        $Results.Passed++
+    }
+    elseif ($hasApprove) {
+        Write-TestResult 'Fixed plan review: verdict is APPROVE (with caveats)' 'PASS' 'Approved but noted Critical findings -- acceptable variance'
+        $Results.Passed++
+    }
+    else {
+        Write-TestResult 'Fixed plan review: verdict is APPROVE' 'FAIL' "Expected APPROVE, got: $($fixedPlanResult.Substring(0, [Math]::Min(200, $fixedPlanResult.Length)))"
+        $Results.Failed++
+    }
+}
+catch {
+    Write-TestResult 'Fixed plan review' 'FAIL' "Error: $_"
+    $Results.Failed++
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: Code review catches flaws in handler.go
+# ---------------------------------------------------------------------------
+
+Write-Host ''
+Write-Host '--- Test 3: Code review (flawed code) ---' -ForegroundColor Cyan
+
+$codePath = Join-Path $TestDir 'test-code' 'handler.go'
+$codeContent = Get-Content $codePath -Raw
+
+$codePrompt = @"
+You are a code reviewer. Review this Go code for security vulnerabilities and code quality issues.
+
+Return your response in this exact format:
+- Start with VERDICT: followed by APPROVE, REQUEST_CHANGES, or NEEDS_DISCUSSION
+- Then list findings with SEVERITY: (Critical/High/Medium/Low) and FINDING: description including file:line reference
+
+Code to review:
+
+$codeContent
+"@
+
+try {
+    $codeResult = Invoke-ClaudeReview -Prompt $codePrompt
+    $hasRequestChanges = $codeResult -match '(?i)REQUEST.CHANGES'
+    $findsSQLInjection = $codeResult -match '(?i)(SQL.inject|Sprintf.*SQL|string.format.*query|concatenat.*SQL)'
+    $findsCommandInjection = $codeResult -match '(?i)(command.inject|exec\.Command.*user|os.exec.*input|unsanitiz.*command)'
+
+    if ($hasRequestChanges) {
+        Write-TestResult 'Code review: verdict is REQUEST_CHANGES' 'PASS'
+        $Results.Passed++
+    }
+    else {
+        Write-TestResult 'Code review: verdict is REQUEST_CHANGES' 'FAIL' "Expected REQUEST_CHANGES, got: $($codeResult.Substring(0, [Math]::Min(200, $codeResult.Length)))"
+        $Results.Failed++
+    }
+
+    if ($findsSQLInjection) {
+        Write-TestResult 'Code review: identifies SQL injection' 'PASS'
+        $Results.Passed++
+    }
+    else {
+        Write-TestResult 'Code review: identifies SQL injection' 'FAIL' 'Reviewer did not flag SQL injection'
+        $Results.Failed++
+    }
+
+    if ($findsCommandInjection) {
+        Write-TestResult 'Code review: identifies command injection' 'PASS'
+        $Results.Passed++
+    }
+    else {
+        Write-TestResult 'Code review: identifies command injection' 'FAIL' 'Reviewer did not flag command injection'
+        $Results.Failed++
+    }
+}
+catch {
+    Write-TestResult 'Code review (flawed code)' 'FAIL' "Error: $_"
+    $Results.Failed += 3
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: Code review approves fixed code
+# ---------------------------------------------------------------------------
+
+Write-Host ''
+Write-Host '--- Test 4: Code review (fixed code) ---' -ForegroundColor Cyan
+
+$fixedCodePath = Join-Path $TestDir 'test-code' 'handler-fixed.go'
+$fixedCodeContent = Get-Content $fixedCodePath -Raw
+
+$fixedCodePrompt = @"
+You are a code reviewer. Review this Go code for security vulnerabilities and code quality issues.
+
+Return your response in this exact format:
+- Start with VERDICT: followed by APPROVE, REQUEST_CHANGES, or NEEDS_DISCUSSION
+- Then list findings with SEVERITY: (Critical/High/Medium/Low) and FINDING: description
+
+Code to review:
+
+$fixedCodeContent
+"@
+
+try {
+    $fixedCodeResult = Invoke-ClaudeReview -Prompt $fixedCodePrompt
+    $hasApproveCode = $fixedCodeResult -match '(?i)APPROVE'
+    $hasCriticalCode = $fixedCodeResult -match '(?i)Critical'
+
+    if ($hasApproveCode -and -not $hasCriticalCode) {
+        Write-TestResult 'Fixed code review: verdict is APPROVE' 'PASS'
+        $Results.Passed++
+    }
+    elseif ($hasApproveCode) {
+        Write-TestResult 'Fixed code review: verdict is APPROVE (with caveats)' 'PASS' 'Approved but noted caveats -- acceptable'
+        $Results.Passed++
+    }
+    else {
+        Write-TestResult 'Fixed code review: verdict is APPROVE' 'FAIL' "Expected APPROVE, got: $($fixedCodeResult.Substring(0, [Math]::Min(200, $fixedCodeResult.Length)))"
+        $Results.Failed++
+    }
+}
+catch {
+    Write-TestResult 'Fixed code review' 'FAIL' "Error: $_"
+    $Results.Failed++
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+Write-Host ''
+Write-Host '=== Results ===' -ForegroundColor Cyan
+$total = $Results.Passed + $Results.Failed + $Results.Skipped
+Write-Host "  Passed:  $($Results.Passed)/$total" -ForegroundColor Green
+if ($Results.Failed -gt 0) {
+    Write-Host "  Failed:  $($Results.Failed)/$total" -ForegroundColor Red
+}
+if ($Results.Skipped -gt 0) {
+    Write-Host "  Skipped: $($Results.Skipped)/$total" -ForegroundColor Yellow
+}
+Write-Host ''
+
+if ($Results.Failed -gt 0) {
+    Write-Host 'RESULT: FAIL' -ForegroundColor Red
+    exit 1
+}
+else {
+    Write-Host 'RESULT: PASS' -ForegroundColor Green
+    exit 0
+}

--- a/tests/review-pipeline/test-code/handler-fixed.go
+++ b/tests/review-pipeline/test-code/handler-fixed.go
@@ -1,0 +1,55 @@
+package auth
+
+import (
+	"crypto/subtle"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+)
+
+type loginRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// LoginHandler handles user login requests.
+func LoginHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var req loginRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		// Look up user by username using parameterized query
+		var storedHash string
+		err := db.QueryRowContext(r.Context(),
+			"SELECT password_hash FROM users WHERE username = ?", req.Username,
+		).Scan(&storedHash)
+		if err != nil {
+			// Generic message prevents user enumeration
+			http.Error(w, "invalid credentials", http.StatusUnauthorized)
+			return
+		}
+
+		// Constant-time comparison (placeholder for bcrypt.CompareHashAndPassword)
+		if subtle.ConstantTimeCompare([]byte(req.Password), []byte(storedHash)) != 1 {
+			http.Error(w, "invalid credentials", http.StatusUnauthorized)
+			return
+		}
+
+		token := generateToken(req.Username)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"token": token})
+	}
+}
+
+func generateToken(username string) string {
+	// In production: use a proper JWT library with RS256 signing and expiry
+	return "placeholder-jwt-for-" + username
+}

--- a/tests/review-pipeline/test-code/handler.go
+++ b/tests/review-pipeline/test-code/handler.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"os/exec"
+)
+
+// LoginHandler handles user login requests.
+func LoginHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		username := r.URL.Query().Get("username")
+		password := r.URL.Query().Get("password")
+
+		// Look up user by username
+		var storedPassword string
+		query := fmt.Sprintf("SELECT password FROM users WHERE username = '%s'", username)
+		err := db.QueryRow(query).Scan(&storedPassword)
+		if err != nil {
+			http.Error(w, "User not found: "+username, http.StatusUnauthorized)
+			return
+		}
+
+		// Check password
+		if password != storedPassword {
+			http.Error(w, "Wrong password for user: "+username, http.StatusUnauthorized)
+			return
+		}
+
+		// Generate token
+		token := generateToken(username)
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte(token))
+	}
+}
+
+// PingHandler runs a system health check.
+func PingHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		host := r.URL.Query().Get("host")
+		out, err := exec.Command("ping", "-c", "1", host).Output()
+		if err != nil {
+			http.Error(w, "ping failed", http.StatusInternalServerError)
+			return
+		}
+		w.Write(out)
+	}
+}
+
+func generateToken(username string) string {
+	return "token-" + username + "-static-secret-key-12345"
+}

--- a/tests/review-pipeline/test-plan-fixed.md
+++ b/tests/review-pipeline/test-plan-fixed.md
@@ -1,0 +1,63 @@
+# Plan: User Authentication Module
+
+## Goal
+
+Add username/password authentication to the API server with industry-standard security practices.
+
+## Steps
+
+### 1. Create user database table
+
+```sql
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY,
+    username TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### 2. Implement registration endpoint
+
+- `POST /api/register` accepts `{ username, password }`
+- Validate input: username 3-50 chars alphanumeric, password minimum 12 chars
+- Hash password with bcrypt (cost factor 12) before storing
+- Return 201 on success, 400 on validation failure, 409 on duplicate username
+
+### 3. Implement login endpoint
+
+- `POST /api/login` accepts `{ username, password }`
+- Compare password against stored bcrypt hash using constant-time comparison
+- Return a JWT token on success (1-hour expiry, RS256 signing)
+- Rate limit: 5 attempts per IP per minute, exponential backoff after 3 failures
+- Return 401 on failure with generic "invalid credentials" message (no user enumeration)
+
+### 4. Add auth middleware
+
+- Extract token from `Authorization: Bearer <token>` header
+- Verify JWT signature and expiration
+- Reject expired tokens with 401
+- Attach user claims to request context
+
+### 5. Add refresh token flow
+
+- Issue refresh token (7-day expiry) alongside access token
+- `POST /api/refresh` exchanges a valid refresh token for a new access token
+- Refresh tokens are single-use (rotated on each refresh)
+- Store refresh token hashes in database for revocation support
+
+## Security Considerations
+
+- All passwords hashed with bcrypt before storage
+- JWT tokens expire after 1 hour; refresh tokens after 7 days
+- Rate limiting on login to prevent brute force
+- Generic error messages prevent user enumeration
+- Refresh token rotation prevents replay attacks
+
+## Acceptance Criteria
+
+- Users can register with validated input
+- Users can log in and receive time-limited tokens
+- Protected routes reject expired or invalid tokens
+- Login endpoint is rate-limited
+- No plaintext passwords stored anywhere

--- a/tests/review-pipeline/test-plan.md
+++ b/tests/review-pipeline/test-plan.md
@@ -1,0 +1,42 @@
+# Plan: User Authentication Module
+
+## Goal
+
+Add username/password authentication to the API server.
+
+## Steps
+
+### 1. Create user database table
+
+```sql
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY,
+    username TEXT UNIQUE NOT NULL,
+    password TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### 2. Implement registration endpoint
+
+- `POST /api/register` accepts `{ username, password }`
+- Store password directly in the database
+- Return 201 on success
+
+### 3. Implement login endpoint
+
+- `POST /api/login` accepts `{ username, password }`
+- Compare password with stored value
+- Return a JWT token on success
+- Token never expires
+
+### 4. Add auth middleware
+
+- Extract token from `Authorization` header
+- Verify JWT signature
+- Attach user to request context
+
+## Acceptance Criteria
+
+- Users can register and log in
+- Protected routes require a valid token


### PR DESCRIPTION
## Summary
- Add test artifacts with intentional security flaws: SQL injection, command injection, plaintext passwords, no token expiry
- Add corrected versions that should pass review
- PowerShell test runner (`run-review-test.ps1`) invokes Claude CLI to validate both plan-reviewer and code-reviewer produce correct verdicts
- Documented expected findings and template usage for other projects

## Test plan
- [ ] All files pass markdownlint
- [ ] `pwsh -File tests/review-pipeline/run-review-test.ps1` passes (requires Claude CLI auth)

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)