### PR TITLE
feat: lifecycle metadata PoC (10 entries) and AP#27/KG#17 duplicate resolution

### DIFF
--- a/claude/rules/archive/autolearn-patterns.md
+++ b/claude/rules/archive/autolearn-patterns.md
@@ -1,0 +1,24 @@
+# Archived Autolearn Patterns
+
+Deprecated and superseded entries from `../autolearn-patterns.md`.
+
+## 27. golangci-lint bodyclose with websocket.Dial
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** superseded-by-KG17
+
+**Category:** lint-fix
+**Context:** The `coder/websocket` library's `websocket.Dial()` returns `(conn, *http.Response, error)`. The golangci-lint `bodyclose` linter requires that the `*http.Response` body is always closed, even in test code where the response is typically discarded with `_, _, err := websocket.Dial(...)`.
+**Mistake:** First fix only addressing some call sites, or using `replace_all` blindly which creates variable name collisions with other uses of `_` in the same scope (e.g., a `conn.Read()` return variable also named `resp`).
+**Fix:** For each `websocket.Dial` call, change to:
+
+```go
+conn, resp, err := websocket.Dial(ctx, wsURL, nil)
+if resp != nil && resp.Body != nil {
+    resp.Body.Close()
+}
+if err != nil {
+    t.Fatalf("websocket dial: %v", err)
+}
+```
+
+**Lesson:** When fixing a lint issue across multiple call sites, ALWAYS grep for ALL occurrences first before making partial fixes. Check for variable name collisions in the surrounding scope before using `replace_all`.

--- a/claude/rules/autolearn-patterns.md
+++ b/claude/rules/autolearn-patterns.md
@@ -1,7 +1,7 @@
 ---
 description: Learned patterns from past sessions. Read when encountering similar situations.
 tier: 2
-entry_count: 76
+entry_count: 75
 last_updated: "2026-02-28"
 ---
 
@@ -10,6 +10,8 @@ last_updated: "2026-02-28"
 Patterns discovered through past sessions. Each entry includes the pattern, context, and fix/approach.
 
 ## 1. gosec G101 False Positive on Constants Near Credential Code
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** lint-fix
 **Context:** gosec G101 flags constants as "hardcoded credentials" when their **name** contains "credential", "password", "secret", "token", or "passphrase", OR when their **value** contains sensitive-looking strings like "snmp". In vault/credential modules, expect 5-10+ false positives across type labels, event topics, and env var name constants. These appear incrementally in CI -- fixing one batch may reveal more on the next run.
@@ -44,6 +46,8 @@ go-licenses check ./... 2>&1 | grep -E "GPL|AGPL|LGPL|SSPL" && exit 1 || echo "N
 ```
 
 ## 5. WebSocket Auth: JWT via Query Parameter
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** architecture-pattern
 **Context:** Browser WebSocket API doesn't support custom headers (`Authorization: Bearer ...`). Standard auth middleware can't validate WS connections.
@@ -164,6 +168,9 @@ req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 
 ## 17. swaggertype Tags for Platform-Specific Type Enums
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+**See also:** AP#35, KG#12, KG#57, KG#59
+
 **Category:** ci-fix
 **Context:** swag (swaggo/swag) introspects Go types like `time.Duration` and generates platform-specific enum definitions. The same swag version (e.g., v1.16.4) produces different enum values on Linux vs Windows (e.g., `minDuration`/`maxDuration` present or absent). This causes swagger drift check failures in CI when specs are generated locally on a different platform.
 **Fix:** Add `swaggertype:"integer"` (or `"string"`) struct tag to override swag's introspection:
@@ -279,22 +286,9 @@ func (a *tokenAdapter) ValidateAccessToken(t string) (*gateway.TokenClaims, erro
 
 ## 27. golangci-lint bodyclose with websocket.Dial
 
-**Category:** lint-fix
-**Context:** The `coder/websocket` library's `websocket.Dial()` returns `(conn, *http.Response, error)`. The golangci-lint `bodyclose` linter requires that the `*http.Response` body is always closed, even in test code where the response is typically discarded with `_, _, err := websocket.Dial(...)`.
-**Mistake:** First fix only addressing some call sites, or using `replace_all` blindly which creates variable name collisions with other uses of `_` in the same scope (e.g., a `conn.Read()` return variable also named `resp`).
-**Fix:** For each `websocket.Dial` call, change to:
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** superseded-by-KG17
 
-```go
-conn, resp, err := websocket.Dial(ctx, wsURL, nil)
-if resp != nil && resp.Body != nil {
-    resp.Body.Close()
-}
-if err != nil {
-    t.Fatalf("websocket dial: %v", err)
-}
-```
-
-**Lesson:** When fixing a lint issue across multiple call sites, ALWAYS grep for ALL occurrences first before making partial fixes. Check for variable name collisions in the surrounding scope before using `replace_all`.
+Archived to `claude/rules/archive/autolearn-patterns.md`. See KG#17 for the consolidated entry.
 
 ## 28. Go 1.22+ ServeMux Ambiguous Route Pattern Panic
 
@@ -370,6 +364,9 @@ writeJSON(w, http.StatusOK, ActiveThemeResponse(req))
 - Reddit/web data is supplementary; GitHub data alone is sufficient for a comprehensive gap exploitation report
 
 ## 35. Swagger CI Job Needs Explicit go mod download
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+**See also:** AP#17, KG#12, KG#57, KG#59
 
 **Category:** ci-fix
 **Context:** `swag init --parseDependency --parseInternal` resolves Go module dependencies at parse time. The CI swagger drift check relied on `actions/setup-go`'s module cache, but Dependabot dependency bumps change `go.sum` which changes the cache key, causing a miss. With no cached modules and no explicit download step, swag fails with "cannot find all dependencies" and exit code 1.
@@ -1100,6 +1097,8 @@ vi.mock('@/api/auth', () => ({
 **Fix:** Strengthened the Go agent CI checklist to require running `golangci-lint run ./path/to/modified/...` as a mandatory step, not just "watch for" patterns. Also added it as step 4 in the numbered list.
 
 ## 85. Roadmap Drift: Verify Claims Against Source Code
+
+**Added:** 2026-02-24 | **Source:** SubNetree | **Status:** active
 
 **Category:** process-pattern
 **Context:** Roadmap checklists drift from reality in both directions: (1) items implemented but never checked off, (2) items listed as "TODO" that are already done. Both cause wasted planning effort. Reading the roadmap alone is insufficient -- the source code is the source of truth.

--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -11,6 +11,8 @@ Platform-specific issues, tool quirks, and surprising behaviors discovered throu
 
 ## 1. Windows MSYS Bash Path Translation
 
+**Added:** 2026-02-17 | **Source:** global | **Status:** active
+
 **Platform:** Windows (MSYS_NT)
 **Issue:** MSYS bash auto-translates Unix-style paths to Windows paths in some contexts. Paths starting with `/c/` become `C:\`.
 **Workaround:** Use `MSYS_NO_PATHCONV=1` prefix for commands where path translation causes problems, or use double-slash `//` to prevent translation.
@@ -116,6 +118,9 @@ Regular prompts containing numbers still fire normally (e.g., "fix issue #297").
 
 ## 12. swag Generates Platform-Specific time.Duration Enums
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+**See also:** AP#17, AP#35, KG#57, KG#59
+
 **Platform:** Go (cross-platform)
 **Issue:** `swag init` with `--parseDependency --parseInternal` introspects `time.Duration` and generates an enum definition. The exact enum values differ across Go versions and platforms -- Linux CI may include `minDuration`/`maxDuration` while Windows local doesn't (or vice versa). Even with the same swag version pinned (`v1.16.4`), the Go toolchain version affects the output.
 **Diagnosis:** Swagger drift check fails in CI. The diff shows `minDuration`/`maxDuration` being added or removed from the `time.Duration` enum.
@@ -178,6 +183,8 @@ If you miss some, close manually: `gh issue close N --comment "Shipped in PR #X"
 **Example:** PR #270 body had `Closes #226, #251, #259, #254, #249` -- only #226 was auto-closed. The other 4 required manual closure.
 
 ## 17. websocket.Dial Response Body Must Be Closed
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Go (all) / coder/websocket library
 **Issue:** `websocket.Dial(ctx, url, nil)` returns `(*websocket.Conn, *http.Response, error)`. Even though you typically only care about the connection, the golangci-lint `bodyclose` linter requires that the `*http.Response` body is always closed. Ignoring the response with `_, _, err := websocket.Dial(...)` triggers lint errors.
@@ -271,6 +278,8 @@ if ($resp.StatusCode -eq 200) { ... }  # always works
 **Fix:** Remove the cla-assistant.io integration (redundant if you have a GitHub Actions CLA workflow) or add `dependabot[bot]` to its allowlist. The Actions-based CLA workflow is more configurable and handles bot authors correctly.
 
 ## 25. Parallel Background Agents Share Working Tree
+
+**Added:** 2026-02-17 | **Source:** global | **Status:** active
 
 **Platform:** Claude Code (all)
 **Issue:** When launching multiple background agents (`Task` tool) in parallel that modify files, ALL agents write to the currently checked-out git branch. The agents don't create or switch branches -- they just write files to the working directory. After both complete, all changes are mixed together as unstaged modifications on whichever branch was checked out.
@@ -711,6 +720,9 @@ powershell.exe -NoProfile -File /tmp/frontend-cmd.ps1 2>&1
 
 ## 57. Swagger x-enum-descriptions Blocks Differ Between Windows and Linux
 
+**Added:** 2026-02-24 | **Source:** SubNetree | **Status:** active
+**See also:** AP#17, AP#35, KG#12, KG#59
+
 **Platform:** Go (swaggo/swag, cross-platform)
 **Issue:** Windows `swag init` generates `x-enum-descriptions` array blocks for Go enums with comment annotations. Linux CI's `swag init` (same version) omits these blocks entirely. The `x-enum-comments` map and `x-enum-varnames` array are generated identically on both platforms. This is a sibling of gotcha #12 (time.Duration enums) but affects any enum type with comment-annotated values.
 **Diagnosis:** Swagger Drift Check fails in CI. Diff shows `x-enum-descriptions` arrays being removed from swagger files.
@@ -740,6 +752,9 @@ git reset --hard origin/main     # safe when no uncommitted work
 
 ## 59. Perl Regex for Stripping Swagger YAML Corrupts Line Boundaries
 
+**Added:** 2026-02-24 | **Source:** SubNetree | **Status:** active
+**See also:** AP#17, AP#35, KG#12, KG#57
+
 **Platform:** Windows (MSYS_NT) / swaggo/swag
 **Issue:** The perl one-liner used to strip `x-enum-descriptions` from `swagger.yaml` can concatenate adjacent lines. When a YAML enum description value is immediately followed by an `x-enum-descriptions` block, the regex removes the block AND the newline, joining the description with the next YAML key on one line. This produces invalid YAML.
 **Diagnosis:** Swagger Drift Check passes for JSON but fails for YAML. The diff shows line concatenation rather than missing blocks.
@@ -757,6 +772,8 @@ grep "x-enum-varnames" api/swagger/swagger.yaml | grep -v "^\s*x-enum-varnames"
 **Prevention:** Consider switching to a YAML-aware tool (yq) for swagger post-processing instead of regex. Or validate the YAML parses cleanly after stripping.
 
 ## 60. Go Binary Permission Denied on MSYS -- Use go run Instead
+
+**Added:** 2026-02-24 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Windows (MSYS_NT)
 **Issue:** Go tool binaries installed to `~/go/bin/` (e.g., `swag`, `protoc-gen-go`) may have filesystem permission issues on MSYS bash, returning "permission denied" even when the file exists and is executable.


### PR DESCRIPTION
## Summary

- **Metadata annotations** on 10 proof-of-concept entries (5 from autolearn-patterns, 5 from known-gotchas) with `**Added:**`, `**Source:**`, and `**Status:**` fields per ADR-0014
- **Duplicate resolution**: AP#27 (bodyclose websocket.Dial) superseded by KG#17 and archived to `claude/rules/archive/autolearn-patterns.md`; frontmatter `entry_count` updated 76 -> 75
- **Swagger cross-references**: 5 related swagger entries (AP#17, AP#35, KG#12, KG#57, KG#59) linked via `**See also:**`

### Annotated Entries

| Entry | Title | Source |
|-------|-------|--------|
| AP#1 | gosec G101 false positive | SubNetree |
| AP#5 | WebSocket JWT auth | SubNetree |
| AP#17 | swaggertype tags | SubNetree |
| AP#35 | Swagger CI go mod download | SubNetree |
| AP#85 | Roadmap drift verification | SubNetree |
| KG#1 | Windows MSYS path translation | global |
| KG#12 | swag platform-specific enums | SubNetree |
| KG#17 | websocket.Dial bodyclose | SubNetree |
| KG#25 | Parallel agents share working tree | global |
| KG#60 | Go binary permission denied | SubNetree |

Refs #112

## Test plan

- [ ] Verify `npx markdownlint-cli2` passes on all modified files
- [ ] Verify AP#27 is marked superseded in main file and full text exists in archive
- [ ] Verify frontmatter `entry_count` is 75 (was 76)
- [ ] Verify swagger cluster has bidirectional cross-references

🤖 Generated with [Claude Code](https://claude.com/claude-code)