### PR TITLE
feat: add quality gates to project templates

### DIFF
--- a/project-templates/claude-md-template.md
+++ b/project-templates/claude-md-template.md
@@ -77,15 +77,20 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 - Push branch and create PR via `gh pr create`
 - Merge only after CI passes
 
-### Testing Before Push
+### Pre-Commit Verification (Mandatory)
 
-The pre-push hook handles this automatically. To run checks manually:
+**Every commit must pass build, test, and lint.** No exceptions for
+"small changes" or "just config." The workflow is:
+**Explore -> Plan -> Code -> Verify -> Commit**
 
 ```bash
 make ci    # build + test + lint (same checks as CI and the pre-push hook)
 ```
 
-Fix all failures before pushing. CI should only confirm what you've already verified locally.
+Fix all failures before committing. CI should only confirm what you've
+already verified locally. If you find errors (even in unrelated code),
+fix them inline or create a tracking issue immediately. See
+`~/.claude/rules/error-policy.md` for the full fix-forward workflow.
 
 ### Code Review
 
@@ -159,6 +164,8 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 - **Architecture:** See `docs/ARCHITECTURE.md` for system design
 - **Decisions:** See `docs/decisions.md` for ADRs and design rationale
 - **Global conventions:** See `~/.claude/CLAUDE.md` for workspace-wide standards
+- **Core principles:** See `~/.claude/rules/core-principles.md` for immutable development rules
+- **Error policy:** See `~/.claude/rules/error-policy.md` for fix-forward workflow
 - **Local overrides:** Add machine-specific or project-specific patterns to `~/.claude/rules/<name>.local.md` (never synced, never committed)
 
 ---

--- a/project-templates/workspace-claude-md-template.md
+++ b/project-templates/workspace-claude-md-template.md
@@ -85,6 +85,15 @@ WORKSPACE_ROOT/
 - Always cite sources in code and documentation
 - Maintain `README.md` for GitHub with credits section
 
+## Quality Gates
+
+All projects in this workspace follow these quality gates from DevKit:
+
+- **Pre-commit**: Build, test, and lint must pass before every commit
+- **Fix-forward**: Every error found gets fixed or tracked immediately (no "pre-existing" bypass)
+- **Core principles**: See `~/.claude/rules/core-principles.md` for immutable rules
+- **Error policy**: See `~/.claude/rules/error-policy.md` for fix-forward workflow
+
 ## Adding a New Project
 
 1. Create a folder under `WORKSPACE_ROOT`


### PR DESCRIPTION
## Summary

- Adds mandatory pre-commit verification section to project CLAUDE.md template (replaces advisory "Testing Before Push")
- Adds core-principles.md and error-policy.md references to project template
- Adds Quality Gates section to workspace CLAUDE.md template
- New projects created from these templates inherit quality gates from day one

## Test plan

- [ ] Verify project template has "Pre-Commit Verification (Mandatory)" section
- [ ] Verify project template references core-principles.md and error-policy.md
- [ ] Verify workspace template has "Quality Gates" section
- [ ] Lint passes on both templates (0 errors confirmed)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)