### PR TITLE
feat: add auto-push prompt after /reflect and session review (#89)

### DIFF
--- a/claude/skills/autolearn/workflows/quick-reflect.md
+++ b/claude/skills/autolearn/workflows/quick-reflect.md
@@ -100,12 +100,26 @@ DEVKIT=$(python3 -c "import json; c=json.load(open('$HOME/.devkit-config.json'))
 [ -z "$DEVKIT" ] && for d in "$HOME/DevSpace/devkit" "/d/DevSpace/devkit"; do [ -f "$d/.sync-manifest.json" ] && DEVKIT="$d" && break; done
 
 if [ -n "$DEVKIT" ] && [ -n "$(git -C "$DEVKIT" status --porcelain -- claude/ 2>/dev/null)" ]; then
-    echo "DevKit has uncommitted changes. Run /devkit-sync push to share them."
+    git -C "$DEVKIT" diff --stat -- claude/
 fi
 ```
 
-If changes exist, append to the summary:
+If changes exist, prompt the user:
 
 ```text
-**DevKit sync:** Uncommitted changes detected. Run `/devkit-sync push` to commit and share.
+**DevKit sync:** Uncommitted changes detected in DevKit clone.
+
+  (1) Push DevKit changes now
+  (2) Skip -- push later with /devkit-sync push
 ```
+
+If the user selects **1**, run the push workflow inline:
+
+1. Read machine ID from `~/.claude/.machine-id` (if missing, tell the user to run `/devkit-sync init` and stop)
+2. `git -C <devkit> add claude/`
+3. `git -C <devkit> commit` with message `chore(sync): <machine-id> session learnings <date>` and co-author tag
+4. `git -C <devkit> push -u origin sync/<machine-id>`
+5. Check for an existing PR with `gh pr list -R HerbHall/devkit --head sync/<machine-id>`; if none, create one with `gh pr create`
+6. Report the PR URL
+
+If the user selects **2**, acknowledge and move on. No further action needed.


### PR DESCRIPTION
## Summary

- Enhances `/reflect` (quick-reflect step 6) with a numbered push prompt: 1=push now, 2=skip
- Enhances session review (step 8) with the same prompt for consistency
- Inline push workflow guides user through commit, branch push, and PR creation
- Supports the multi-machine sync strategy from ADR-0011

Closes #89

## Test plan

- [ ] Run `/reflect` after making DevKit changes, verify push prompt appears at step 6
- [ ] Select option 1, verify commit/push/PR workflow executes
- [ ] Select option 2, verify skip works cleanly
- [ ] Verify session-review step 8 shows matching prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)