### PR TITLE
fix: sync documentation with actual project state

### DIFF
--- a/.sync-manifest.json
+++ b/.sync-manifest.json
@@ -8,9 +8,12 @@
       "claude/settings.template.json"
     ],
     "rules": [
+      "claude/rules/agent-team-coordination.md",
       "claude/rules/autolearn-patterns.md",
+      "claude/rules/compaction-recovery.md",
       "claude/rules/known-gotchas.md",
       "claude/rules/markdown-style.md",
+      "claude/rules/review-policy.md",
       "claude/rules/subagent-ci-checklist.md",
       "claude/rules/workflow-preferences.md"
     ],
@@ -30,10 +33,13 @@
       "claude/skills/setup-github-actions",
       "claude/skills/systematic-debugging",
       "claude/skills/webapp-testing",
-      "claude/skills/windows-development"
+      "claude/skills/windows-development",
+      "claude/skills/code-review",
+      "claude/skills/plan-review"
     ],
     "agents": [
       "claude/agents/go-test-writer.md",
+      "claude/agents/plan-reviewer.md",
       "claude/agents/portfolio-analyzer.md",
       "claude/agents/review-code.md",
       "claude/agents/security-analyzer.md",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,9 @@ bash setup/legacy/verify.sh
 devkit/
 ├── claude/              - Claude Code config (rules, skills, agents, hooks)
 │   ├── CLAUDE.md        - Global instructions (installed to ~/.claude/)
-│   ├── rules/           - Auto-loaded pattern files (5 files, 70+ patterns)
-│   ├── skills/          - Invokable skills (15 skills with workflow files)
-│   ├── agents/          - Agent templates (6 agents)
+│   ├── rules/           - Auto-loaded pattern files (8 files, 135+ patterns)
+│   ├── skills/          - Invokable skills (18 skills with workflow files)
+│   ├── agents/          - Agent templates (7 agents)
 │   └── hooks/           - SessionStart hook
 ├── devspace/            - Workspace shared configs (.editorconfig, VS Code)
 │   ├── templates/       - Project starter templates (ADR, design, test plan)
@@ -37,6 +37,7 @@ devkit/
 ├── setup/               - PowerShell stubs (*.ps1, lib/*.ps1)
 │   ├── lib/             - Shared PowerShell libraries
 │   └── legacy/          - Deprecated bash scripts
+├── tests/               - E2E tests (review pipeline validation)
 ├── METHODOLOGY.md       - 6-phase development process
 └── CHANGELOG.md         - Version history
 ```
@@ -99,6 +100,8 @@ grep -r "HerbHall\|SubNetree\|D:\\\\DevSpace" claude/ devspace/ mcp/ setup/
 3. Include: category, context, fix, and example
 
 **Sync from a workstation:**
+
+With symlinks active (via `setup/sync.ps1 -Link`), changes to `~/.claude/` are already in the DevKit clone. Run `/devkit-sync push` to commit and push. For manual sync without symlinks:
 
 ```bash
 cp ~/.claude/rules/*.md claude/rules/

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Setup creates symlinks from `~/.claude/` to the DevKit clone (or copies files in
 
 | Component | Count | Location |
 |-----------|-------|----------|
-| Rules (auto-loaded every session) | 5 files | `claude/rules/` |
+| Rules (auto-loaded every session) | 8 files | `claude/rules/` |
 | Skills (invoke with `/skill-name`) | 18 skills | `claude/skills/` |
-| Agent templates | 6 agents | `claude/agents/` |
+| Agent templates | 7 agents | `claude/agents/` |
 | SessionStart hook | 1 | `claude/hooks/` |
 | Setup + verification scripts | 3 | `setup/legacy/` |
 
@@ -54,7 +54,7 @@ Setup creates symlinks from `~/.claude/` to the DevKit clone (or copies files in
 
 | Directory | Purpose |
 |-----------|---------|
-| `claude/` | Global Claude Code config — CLAUDE.md, 5 rules files (70+ patterns), 18 skills, 6 agent templates, hooks |
+| `claude/` | Global Claude Code config — CLAUDE.md, 8 rules files (135+ patterns), 18 skills, 7 agent templates, hooks |
 | `devspace/` | Workspace shared configs — .editorconfig, .markdownlint.json, VS Code fragments |
 | `docs/` | Human-readable guides — architecture decisions, profile format spec |
 | `machine/` | Machine state snapshots — VS Code extensions, tool versions |
@@ -190,9 +190,12 @@ With symlinks active, changes flow automatically:
 
 | File | Entries | Purpose |
 |------|---------|---------|
-| `autolearn-patterns.md` | 70+ | Learned patterns: lint fixes, CI config, architecture, testing |
-| `known-gotchas.md` | 47+ | Platform issues: Windows, GitHub, Go, React, Docker |
+| `agent-team-coordination.md` | - | Multi-agent team coordination rules and anti-patterns |
+| `autolearn-patterns.md` | 76 | Learned patterns: lint fixes, CI config, architecture, testing |
+| `compaction-recovery.md` | - | Context compaction recovery rules and loop detection |
+| `known-gotchas.md` | 60 | Platform issues: Windows, GitHub, Go, React, Docker |
 | `markdown-style.md` | - | Markdownlint conventions |
+| `review-policy.md` | - | Independent review policy: mandatory triggers and scope |
 | `subagent-ci-checklist.md` | - | Pre-commit CI validation checklists |
 | `workflow-preferences.md` | 11 | Established conventions: git, commits, testing |
 
@@ -218,12 +221,16 @@ Claude.ai Chat uses a separate skill store - install via Settings > Skills in th
 | server-management | Process management, monitoring, scaling decisions | Code/Cowork |
 | systematic-debugging | 4-phase debugging with root cause analysis | Code/Chat |
 | webapp-testing | E2E testing, Playwright, deep audit strategies | Code |
+| code-review | Independent code review gate before commits | Code |
+| plan-review | Independent plan review gate before implementation | Code |
+| devkit-sync | Multi-machine DevKit sync: status, push, pull, init, diff | Code |
 
 ### Agent Templates
 
 | Agent | Purpose |
 |-------|---------|
 | go-test-writer | Table-driven Go tests, benchmarks, mock interfaces |
+| plan-reviewer | Adversarial plan review with fresh context |
 | review-code | Security + quality review with verdict |
 | security-analyzer | OWASP-focused vulnerability analysis |
 | portfolio-analyzer | Scans all agent/skill locations for overlap and gaps |


### PR DESCRIPTION
## Summary
- Update counts: rules 5->8, agents 6->7, patterns 70+->135+, gotchas 47+->60
- Add 3 missing rules, 2 missing skills, 1 missing agent to `.sync-manifest.json`
- Add `code-review`, `plan-review`, `devkit-sync` to README skills table
- Add `plan-reviewer` to README agent table
- Add `tests/` directory to CLAUDE.md structure tree
- Update sync instructions in CLAUDE.md

## Test plan
- [ ] All counts verified against actual file system
- [ ] Markdownlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)