### PR TITLE
feat: enforce pre-commit verification in workflow

### DIFF
--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -163,6 +163,11 @@ This project is NOT worth pursuing if:
    - Write a brief spec (what it does, acceptance criteria)
    - Run `/plan-review` against the feature spec before writing code
    - Implement with tests
+   - **Pre-commit verification** (mandatory, no exceptions):
+     - Build passes (`go build`, `tsc --noEmit`, etc.)
+     - Tests pass (`go test`, `vitest`, etc.)
+     - Lint passes (`golangci-lint`, `eslint`, etc.)
+     - See `subagent-ci-checklist.md` for stack-specific checks
    - Run `/code-review` before committing (Critical/High findings block the commit)
    - Verify with `/quality-control`
    - Create PR, merge after CI passes
@@ -245,24 +250,26 @@ IPScan is the cautionary example: a network scanner that grew into a full monito
 Session work
   → /reflect captures learnings
     → MCP Memory (deep store, searchable)
-    → Rules files (fast path, auto-loaded)
+    → Tier 2 rules files (fast path, auto-loaded)
+    → DevKit issues for Tier 1 changes
       → Next session starts with all accumulated knowledge
 ```
 
 ### Maintaining the devkit
 
-After significant sessions, sync changes back:
+Projects discover improvements through daily work. Changes flow to
+DevKit through issues, not direct file edits:
 
-```bash
-# Copy updated rules
-cp ~/.claude/rules/*.md ~/workspace/devkit/claude/rules/
+1. **During project work**: `/reflect` stores learnings in MCP Memory
+   and Tier 2 rules files (patterns, gotchas). For Tier 1 changes
+   (workflow preferences, review policy), it creates DevKit issues.
+2. **During DevKit work**: Address accumulated issues, validate
+   proposed changes, and commit to DevKit.
+3. **Sync propagates**: `setup/sync.ps1 -Link` symlinks DevKit files
+   to `~/.claude/`. All projects inherit updates immediately.
 
-# Copy new skills
-cp -r ~/.claude/skills/new-skill ~/workspace/devkit/claude/skills/
-
-# Commit
-cd ~/workspace/devkit && git add -A && git commit -m "chore: sync patterns from [project]"
-```
+Symlinks are **read-only from the project perspective**. Projects
+read DevKit rules via symlinks but write changes through issues.
 
 ### When to Update the Methodology
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -5,12 +5,17 @@ High-level guidance for all sessions. Project-specific details go in
 
 ## Workflow
 
-**IMPORTANT**: Always **Explore -> Plan -> Code -> Commit**
+**IMPORTANT**: Always **Explore -> Plan -> Code -> Verify -> Commit**
 
 1. Read relevant files first - understand before coding
 2. Create detailed plan and get approval before implementing
 3. Implement methodically
-4. Commit with clear messages including
+4. **Verify before committing** (mandatory, no exceptions):
+   - Build passes (language-appropriate: `go build`, `tsc`, etc.)
+   - Tests pass (`go test`, `vitest`, etc.)
+   - Lint passes (`golangci-lint`, `eslint`, etc.)
+   - See `subagent-ci-checklist.md` for stack-specific checks
+5. Commit with clear messages including
    `Co-Authored-By: Claude <noreply@anthropic.com>`
 
 **Course Correct Early**: Interrupt me if I'm heading the wrong direction.


### PR DESCRIPTION
## Summary

- Adds mandatory "Verify" step to CLAUDE.md workflow (Explore->Plan->Code->**Verify**->Commit)
- Adds pre-commit verification gate to Phase 4 in METHODOLOGY.md with explicit build/test/lint requirements
- Updates cross-project learning section to use issues-as-bridge pattern instead of direct file copy

## Test plan

- [ ] Verify CLAUDE.md workflow shows 5 steps including "Verify before committing"
- [ ] Verify METHODOLOGY.md Phase 4 includes pre-commit verification block
- [ ] Verify cross-project learning section references issues, not direct file copy
- [ ] Lint passes on both files (0 errors confirmed)

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)