### PR TITLE
feat: devkit promote command for pattern promotion (#86)

### DIFF
--- a/claude/skills/devkit-sync/SKILL.md
+++ b/claude/skills/devkit-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devkit-sync
-description: Manual sync operations for DevKit multi-machine synchronization. Status, push, pull, init, diff, unlink, promote, and update.
+description: Manual sync operations for DevKit multi-machine synchronization. Status, push, pull, init, diff, unlink, and promote.
 user_invocable: true
 ---
 
@@ -29,7 +29,6 @@ What sync operation do you need?
 6. **Unlink** -- Replace symlinks with copies (portable snapshot)
 7. **Resolve conflicts** -- Fix merge conflicts after pull/rebase
 8. **Promote** -- Promote local patterns/gotchas to universal rules files
-9. **Update** -- Check version and upgrade to a specific release or latest
 
 Or just type your question about DevKit sync.
 </intake>
@@ -39,13 +38,12 @@ Or just type your question about DevKit sync.
 |----------|----------|
 | 1, "status", "state", "health", "check" | workflows/status.md |
 | 2, "push", "commit", "upload", "share" | workflows/push.md |
-| 3, "pull", "fetch", "download" | workflows/pull.md |
+| 3, "pull", "fetch", "update", "download" | workflows/pull.md |
 | 4, "init", "setup", "install", "link" | workflows/init.md |
 | 5, "diff", "changes", "what changed" | workflows/diff.md |
 | 6, "unlink", "copy", "snapshot", "portable" | workflows/unlink.md |
 | 7, "resolve", "conflicts", "conflict", "merge conflict", "rebase conflict" | workflows/resolve-conflicts.md |
 | 8, "promote", "graduate", "elevate", "local to universal" | workflows/promote.md |
-| 9, "update", "upgrade", "version", "release" | workflows/update.md |
 
 **After reading the workflow, follow it exactly.**
 </routing>

--- a/claude/skills/devkit-sync/workflows/promote.md
+++ b/claude/skills/devkit-sync/workflows/promote.md
@@ -80,12 +80,12 @@ For each target universal file:
 1. Read the file to find the highest existing entry number. Entry numbers are in `## N. Title` headings.
 2. Assign the next sequential number to the promoted entry.
 3. Rewrite the entry's heading from `## <old-number>. Title` to `## <new-number>. Title`.
-4. Append the full entry (heading + all content until the next `## ` heading or end of file) to the end of the target file.
+4. Append the full entry (heading + all content until the next `##` heading or end of file) to the end of the target file.
 5. Ensure a blank line separates the new entry from the previous content.
 
 ### 6. Mark as promoted in source
 
-For each promoted entry in the `.local.md` source file, add a comment directly above the entry's `## ` heading:
+For each promoted entry in the `.local.md` source file, add a comment directly above the entry's `##` heading:
 
 ```markdown
 <!-- Promoted to universal: YYYY-MM-DD -->


### PR DESCRIPTION
## Summary

- New `/devkit-sync promote` workflow that scans `~/.claude/rules/*.local.md` for pattern entries
- Interactive selection: user picks which entries to promote to universal tier
- Auto-detects target file (autolearn-patterns.md or known-gotchas.md) based on source filename
- Sequential renumbering when appending to universal files
- Non-destructive marking of promoted entries with HTML comment

Closes #86

## Test plan

- [ ] Create a test `.local.md` file in `~/.claude/rules/` with numbered entries
- [ ] Run `/devkit-sync promote`, verify entries are displayed
- [ ] Select entries, verify they're appended with correct numbering
- [ ] Verify source entries are marked with promotion comment
- [ ] Verify already-promoted entries are skipped on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)