### PR TITLE
feat: add project-level settings.json template and permission strategy docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+# EditorConfig helps maintain consistent coding styles
+# https://editorconfig.org
+
+root = false

--- a/.sync-manifest.json
+++ b/.sync-manifest.json
@@ -100,13 +100,15 @@
       "description": "Per-repository config. Lives in project repos, not in DevKit. DevKit provides templates and a promotion path.",
       "templates": [
         "project-templates/claude-md-template.md",
-        "project-templates/workspace-claude-md-template.md"
+        "project-templates/workspace-claude-md-template.md",
+        "project-templates/settings.json"
       ],
       "convention": {
         "project_claude_md": "<project-root>/CLAUDE.md",
+        "project_settings_committed": "<project-root>/.claude/settings.json",
+        "project_settings_local": "<project-root>/.claude/settings.local.json",
         "project_rules": "<project-root>/.claude/rules/*.md",
-        "project_skills": "<project-root>/.claude/skills/*/",
-        "project_settings": "<project-root>/.claude/settings.local.json"
+        "project_skills": "<project-root>/.claude/skills/*/"
       }
     }
   },

--- a/claude/rules/autolearn-patterns.md
+++ b/claude/rules/autolearn-patterns.md
@@ -1,8 +1,8 @@
 ---
 description: Learned patterns from past sessions. Read when encountering similar situations.
 tier: 2
-entry_count: 75
-last_updated: "2026-02-28"
+entry_count: 76
+last_updated: "2026-03-01"
 ---
 
 # Learned Patterns
@@ -1109,3 +1109,15 @@ vi.mock('@/api/auth', () => ({
 3. For agent features, read the actual platform-specific files (e.g., `*_other.go` for Linux stubs)
 
 This can eliminate significant planned work when items are already implemented but unchecked.
+
+## 86. Two-Layer Permission Strategy for Claude Code Projects
+
+**Category:** workflow-pattern
+**Context:** Claude Code settings do NOT cascade from parent directories (unlike .editorconfig). Each project is independent. The `~/.claude/settings.json` (user-level) provides global defaults that merge into every project's permissions. Over time, interactive approvals accumulate hundreds of specific command entries (e.g., `Bash(gh pr merge 30 --squash --admin)`) instead of broad wildcards.
+**Fix:** Two-layer approach:
+
+1. **User-level** (`~/.claude/settings.json`): Broad wildcards: `"Bash"`, `"Read"`, `"Edit"`, `"Write"`, `"WebFetch"`, `"WebSearch"`, `"Glob"`, `"Grep"`, `"Task"`, `"Skill"`, `"mcp__*"`. These are baseline permissions for the machine owner.
+2. **Project-level** (`<project>/.claude/settings.json`): Tool-specific wildcards (`Bash(git:*)`, `Bash(gh:*)`, `Bash(make:*)`) committed to repo, shareable with collaborators. Project deny rules restrict dangerous operations.
+
+Periodically clean up user-level settings.json to remove accumulated specific approvals -- they are redundant when broad wildcards are present.
+**Proven:** Replaced 157 individual approvals with 11 broad wildcards. All projects immediately inherited tool access without per-command prompts.

--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -1,8 +1,8 @@
 ---
 description: Known gotchas and platform-specific issues. Read when debugging unexpected behavior.
 tier: 2
-entry_count: 60
-last_updated: "2026-02-28"
+entry_count: 61
+last_updated: "2026-03-01"
 ---
 
 # Known Gotchas
@@ -789,3 +789,18 @@ go run github.com/swaggo/swag/cmd/swag@v1.16.4 init -g cmd/app/main.go -o api/sw
 ```
 
 **Key insight:** `go run` downloads the module to a temp cache and executes it directly, bypassing any filesystem permission issues with the `~/go/bin/` directory. Pin the version with `@vX.Y.Z` for reproducibility. Works for any Go tool: `swag`, `protoc-gen-go`, `golangci-lint`, etc.
+
+## 61. Claude Code settings.local.json Does NOT Cascade from Parent Directories
+
+**Platform:** Claude Code (all)
+**Issue:** Unlike `.editorconfig` which walks up directories, Claude Code `settings.local.json` and `settings.json` do NOT cascade from parent directories. `D:\DevSpace\.claude\settings.local.json` does NOT apply to `D:\DevSpace\ProjectA\`. Each project is an independent scope.
+**Impact:** Every new project requires manually approving every tool use, even when broad permissions exist in a parent directory.
+**Settings hierarchy (actual):**
+
+1. User-level: `~/.claude/settings.json` (applies to ALL projects)
+2. Project-level: `<project>/.claude/settings.json` (committed, collaborator-shared)
+3. Project-local: `<project>/.claude/settings.local.json` (gitignored, session accumulation)
+
+Permission arrays **merge** across scopes. Deny rules take precedence.
+**Fix:** Put broad tool permission wildcards in `~/.claude/settings.json` (user-level). These apply as defaults to every project. Use project-level `settings.json` only for project-specific deny rules or overrides. DevKit's `settings.template.json` has the correct broad wildcards -- apply them to `~/.claude/settings.json`, not to a parent workspace directory.
+**Prevention:** When scaffolding new projects, copy `project-templates/settings.json` to `<project>/.claude/settings.json`. See DevKit issue #131.

--- a/project-templates/settings.json
+++ b/project-templates/settings.json
@@ -1,0 +1,52 @@
+{
+  "_comment": "Project-level Claude Code settings. Committed to repo. Collaborators inherit these.",
+  "_comment2": "User-level ~/.claude/settings.json provides global defaults (broad tool access). This file adds project-specific overrides.",
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(make:*)",
+      "Bash(npx:*)",
+      "Bash(go:*)",
+      "Bash(python:*)",
+      "Bash(python3:*)",
+      "Bash(node:*)",
+      "Bash(cargo:*)",
+      "Bash(dotnet:*)",
+      "Bash(docker:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(grep:*)",
+      "Bash(find:*)",
+      "Bash(mkdir:*)",
+      "Bash(cp:*)",
+      "Bash(mv:*)",
+      "Bash(echo:*)",
+      "Bash(pwd:*)",
+      "Bash(which:*)",
+      "Bash(command:*)",
+      "Bash(wc:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(sort:*)",
+      "Bash(uniq:*)",
+      "Bash(diff:*)",
+      "Bash(test:*)",
+      "Bash(bash:*)",
+      "Read",
+      "Edit",
+      "Write",
+      "Glob",
+      "Grep",
+      "Task",
+      "Skill",
+      "WebFetch",
+      "WebSearch",
+      "mcp__*"
+    ],
+    "deny": [
+      "Bash(rm -rf /)"
+    ]
+  },
+  "enableAllProjectMcpServers": true
+}


### PR DESCRIPTION
## Summary

- Add `project-templates/settings.json` with tool-specific Bash wildcards for new project scaffolding
- Update `.sync-manifest.json` to include settings template in project tier and clarify committed vs local settings convention
- Document two-layer permission strategy (AP#86) and settings non-cascading gotcha (KG#61)
- Add `.editorconfig` (`root=false`) to inherit from DevSpace parent

## Test plan

- [ ] Verify `project-templates/settings.json` is valid JSON
- [ ] Verify sync manifest schema is consistent
- [ ] Verify AP#86 and KG#61 entries follow existing format

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)