### PR TITLE
feat: formalize .local.md override pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,21 @@ This backs up any existing files in `~/.claude/`, creates symlinks for all share
 
 Local-only files (`*.local.md`, `settings.local.json`, `.credentials*`) are never synced. See [ADR-0011](docs/ADR-0011-sync-architecture.md) for the full rationale and alternatives considered.
 
+## Local Overrides
+
+Rules files ending in `.local.md` provide machine-specific overrides that complement the universal rules. Claude Code loads all `*.md` files from `~/.claude/rules/` automatically, so a file like `~/.claude/rules/my-machine.local.md` is picked up alongside the synced rules -- no extra configuration needed.
+
+**How it works:** Universal rules (`autolearn-patterns.md`, `known-gotchas.md`, etc.) are symlinked from DevKit and shared across machines. Local rules (`*.local.md`) are real files that live only on one machine. The sync system never touches them -- `.local.md` files are excluded via `.sync-manifest.json` `local_only_patterns` and `.gitignore`.
+
+**When to use local overrides:**
+
+- Machine-specific paths or tool locations (e.g., Python at a non-standard path)
+- OS-specific gotchas that only apply to one workstation
+- Patterns discovered during project work that aren't yet promoted to universal rules
+- Temporary notes or reminders for the current machine
+
+A starter template is available at [`project-templates/rules-local-template.md`](project-templates/rules-local-template.md). Copy it to `~/.claude/rules/` and rename with a `.local.md` suffix.
+
 ## Manual Setup
 
 If you prefer to set things up yourself:

--- a/project-templates/claude-md-template.md
+++ b/project-templates/claude-md-template.md
@@ -162,6 +162,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 - **Architecture:** See `docs/ARCHITECTURE.md` for system design
 - **Decisions:** See `docs/decisions.md` for ADRs and design rationale
 - **Global conventions:** See `~/.claude/CLAUDE.md` for workspace-wide standards
+- **Local overrides:** Add machine-specific or project-specific patterns to `~/.claude/rules/<name>.local.md` (never synced, never committed)
 
 ---
 

--- a/project-templates/rules-local-template.md
+++ b/project-templates/rules-local-template.md
@@ -1,0 +1,35 @@
+# Machine-Specific Rules
+
+<!-- This file holds patterns and gotchas specific to this workstation.
+     Claude Code loads it automatically from ~/.claude/rules/.
+
+     HOW TO USE:
+     1. Copy this template to ~/.claude/rules/<name>.local.md
+     2. Replace the placeholder sections with your actual patterns
+     3. The file is never synced — it stays on this machine only
+
+     To promote a pattern to universal rules, use /devkit-sync promote
+     or manually copy the entry into the appropriate rules file. -->
+
+## Machine Environment
+
+<!-- Record machine-specific paths, tool versions, or quirks here. -->
+
+- OS: [your OS and version]
+- Shell: [bash / zsh / PowerShell]
+- Notable tool paths: [e.g., Python at /usr/local/bin/python3.12]
+
+## Machine-Specific Patterns
+
+<!-- Patterns that apply only to this workstation. Use the same format
+     as autolearn-patterns.md: Category, Context, Fix, Example. -->
+
+## Project-Specific Patterns
+
+<!-- Patterns discovered during project work that haven't been promoted
+     to universal rules yet. Include the project name for context. -->
+
+## Temporary Notes
+
+<!-- Short-lived reminders, debugging notes, or work-in-progress items.
+     Clean these out periodically. -->


### PR DESCRIPTION
## Summary

- Add "Local Overrides" section to README explaining the .local.md convention
- Create `rules-local-template.md` starter template for machine-specific rules
- Add local override reference to project CLAUDE.md template

## Test plan

- [ ] CI passes (markdown lint)
- [ ] Template file is valid markdown

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)