### PR TITLE
feat: scope-aware autolearn abstraction pipeline (#109)

### DIFF
--- a/claude/skills/autolearn/SKILL.md
+++ b/claude/skills/autolearn/SKILL.md
@@ -25,6 +25,15 @@ Deliberate retrospective analysis for continuous improvement. Extracts learnings
 - Rules files are the fast path -- they're injected into every session automatically
 - MCP Memory is the deep store -- searchable, relational, comprehensive
 
+**Scope-Aware Routing**
+
+Storage depends on WHERE the session is running:
+
+- **In DevKit repo** (`.sync-manifest.json` present): Write Tier 2 rules directly. DevKit is the source of truth.
+- **In any other project**: Write to MCP Memory only. For stack-specific or universal learnings, create a DevKit issue (`gh issue create -R HerbHall/devkit`) so the learning can be reviewed and promoted to rules files through a PR.
+
+This prevents projects from modifying symlinked rules files directly. Symlinks provide READ access to DevKit rules; writing flows through issues.
+
 **Deduplication is Critical**
 
 - Always search MCP Memory before creating entities: `search_nodes` with relevant keywords

--- a/claude/skills/autolearn/workflows/quick-reflect.md
+++ b/claude/skills/autolearn/workflows/quick-reflect.md
@@ -72,14 +72,43 @@ create_relations: [{
 }]
 ```
 
-### 5. Tier Boundary Check
+### 5. Scope Assessment and Rules Update
 
-Before updating any rules files, check the `tier` field in YAML frontmatter:
+Determine where this session is running to decide how to handle rules:
+
+**Detect context:**
+
+- Check if `.sync-manifest.json` exists in the current working directory (or a parent)
+- If found and contains `"version": 2`: this is the **DevKit repo** -- direct rules editing is allowed
+- Otherwise: this is a **project context** -- rules files are read-only (symlinked)
+
+**If in DevKit repo:**
+
+Check tier boundaries before editing:
 
 - **Tier 0** (`core-principles.md`, `error-policy.md`): NEVER modify. Immutable.
 - **Tier 1** (`workflow-preferences.md`, `review-policy.md`): Do NOT edit directly.
-  If a finding affects Tier 1 rules, create a DevKit issue instead.
-- **Tier 2** (`autolearn-patterns.md`, `known-gotchas.md`): Safe to add entries.
+  Create a DevKit issue instead.
+- **Tier 2** (`autolearn-patterns.md`, `known-gotchas.md`): Safe to add entries directly.
+
+**If in a project (not DevKit):**
+
+1. Store all learnings in MCP Memory only (step 4 above).
+2. For findings that are universal (apply across projects) or stack-specific (apply to all projects using this language/framework), create a DevKit issue:
+
+```bash
+gh issue create -R HerbHall/devkit \
+  --title "autolearn: <brief description>" \
+  --body "Source project: $(basename $(pwd))
+Category: <pattern|gotcha|correction>
+Confidence: HIGH
+
+<description of the learning>
+
+Suggested rules file: <autolearn-patterns.md or known-gotchas.md>"
+```
+
+**Important:** Do NOT edit files in `~/.claude/rules/` -- they are symlinks to DevKit.
 
 ### 6. Report Summary
 
@@ -88,48 +117,13 @@ Present a brief summary to the user:
 ```text
 ## Quick Reflect Summary
 
-**Learnings stored:** N items
+**Learnings stored (MCP Memory):** N items
 - [Category] Entity name: Brief description
 
 **Skipped (already known):** N items
 **Skipped (low confidence):** N items
 
-Rules file updates suggested: [Yes/No]
-- If yes, recommend running `/reflect` with "update knowledge" option
-- Tier 1 changes proposed: [list DevKit issues created, if any]
+**Context:** [DevKit / Project (<name>)]
+**Rules files updated:** [Yes (Tier 2 only) / No -- DevKit issues created instead]
+- [List DevKit issue numbers if any were created]
 ```
-
-### 6. DevKit Sync Check
-
-After storing learnings, check if the DevKit clone has uncommitted changes (rules files were likely modified via symlinks):
-
-```bash
-# Find DevKit clone
-DEVKIT=$(python3 -c "import json; c=json.load(open('$HOME/.devkit-config.json')); print(c['devspace']+'/devkit')" 2>/dev/null)
-# Fallback paths
-[ -z "$DEVKIT" ] && for d in "$HOME/DevSpace/devkit" "/d/DevSpace/devkit"; do [ -f "$d/.sync-manifest.json" ] && DEVKIT="$d" && break; done
-
-if [ -n "$DEVKIT" ] && [ -n "$(git -C "$DEVKIT" status --porcelain -- claude/ 2>/dev/null)" ]; then
-    git -C "$DEVKIT" diff --stat -- claude/
-fi
-```
-
-If changes exist, prompt the user:
-
-```text
-**DevKit sync:** Uncommitted changes detected in DevKit clone.
-
-  (1) Push DevKit changes now
-  (2) Skip -- push later with /devkit-sync push
-```
-
-If the user selects **1**, run the push workflow inline:
-
-1. Read machine ID from `~/.claude/.machine-id` (if missing, tell the user to run `/devkit-sync init` and stop)
-2. `git -C <devkit> add claude/`
-3. `git -C <devkit> commit` with message `chore(sync): <machine-id> session learnings <date>` and co-author tag
-4. `git -C <devkit> push -u origin sync/<machine-id>`
-5. Check for an existing PR with `gh pr list -R HerbHall/devkit --head sync/<machine-id>`; if none, create one with `gh pr create`
-6. Report the PR URL
-
-If the user selects **2**, acknowledge and move on. No further action needed.

--- a/claude/skills/autolearn/workflows/update-knowledge.md
+++ b/claude/skills/autolearn/workflows/update-knowledge.md
@@ -2,7 +2,25 @@
 
 Merge accumulated learnings from MCP Memory into rules files. Ensures rules files stay current and useful.
 
+**This workflow modifies rules files directly.** It must only run in the DevKit repo.
+
 ## Steps
+
+### 0. Context Guard
+
+Check if the current working directory is the DevKit repo:
+
+- Look for `.sync-manifest.json` containing `"version": 2`
+- If NOT in DevKit: **STOP**. Print this message and exit:
+
+```text
+This workflow writes directly to rules files and must run in the DevKit repo.
+
+To promote learnings from this project:
+1. Run `/reflect` (quick or session review) -- learnings go to MCP Memory
+2. Universal learnings are filed as DevKit issues automatically
+3. In a DevKit session, run `/reflect` with "update knowledge" to merge them
+```
 
 ### 1. Read Current Rules Files
 


### PR DESCRIPTION
## Summary

- Autolearn workflows now detect whether the session is in DevKit or a project
- In DevKit: Tier 2 rules files can be edited directly (existing behavior)
- In projects: learnings go to MCP Memory only; universal findings create DevKit issues
- Update-knowledge workflow requires DevKit context with a guard that stops and explains the promotion path
- Removes DevKit Sync Check steps (replaced by scope-aware issue creation)

## Files Changed

- `claude/skills/autolearn/SKILL.md` -- added Scope-Aware Routing section
- `claude/skills/autolearn/workflows/quick-reflect.md` -- scope assessment replaces tier check + sync check
- `claude/skills/autolearn/workflows/session-review.md` -- scope assessment replaces tier check + sync check
- `claude/skills/autolearn/workflows/update-knowledge.md` -- added context guard (step 0)

## Test plan

- [ ] Run `/reflect` quick in a non-DevKit project -- verify it stores to MCP Memory and creates DevKit issues (not rules files)
- [ ] Run `/reflect` quick in DevKit repo -- verify it edits Tier 2 rules directly
- [ ] Run `/reflect` update knowledge in a project -- verify it stops with explanation message
- [ ] Run `/reflect` update knowledge in DevKit -- verify it proceeds normally

Closes #109

Co-Authored-By: Claude <noreply@anthropic.com>