### PR TITLE
fix: sync.ps1 StrictMode crash on v2 manifest

### DIFF
--- a/setup/sync.ps1
+++ b/setup/sync.ps1
@@ -109,7 +109,9 @@ function Read-SyncManifest {
     $manifest = Get-Content $manifestPath -Raw | ConvertFrom-Json
 
     # v2 schema: tiers.universal replaces shared
-    if ($manifest.tiers -and $manifest.tiers.universal -and -not $manifest.shared) {
+    # Use PSObject.Properties to avoid PropertyNotFoundException under Set-StrictMode -Version Latest
+    $hasShared = $manifest.PSObject.Properties.Match('shared').Count -gt 0
+    if ($manifest.tiers -and $manifest.tiers.universal -and -not $hasShared) {
         $manifest | Add-Member -NotePropertyName 'shared' -NotePropertyValue $manifest.tiers.universal -Force
     }
 


### PR DESCRIPTION
## Summary

- `Read-SyncManifest` accessed `$manifest.shared` in a conditional, which throws `PropertyNotFoundException` under `Set-StrictMode -Version Latest` when the property doesn't exist
- v2 manifests use `tiers.universal` instead of `shared` -- the backward compat shim adds `.shared` but the existence check itself threw before reaching `Add-Member`
- Fix: use `PSObject.Properties.Match('shared')` for safe property check

## Test plan

- [x] `pwsh setup/sync.ps1 -Link` completes successfully (39 symlinks created)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)