### PR TITLE
feat: rules audit workflow and last-relevant tracking in /reflect

### DIFF
--- a/claude/skills/autolearn/SKILL.md
+++ b/claude/skills/autolearn/SKILL.md
@@ -61,6 +61,7 @@ What would you like to reflect on?
 2. **Session review** -- Comprehensive session retrospective with full MCP Memory sync
 3. **Update knowledge** -- Merge accumulated learnings into rules files
 4. **Skill improvement** -- Analyze past mistakes and improve existing skills/agents
+5. **Audit rules** -- Health check: stale entries, missing metadata, duplicates, cross-references
 
 **Wait for response before proceeding.**
 </intake>
@@ -72,6 +73,7 @@ What would you like to reflect on?
 | 2, "session", "review", "comprehensive", "full" | workflows/session-review.md |
 | 3, "update", "knowledge", "rules", "merge" | workflows/update-knowledge.md |
 | 4, "skill", "improve", "agent", "fix" | workflows/skill-improvement.md |
+| 5, "audit", "rules", "health", "stale" | workflows/audit-rules.md |
 
 **After reading the workflow, follow it exactly.**
 </routing>

--- a/claude/skills/autolearn/workflows/audit-rules.md
+++ b/claude/skills/autolearn/workflows/audit-rules.md
@@ -1,0 +1,135 @@
+# Audit Rules
+
+Health check and maintenance workflow for Tier 2 rules files. Identifies stale entries, missing metadata, potential duplicates, and proposes actions.
+
+## Context Guard
+
+This workflow modifies rules files directly. It may only run in the DevKit repo.
+
+**Check:** Does `.sync-manifest.json` exist with `"version": 2`?
+
+- If yes: proceed
+- If no: stop and tell the user this workflow requires a DevKit session
+
+## Steps
+
+### 1. Parse All Tier 2 Entries
+
+Read both rules files:
+
+- `~/.claude/rules/autolearn-patterns.md`
+- `~/.claude/rules/known-gotchas.md`
+
+For each entry, extract:
+
+- Number and title (from `## N. Title`)
+- Category or Platform (first bold field)
+- Metadata fields if present (`**Added:**`, `**Source:**`, `**Status:**`, `**Last relevant:**`, `**See also:**`)
+
+### 2. Generate Health Report
+
+Present a summary table:
+
+```text
+## Rules Health Report
+
+| Metric | autolearn-patterns | known-gotchas | Total |
+|--------|-------------------|---------------|-------|
+| Total entries | N | N | N |
+| With metadata | N | N | N |
+| Missing metadata | N | N | N |
+| Active | N | N | N |
+| Deprecated | N | N | N |
+| Superseded | N | N | N |
+| Stale (see below) | N | N | N |
+
+Frontmatter entry_count: AP=N (actual N), KG=N (actual N)
+```
+
+Flag any mismatch between frontmatter `entry_count` and actual count.
+
+### 3. Identify Stale Entries
+
+An entry is **stale** if ALL of these are true:
+
+- Has an `**Added:**` date older than 90 days
+- Does NOT have a `**Last relevant:**` date
+- Status is `active`
+
+List stale entries:
+
+```text
+### Stale Entries (no recent relevance signal)
+
+| Entry | Title | Added | Days Old |
+|-------|-------|-------|----------|
+| AP#N | ... | YYYY-MM-DD | N |
+```
+
+Note: stale does not mean wrong. Many entries remain valid indefinitely. This list is for review, not automatic deprecation.
+
+### 4. Identify Potential Duplicates
+
+Search for entries with:
+
+- Same category/platform AND similar keywords in the title
+- Cross-file overlaps (an AP entry and a KG entry covering the same topic)
+
+Flag candidates but do NOT auto-merge. Present as:
+
+```text
+### Potential Duplicates
+
+| Entry A | Entry B | Reason |
+|---------|---------|--------|
+| AP#N | KG#M | Same topic: <description> |
+```
+
+### 5. Propose Actions
+
+For each finding, propose one of:
+
+- **Confirm active**: Entry is still relevant, add `**Last relevant:**` date
+- **Deprecate**: Entry is no longer applicable, move to archive
+- **Merge**: Two entries cover the same topic, consolidate
+- **Add metadata**: Entry is missing metadata fields
+- **Cross-reference**: Related entries should link to each other
+
+Present as a numbered action list:
+
+```text
+### Proposed Actions
+
+1. [confirm] AP#5 -- Still relevant (WebSocket JWT pattern used in SubNetree)
+2. [deprecate] AP#N -- No longer applicable because...
+3. [merge] AP#N + KG#M -- Same topic, consolidate into KG#M
+4. [metadata] KG#N -- Add Added/Source/Status fields
+5. [xref] AP#17, KG#12, KG#57 -- Add See also cross-references
+```
+
+### 6. Execute Approved Actions
+
+**Wait for user approval before executing.** The user may approve all, select specific actions, or skip entirely.
+
+For each approved action:
+
+- **Confirm active**: Add or update `**Last relevant:** YYYY-MM-DD`
+- **Deprecate**: Mark `**Status:** deprecated (YYYY-MM-DD) -- reason`, move to archive file, update frontmatter `entry_count`
+- **Merge**: Combine content into the surviving entry, supersede the other, archive the superseded entry
+- **Add metadata**: Insert `**Added:** date | **Source:** project | **Status:** active` line
+- **Cross-reference**: Add `**See also:**` lines to related entries
+
+### 7. Report Summary
+
+```text
+## Audit Summary
+
+**Actions executed:** N of M proposed
+**Entries deprecated:** N (moved to archive)
+**Entries merged:** N
+**Metadata added:** N entries
+**Cross-references added:** N entries
+**Frontmatter updated:** [Yes/No]
+
+Next audit recommended: YYYY-MM-DD (90 days from now)
+```

--- a/claude/skills/autolearn/workflows/quick-reflect.md
+++ b/claude/skills/autolearn/workflows/quick-reflect.md
@@ -102,6 +102,14 @@ Check tier boundaries before editing:
   Create a DevKit issue instead.
 - **Tier 2** (`autolearn-patterns.md`, `known-gotchas.md`): Safe to add entries directly.
 
+**Update "last relevant" timestamps (DevKit context only):**
+
+If an existing pattern or gotcha was actively applied during this session (not just read, but used to solve a problem or avoid a mistake), and the entry has a metadata line, update its `**Last relevant:**` field:
+
+- If the entry already has `**Last relevant:**`, update the date
+- If the entry has other metadata fields but no `**Last relevant:**`, append it
+- If the entry has no metadata at all, skip (metadata addition is an audit task)
+
 **If in a project (not DevKit):**
 
 1. Store all learnings in MCP Memory only (step 5 above).

--- a/claude/skills/autolearn/workflows/session-review.md
+++ b/claude/skills/autolearn/workflows/session-review.md
@@ -129,6 +129,14 @@ Check tier boundaries before editing:
   Create a DevKit issue instead.
 - **Tier 2** (`autolearn-patterns.md`, `known-gotchas.md`): Safe to add entries directly.
 
+**Update "last relevant" timestamps:**
+
+If an existing pattern or gotcha was actively applied during this session (not just read, but used to solve a problem or avoid a mistake), and the entry has a metadata line, update its `**Last relevant:**` field:
+
+- If the entry already has `**Last relevant:**`, update the date
+- If the entry has other metadata fields but no `**Last relevant:**`, append it
+- If the entry has no metadata at all, skip (metadata addition is an audit task)
+
 Read current Tier 2 rules files and for each HIGH-confidence finding:
 
 1. Check if it's already in the appropriate file


### PR DESCRIPTION
## Summary

- **New audit workflow** (`/reflect` option 5): Health check for Tier 2 rules files -- parses all entries, generates health report table, identifies stale entries (>90 days, no last-relevant signal), flags potential duplicates, proposes actions with user approval before executing
- **Last-relevant tracking**: Quick-reflect and session-review workflows now update `**Last relevant:**` timestamps on entries that were actively applied during the session (DevKit context only)
- **SKILL.md routing**: Added route 5 for `"audit", "rules", "health", "stale"` keywords

### Files Changed

| File | Change |
|------|--------|
| `claude/skills/autolearn/workflows/audit-rules.md` | New: 7-step audit workflow |
| `claude/skills/autolearn/SKILL.md` | Added option 5 and routing entry |
| `claude/skills/autolearn/workflows/quick-reflect.md` | Added last-relevant sub-step in scope assessment |
| `claude/skills/autolearn/workflows/session-review.md` | Added last-relevant sub-step in scope assessment |

Refs #112

## Test plan

- [ ] Verify `npx markdownlint-cli2` passes on all modified files
- [ ] Verify SKILL.md routing table has 5 entries matching 5 workflow files
- [ ] Verify audit-rules.md has context guard (DevKit only)
- [ ] Verify quick-reflect.md and session-review.md both have last-relevant sub-step

🤖 Generated with [Claude Code](https://claude.com/claude-code)