### PR TITLE
fix: Set-MachineIdentity crash in non-interactive mode

### DIFF
--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -1,7 +1,7 @@
 ---
 description: Known gotchas and platform-specific issues. Read when debugging unexpected behavior.
 tier: 2
-entry_count: 79
+entry_count: 80
 last_updated: "2026-03-01"
 ---
 
@@ -1040,3 +1040,25 @@ ignored:
 **Platform:** GitHub
 **Issue:** Repository secrets for GitHub Actions are under Settings > Secrets and variables > Actions. The "Secrets and variables" item has a dropdown arrow that must be clicked to expand and reveal the "Actions" submenu. Easy to miss when looking at the Settings sidebar.
 **Fix:** Use CLI instead: `gh secret set SECRETNAME` (prompts for value). `gh secret list` to verify.
+
+## 80. PowerShell StrictMode Throws on Nonexistent Property Access in Conditionals
+
+**Platform:** PowerShell 7+
+**Issue:** Under `Set-StrictMode -Version Latest`, accessing a property that doesn't exist on a `PSCustomObject` throws `PropertyNotFoundException` -- even inside a boolean conditional like `if (-not $obj.prop)`. The error fires before the `-not` operator evaluates. This breaks backward-compatibility shims that check for a property before adding it (e.g., `if (-not $manifest.shared) { Add-Member ... }`).
+**Diagnosis:** Error says "The property 'X' cannot be found on this object" pointing to the conditional line, not to a property assignment.
+**Fix:** Use `PSObject.Properties.Match()` for safe existence checks:
+
+```powershell
+# BAD: throws under StrictMode when 'shared' doesn't exist
+if ($manifest.tiers -and -not $manifest.shared) {
+    $manifest | Add-Member -NotePropertyName 'shared' -NotePropertyValue $manifest.tiers.universal
+}
+
+# GOOD: safe property existence check
+$hasShared = $manifest.PSObject.Properties.Match('shared').Count -gt 0
+if ($manifest.tiers -and -not $hasShared) {
+    $manifest | Add-Member -NotePropertyName 'shared' -NotePropertyValue $manifest.tiers.universal
+}
+```
+
+**Note:** This does NOT affect hashtables (`$hash.missing` returns `$null` under StrictMode). Only `PSCustomObject` (from `ConvertFrom-Json`, `New-Object`, etc.) throws.

--- a/setup/sync.ps1
+++ b/setup/sync.ps1
@@ -297,8 +297,9 @@ function Set-MachineIdentity {
     Write-Step "Machine identity is used in sync branch names and commit messages."
     Write-Step "Default (from hostname): $default"
 
+    # In non-interactive mode (piped from bash, CI), Read-Host returns null
     $userInput = Read-Host -Prompt "  Machine ID [$default]"
-    $machineId = if ($userInput.Trim()) { $userInput.Trim() } else { $default }
+    $machineId = if ($userInput -and $userInput.Trim()) { $userInput.Trim() } else { $default }
 
     # Validate
     if ($machineId -notmatch '^[a-z0-9][a-z0-9-]{1,28}[a-z0-9]$') {


### PR DESCRIPTION
## Summary

Closes #143

- Guard `Read-Host` return value with null check before `.Trim()` -- `Read-Host` returns null in non-interactive contexts (piped from bash, CI)
- Add KG#80: PowerShell StrictMode property access gotcha (discovered during PR #142)

## Test plan

- [x] `npx markdownlint-cli2` passes on known-gotchas.md
- [x] Entry count (80) matches frontmatter
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)