### PR TITLE
feat: add new-project scaffolding route to devkit-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ This backs up any existing files in `~/.claude/`, creates symlinks for all share
 | `/devkit-sync promote` | Graduate local patterns to universal rules |
 | `/devkit-sync update` | Check version and upgrade to latest release |
 | `/devkit-sync verify` | Check if DevKit updates reached all active projects |
+| `/devkit-sync new-project` | Scaffold a new project with templates and profile |
 
 ### Multi-machine workflow
 

--- a/claude/skills/devkit-sync/SKILL.md
+++ b/claude/skills/devkit-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devkit-sync
-description: Manual sync operations for DevKit multi-machine synchronization. Status, push, pull, init, diff, unlink, promote, and update.
+description: Manual sync operations for DevKit multi-machine synchronization. Status, push, pull, init, diff, unlink, promote, update, and new-project scaffolding.
 user_invocable: true
 ---
 
@@ -31,6 +31,7 @@ What sync operation do you need?
 8. **Promote** -- Promote local patterns/gotchas to universal rules files
 9. **Update** -- Check version and upgrade to a specific release or latest
 10. **Verify** -- Check if DevKit updates reached all active projects
+11. **New project** -- Scaffold a new project with DevKit templates and profile
 
 Or just type your question about DevKit sync.
 </intake>
@@ -48,6 +49,7 @@ Or just type your question about DevKit sync.
 | 8, "promote", "graduate", "elevate", "local to universal" | workflows/promote.md |
 | 9, "update", "upgrade", "version", "release" | workflows/update.md |
 | 10, "verify", "propagation", "check projects", "reach" | workflows/verify.md |
+| 11, "new-project", "scaffold", "create project", "new" | workflows/new-project.md |
 
 **After reading the workflow, follow it exactly.**
 </routing>

--- a/claude/skills/devkit-sync/workflows/new-project.md
+++ b/claude/skills/devkit-sync/workflows/new-project.md
@@ -1,0 +1,124 @@
+# DevKit Sync: New Project
+
+Scaffold a new project directory with DevKit templates and an optional stack profile.
+
+## Steps
+
+1. **Gather project info from the user:**
+
+   Ask the user for:
+
+   - **Project name** (kebab-case, e.g., `my-tool`)
+   - **One-line description** (what does this project do?)
+   - **Profile** -- one of: `go-cli`, `go-web`, `iot-embedded`, or `none`
+
+   Validate the project name: letters, numbers, and hyphens only, must start with a letter or number.
+
+2. **Resolve the DevSpace path:**
+
+   Read `.devkit-config.json` from the DevKit clone root directory. Use the `devspacePath` field to find the DevSpace directory.
+
+   ```bash
+   cat <devkit-root>/.devkit-config.json
+   ```
+
+   If the file does not exist or `devspacePath` is missing, ask the user for their DevSpace path (e.g., `D:\DevSpace` or `~/workspace`).
+
+3. **Create the project directory:**
+
+   ```bash
+   mkdir -p <devspace>/<project-name>
+   ```
+
+   If the directory already exists, warn the user and ask whether to continue.
+
+4. **Initialize git:**
+
+   Check if `git-templates/` exists in the DevKit clone. If it does, use it as the template directory:
+
+   ```bash
+   git init --template=<devkit-root>/git-templates <devspace>/<project-name>
+   ```
+
+   If `git-templates/` does not exist, use a plain init:
+
+   ```bash
+   git init <devspace>/<project-name>
+   ```
+
+5. **Copy always-included templates:**
+
+   These files are copied for every project regardless of profile.
+
+   First, create the `.claude/` directory:
+
+   ```bash
+   mkdir -p <devspace>/<project-name>/.claude
+   ```
+
+   Then copy:
+
+   - `project-templates/claude-md-template.md` to `<project>/CLAUDE.md`
+     - Replace `{{PROJECT_NAME}}` with the project name
+     - Replace `{{PROJECT_DESCRIPTION}}` with the description
+     - Replace `{{PROFILE}}` with the selected profile (or `none`)
+     - Replace `{{DEVSPACE}}` with the resolved DevSpace path
+   - `project-templates/settings.json` to `<project>/.claude/settings.json`
+
+   Use the Read tool to load each template, perform substitutions, then Write the result.
+
+6. **Copy profile-specific templates (go-cli or go-web only):**
+
+   If the user selected `go-cli` or `go-web`, copy these additional files:
+
+   - `project-templates/golangci.yml` to `<project>/.golangci.yml`
+   - `project-templates/Makefile.go` to `<project>/Makefile`
+   - `project-templates/ci.yml` to `<project>/.github/workflows/ci.yml`
+
+   Create the `.github/workflows/` directory first:
+
+   ```bash
+   mkdir -p <devspace>/<project-name>/.github/workflows
+   ```
+
+   These files are copied as-is without substitution.
+
+7. **Optionally create a GitHub repo:**
+
+   Ask the user: "Create a GitHub repo for this project? [y/N]"
+
+   If yes:
+
+   ```bash
+   cd <devspace>/<project-name>
+   git add -A
+   git commit -m "chore: initial project scaffolding"
+   gh repo create <owner>/<project-name> --private --source=. --remote origin --push
+   ```
+
+   Determine `<owner>` from `gh api user --jq '.login'` or `git config --global user.name`.
+
+8. **Report summary:**
+
+   Display what was created:
+
+   - Project directory path
+   - Files created (list each one)
+   - Git initialized (with or without template)
+   - GitHub repo URL (if created)
+
+   Suggest next steps:
+
+   - Edit `CLAUDE.md` to fill in remaining TODO sections
+   - Review `.claude/settings.json` and adjust permissions
+   - Add source code and start building
+   - Run `claude` in the project directory to begin development
+
+## Edge Cases
+
+- Project directory already exists: warn and confirm before continuing
+- `.devkit-config.json` missing: ask user for DevSpace path
+- `git-templates/` not found in DevKit: fall back to plain `git init`
+- `gh` not authenticated: skip GitHub repo creation, tell user the manual command
+- Profile `iot-embedded`: no extra templates are copied (only always-included files)
+- Profile `none`: no extra templates are copied (only always-included files)


### PR DESCRIPTION
## Summary

- Add route 11 (`new-project`) to devkit-sync SKILL.md
- Create `workflows/new-project.md` with step-by-step scaffolding workflow
- Gathers project name, description, and profile (go-cli/go-web/iot-embedded/none)
- Creates directory, git init, copies templates with placeholder substitution
- Profile-specific templates for Go projects (golangci.yml, Makefile, CI workflow)
- Optional GitHub repo creation via `gh repo create`
- Add subcommand row to README

## Test plan

- [ ] Skill routing validation passes (new workflow file exists)
- [ ] Markdown lint passes on new workflow file
- [ ] README subcommands table has 11 rows

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)