### PR TITLE
feat: propagation verification for DevKit updates (#114)

### DIFF
--- a/claude/hooks/SessionStart.sh
+++ b/claude/hooks/SessionStart.sh
@@ -90,6 +90,12 @@ devkit_pull() {
     # Pull with rebase
     if git -C "$devkit_path" pull --rebase origin main 2>/dev/null; then
         echo "DevKit: pulled $behind new commit(s)"
+        # Check if rules files changed in the pull
+        local rules_changed
+        rules_changed=$(git -C "$devkit_path" diff HEAD~"$behind" HEAD --name-only -- claude/rules/ 2>/dev/null | wc -l)
+        if [ "$rules_changed" -gt 0 ]; then
+            echo "DevKit: $rules_changed rule file(s) updated. Symlinked projects are current."
+        fi
         _devkit_log "PULLED_$behind"
         date +%s > "$last_pull_file"
     else

--- a/claude/skills/devkit-sync/SKILL.md
+++ b/claude/skills/devkit-sync/SKILL.md
@@ -30,6 +30,7 @@ What sync operation do you need?
 7. **Resolve conflicts** -- Fix merge conflicts after pull/rebase
 8. **Promote** -- Promote local patterns/gotchas to universal rules files
 9. **Update** -- Check version and upgrade to a specific release or latest
+10. **Verify** -- Check if DevKit updates reached all active projects
 
 Or just type your question about DevKit sync.
 </intake>
@@ -46,6 +47,7 @@ Or just type your question about DevKit sync.
 | 7, "resolve", "conflicts", "conflict", "merge conflict", "rebase conflict" | workflows/resolve-conflicts.md |
 | 8, "promote", "graduate", "elevate", "local to universal" | workflows/promote.md |
 | 9, "update", "upgrade", "version", "release" | workflows/update.md |
+| 10, "verify", "propagation", "check projects", "reach" | workflows/verify.md |
 
 **After reading the workflow, follow it exactly.**
 </routing>

--- a/claude/skills/devkit-sync/workflows/verify.md
+++ b/claude/skills/devkit-sync/workflows/verify.md
@@ -1,0 +1,132 @@
+# Verify Propagation
+
+Check whether DevKit updates have reached all active projects. Reports symlink health, stale copies, and missing files.
+
+## Steps
+
+### 1. Resolve DevKit Source Path
+
+Find the DevKit clone (source of truth for all rules/skills):
+
+```bash
+# Try config file first
+DEVKIT=$(python3 -c "import json; c=json.load(open('$HOME/.devkit-config.json')); print(c.get('devspacePath', c.get('devspace', ''))+'/devkit')" 2>/dev/null)
+
+# Fallback paths
+[ -z "$DEVKIT" ] && for d in "$HOME/DevSpace/devkit" "/d/DevSpace/devkit"; do
+    [ -f "$d/.sync-manifest.json" ] && DEVKIT="$d" && break
+done
+
+if [ -z "$DEVKIT" ]; then
+    echo "Cannot find DevKit clone. Run /devkit-sync init first."
+    exit 1
+fi
+```
+
+### 2. Discover Active Projects
+
+Look for projects that should have DevKit files. Check these sources in order:
+
+1. **Project registry** (`~/.devkit-registry.json`) -- if it exists, use it as the primary source
+2. **Common locations** -- scan directories under the DevSpace root for git repos with `CLAUDE.md`
+
+```bash
+# Registry approach
+if [ -f "$HOME/.devkit-registry.json" ]; then
+    # Read project paths from registry
+    python3 -c "
+import json
+reg = json.load(open('$HOME/.devkit-registry.json'))
+for p in reg.get('projects', []):
+    print(p.get('path', ''))
+"
+fi
+
+# Fallback: scan DevSpace directory
+DEVSPACE=$(dirname "$DEVKIT")
+for dir in "$DEVSPACE"/*/; do
+    [ -d "$dir/.git" ] && [ "$dir" != "$DEVKIT/" ] && echo "$dir"
+done
+```
+
+### 3. Check Each Project
+
+For each discovered project, verify these critical files:
+
+**Files to check:**
+
+| File | Source in DevKit | Expected in Project |
+|------|-----------------|-------------------|
+| `CLAUDE.md` | `claude/CLAUDE.md` | `~/.claude/CLAUDE.md` (global) |
+| `rules/*.md` | `claude/rules/*.md` | `~/.claude/rules/*.md` (global) |
+| Project `CLAUDE.md` | n/a | `<project>/CLAUDE.md` (project-specific) |
+
+**For each file, determine status:**
+
+- **CURRENT (symlinked)**: File is a symlink pointing to DevKit source. Changes propagate automatically.
+- **STALE (copy)**: File is a regular file (not symlink). Compare modification time with DevKit source. If DevKit source is newer, the copy is stale.
+- **MISSING**: File does not exist in the expected location.
+- **BROKEN**: File is a symlink but the target does not exist.
+
+```bash
+check_file() {
+    local target="$1"    # expected file location
+    local source="$2"    # DevKit source file
+
+    if [ -L "$target" ]; then
+        if [ -e "$target" ]; then
+            echo "CURRENT (symlinked)"
+        else
+            echo "BROKEN (dangling symlink)"
+        fi
+    elif [ -f "$target" ]; then
+        if [ "$source" -nt "$target" ]; then
+            echo "STALE (copy, DevKit source is newer)"
+        else
+            echo "OK (copy, up to date)"
+        fi
+    else
+        echo "MISSING"
+    fi
+}
+```
+
+### 4. Generate Report
+
+Present results as a table:
+
+```text
+## Propagation Verification Report
+
+### Global Files (~/.claude/)
+
+| File | Status | Action Needed |
+|------|--------|--------------|
+| CLAUDE.md | CURRENT | None |
+| rules/core-principles.md | CURRENT | None |
+| rules/autolearn-patterns.md | STALE | Run: pwsh setup/sync.ps1 -Link |
+| rules/error-policy.md | MISSING | Run: pwsh setup/sync.ps1 -Link |
+
+### Projects
+
+| Project | CLAUDE.md | Notes |
+|---------|-----------|-------|
+| SubNetree | Present (project-specific) | OK |
+| Runbooks | Missing | Create with template |
+
+### Summary
+
+- Symlinked (current): N files
+- Stale copies: N files
+- Missing: N files
+- Broken symlinks: N files
+```
+
+### 5. Suggest Remediation
+
+Based on findings:
+
+- **Stale copies or missing files**: `pwsh setup/sync.ps1 -Link` to re-establish symlinks
+- **Broken symlinks**: DevKit clone may have moved. Run `/devkit-sync init` to reconfigure
+- **Project missing CLAUDE.md**: Offer to create from template (`project-templates/claude-md-template.md`)
+- **All current**: Report "All projects are current. No action needed."


### PR DESCRIPTION
## Summary

- New `/devkit-sync verify` workflow (route 10) checks all active projects for DevKit update propagation
- Reports file status: CURRENT (symlinked), STALE (copy), MISSING, BROKEN (dangling symlink)
- Discovers projects via `~/.devkit-registry.json` or DevSpace directory scan
- SessionStart hook now reports rule file change count after successful pull
- Suggests remediation: `pwsh setup/sync.ps1 -Link` for stale/missing, `/devkit-sync init` for broken

## Files Changed

- `claude/skills/devkit-sync/workflows/verify.md` (new) -- verification workflow
- `claude/skills/devkit-sync/SKILL.md` -- added route 10 (verify)
- `claude/hooks/SessionStart.sh` -- rules change notification after pull

## Test plan

- [ ] Run `/devkit-sync verify` -- verify it discovers projects and reports file status
- [ ] Verify SessionStart shows rule change count after a pull that includes rule changes
- [ ] Verify route 10 appears in `/devkit-sync` intake menu

Closes #114

Co-Authored-By: Claude <noreply@anthropic.com>