### PR TITLE
ci: add rule metadata validation job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -93,12 +93,17 @@ jobs:
             prefix="${FILE_PREFIX[$file]}"
             while IFS=: read -r num rest; do
               ALL_ENTRIES["${prefix}#${num}"]=1
-            done < <(grep -P '^## (\d+)\.' "$file" | grep -oP '(?<=## )\d+')
+            done < <(tr -d '\r' < "$file" | grep -P '^## (\d+)\.' | grep -oP '(?<=## )\d+')
           done
 
           for file in "${!FILE_PREFIX[@]}"; do
             prefix="${FILE_PREFIX[$file]}"
             echo "--- Validating $file (prefix: $prefix) ---"
+
+            # Strip Windows carriage returns for consistent parsing
+            # (files may be committed from Windows with CRLF endings)
+            clean_file=$(mktemp)
+            tr -d '\r' < "$file" > "$clean_file"
 
             # -------------------------------------------------------
             # (a) Validate **Added:** line format
@@ -132,7 +137,7 @@ jobs:
                 echo "::error file=$file,line=$lineno::Invalid status '$status_val'. Must be: active | deprecated (YYYY-MM-DD) -- reason | superseded-by-<PREFIX>#<N>"
                 errors=$((errors + 1))
               fi
-            done < <(grep -nP '^\*\*Added:\*\*' "$file")
+            done < <(grep -nP '^\*\*Added:\*\*' "$clean_file")
 
             # -------------------------------------------------------
             # (b) Validate **See also:** references
@@ -152,39 +157,41 @@ jobs:
                 fi
 
                 # Verify the heading ## N. exists in the target file
-                if ! grep -qP "^## ${ref_num}\." "$target_file"; then
+                # (use clean_file for the current file, read target fresh with tr)
+                if ! tr -d '\r' < "$target_file" | grep -qP "^## ${ref_num}\."; then
                   echo "::error file=$file,line=$lineno::Reference $ref points to non-existent entry (## ${ref_num}. not found in $target_file)"
                   errors=$((errors + 1))
                 fi
               done
-            done < <(grep -nP '^\*\*See also:\*\*' "$file")
+            done < <(grep -nP '^\*\*See also:\*\*' "$clean_file")
 
             # -------------------------------------------------------
             # (c) Validate entry_count in frontmatter
             # -------------------------------------------------------
             # Read entry_count from YAML frontmatter
-            frontmatter_count=$(grep -P '^entry_count:\s*\d+' "$file" | grep -oP '\d+' || echo "")
+            frontmatter_count=$(grep -P '^entry_count:\s*\d+' "$clean_file" | grep -oP '\d+' || echo "")
             if [ -z "$frontmatter_count" ]; then
               echo "::error file=$file,line=1::Missing entry_count in YAML frontmatter"
               errors=$((errors + 1))
             else
               # Count all ## N. headings
-              total_entries=$(grep -cP '^## \d+\.' "$file" || echo "0")
+              total_entries=$(grep -cP '^## \d+\.' "$clean_file" || echo "0")
 
               # Count deprecated and superseded entries
-              inactive_entries=$(grep -cP '^\*\*Status:\*\* (deprecated|superseded)' "$file" || echo "0")
+              inactive_entries=$(grep -cP '^\*\*Status:\*\* (deprecated|superseded)' "$clean_file" || echo "0")
 
               # Active = total - inactive
               active_entries=$((total_entries - inactive_entries))
 
               if [ "$active_entries" != "$frontmatter_count" ]; then
                 # Find the line number of entry_count for the annotation
-                ec_line=$(grep -nP '^entry_count:' "$file" | head -1 | cut -d: -f1)
+                ec_line=$(grep -nP '^entry_count:' "$clean_file" | head -1 | cut -d: -f1)
                 echo "::error file=$file,line=$ec_line::entry_count is $frontmatter_count but computed active entries = $active_entries (total=$total_entries, inactive=$inactive_entries)"
                 errors=$((errors + 1))
               fi
             fi
 
+            rm -f "$clean_file"
             echo "--- Done: $file ---"
           done
 


### PR DESCRIPTION
## Summary

- Add `validate-rule-metadata` job to `.github/workflows/lint.yml`
- Validates `**Added:**` line format (date, source, status) on annotated entries
- Validates `**See also:**` cross-references point to existing entry numbers
- Validates frontmatter `entry_count` matches computed active entry count
- Only checks entries with metadata -- unannotated entries are skipped
- Uses `::error` annotations for precise line-level CI feedback

## Test plan

- [ ] CI passes on current rules files (13 annotated entries)
- [ ] Unannotated entries are not flagged
- [ ] `entry_count` validation catches mismatches

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)