### PR TITLE
feat: add rules drift detection to SessionStart and devkit-sync

### DIFF
--- a/claude/hooks/SessionStart.sh
+++ b/claude/hooks/SessionStart.sh
@@ -199,6 +199,47 @@ devkit_symlink_health() {
 
 devkit_symlink_health "$(_devkit_resolve_path)"
 
+# ===== Rules Drift Detection =====
+# Compare entry counts between ~/.claude/rules/ and devkit clone.
+# Warns when copies have diverged so user can push or pull.
+devkit_drift_check() {
+    local devkit_path="$1"
+    [ -z "$devkit_path" ] && return 0
+    [ ! -d "$devkit_path/claude/rules" ] && return 0
+
+    local local_rules="$HOME/.claude/rules"
+    [ ! -d "$local_rules" ] && return 0
+
+    local files="autolearn-patterns.md known-gotchas.md workflow-preferences.md"
+    local drifted=0
+
+    for f in $files; do
+        [ ! -f "$local_rules/$f" ] && continue
+        [ ! -f "$devkit_path/claude/rules/$f" ] && continue
+
+        local local_count devkit_count
+        local_count=$(grep -c '^## [0-9]' "$local_rules/$f" 2>/dev/null || echo 0)
+        devkit_count=$(grep -c '^## [0-9]' "$devkit_path/claude/rules/$f" 2>/dev/null || echo 0)
+
+        if [ "$local_count" != "$devkit_count" ]; then
+            local direction
+            if [ "$local_count" -gt "$devkit_count" ]; then
+                direction="local $local_count > devkit $devkit_count (push needed)"
+            else
+                direction="local $local_count < devkit $devkit_count (pull needed)"
+            fi
+            echo "DevKit drift: $f -- $direction"
+            drifted=$((drifted + 1))
+        fi
+    done
+
+    if [ "$drifted" -gt 0 ]; then
+        echo "DevKit: $drifted rules file(s) out of sync. Run /devkit-sync push or pull."
+    fi
+}
+
+devkit_drift_check "$(_devkit_resolve_path)"
+
 # ===== CLAUDE.md Detection =====
 
 # Skip if we're in the home directory

--- a/claude/skills/devkit-sync/workflows/status.md
+++ b/claude/skills/devkit-sync/workflows/status.md
@@ -39,4 +39,24 @@ Show current sync state including symlink health, git status, and drift report.
      Local:    N *.local.md files
    ```
 
-4. **Flag issues** if any symlinks are broken, missing, or are real files instead of symlinks.
+4. **Rules drift report** -- compare entry counts between `~/.claude/rules/` and `<devkit>/claude/rules/` for each rules file:
+
+   ```bash
+   for f in autolearn-patterns.md known-gotchas.md workflow-preferences.md; do
+     local_count=$(grep -c '^## [0-9]' ~/.claude/rules/$f 2>/dev/null || echo 0)
+     devkit_count=$(grep -c '^## [0-9]' <devkit>/claude/rules/$f 2>/dev/null || echo 0)
+     echo "$f: local=$local_count devkit=$devkit_count"
+   done
+   ```
+
+   Include in formatted status:
+
+   ```text
+     Drift:    autolearn-patterns (local 99 = devkit 99 ✓)
+               known-gotchas (local 82 > devkit 79 -- push needed)
+               workflow-preferences (local 16 = devkit 16 ✓)
+   ```
+
+   Direction: local > devkit means "push needed", local < devkit means "pull needed".
+
+5. **Flag issues** if any symlinks are broken, missing, or are real files instead of symlinks.


### PR DESCRIPTION
## Summary

- Add `devkit_drift_check()` function to SessionStart.sh that compares entry counts between `~/.claude/rules/` and the devkit clone
- Warns at session start when rules files have diverged, with push/pull direction
- Add drift report step to `/devkit-sync status` workflow showing per-file entry counts
- Lightweight: 6 `grep -c` calls total, no file content reads

## Test plan

- [x] `bash -n claude/hooks/SessionStart.sh` passes
- [x] `npx markdownlint-cli2` passes on status.md
- [ ] CI lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)