### PR TITLE
feat: SessionStart symlink health validation

### DIFF
--- a/.sync-manifest.json
+++ b/.sync-manifest.json
@@ -13,6 +13,8 @@
         "claude/rules/agent-team-coordination.md",
         "claude/rules/autolearn-patterns.md",
         "claude/rules/compaction-recovery.md",
+        "claude/rules/core-principles.md",
+        "claude/rules/error-policy.md",
         "claude/rules/known-gotchas.md",
         "claude/rules/markdown-style.md",
         "claude/rules/review-policy.md",


### PR DESCRIPTION
## Summary

- Adds `devkit_symlink_health()` function to SessionStart hook that validates critical DevKit files exist in `~/.claude/`
- Detects broken symlinks (target moved/deleted) and completely missing files
- Prints actionable remediation: "Run: pwsh setup/sync.ps1 -Link"
- Adds `core-principles.md` and `error-policy.md` to `.sync-manifest.json` rules list

## Test plan

- [ ] Verify `bash -n claude/hooks/SessionStart.sh` passes (syntax check)
- [ ] Verify `.sync-manifest.json` is valid JSON
- [ ] Verify new rules files appear in the `rules` array in `.sync-manifest.json`
- [ ] Manually test: remove a symlink from `~/.claude/rules/`, run SessionStart, verify warning appears

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)