### PR TITLE
feat: enforce .claude/settings.json on all projects

### DIFF
--- a/claude/hooks/SessionStart.sh
+++ b/claude/hooks/SessionStart.sh
@@ -257,8 +257,20 @@ if [ "$is_project" = false ]; then
     exit 0
 fi
 
-# Already has CLAUDE.md — nothing to do
-if [ -f "CLAUDE.md" ]; then
+# Check for missing project config files
+missing_claude_md=false
+missing_settings=false
+
+if [ ! -f "CLAUDE.md" ]; then
+    missing_claude_md=true
+fi
+
+if [ ! -f ".claude/settings.json" ]; then
+    missing_settings=true
+fi
+
+# Nothing missing — done
+if [ "$missing_claude_md" = false ] && [ "$missing_settings" = false ]; then
     exit 0
 fi
 
@@ -274,9 +286,17 @@ if [ -f ".gitignore" ] && ! grep -q "^\.claude-init-prompted$" .gitignore; then
     echo ".claude-init-prompted" >> .gitignore
 fi
 
-echo ""
-echo "This project doesn't have a CLAUDE.md file."
-echo "  Create one: 'Create a CLAUDE.md for this project'"
-echo ""
+if [ "$missing_claude_md" = true ]; then
+    echo ""
+    echo "This project doesn't have a CLAUDE.md file."
+    echo "  Create one: 'Create a CLAUDE.md for this project'"
+fi
 
+if [ "$missing_settings" = true ]; then
+    echo ""
+    echo "This project doesn't have .claude/settings.json (project-level permissions)."
+    echo "  Copy from DevKit: cp <devkit>/project-templates/settings.json .claude/settings.json"
+fi
+
+echo ""
 exit 0

--- a/git-templates/.claude/settings.json
+++ b/git-templates/.claude/settings.json
@@ -1,0 +1,52 @@
+{
+  "_comment": "Project-level Claude Code settings. Committed to repo. Collaborators inherit these.",
+  "_comment2": "User-level ~/.claude/settings.json provides global defaults (broad tool access). This file adds project-specific overrides.",
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(make:*)",
+      "Bash(npx:*)",
+      "Bash(go:*)",
+      "Bash(python:*)",
+      "Bash(python3:*)",
+      "Bash(node:*)",
+      "Bash(cargo:*)",
+      "Bash(dotnet:*)",
+      "Bash(docker:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(grep:*)",
+      "Bash(find:*)",
+      "Bash(mkdir:*)",
+      "Bash(cp:*)",
+      "Bash(mv:*)",
+      "Bash(echo:*)",
+      "Bash(pwd:*)",
+      "Bash(which:*)",
+      "Bash(command:*)",
+      "Bash(wc:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(sort:*)",
+      "Bash(uniq:*)",
+      "Bash(diff:*)",
+      "Bash(test:*)",
+      "Bash(bash:*)",
+      "Read",
+      "Edit",
+      "Write",
+      "Glob",
+      "Grep",
+      "Task",
+      "Skill",
+      "WebFetch",
+      "WebSearch",
+      "mcp__*"
+    ],
+    "deny": [
+      "Bash(rm -rf /)"
+    ]
+  },
+  "enableAllProjectMcpServers": true
+}


### PR DESCRIPTION
## Summary

- Add `git-templates/.claude/settings.json` so `git init` auto-creates project-level permissions
- Update SessionStart.sh to detect missing `.claude/settings.json` alongside CLAUDE.md
- Closes the gap where 7 of 9 projects lacked settings.json (created before Kit 3)

### Root cause

Projects created before `setup/new-project.ps1` (Kit 3) existed never got `.claude/settings.json`. The git template didn't include it and SessionStart.sh only checked for CLAUDE.md.

### Three-layer coverage after this PR

| Layer | Mechanism | Covers |
|-------|-----------|--------|
| git init | `git-templates/.claude/settings.json` | New repos via `git init` |
| Scaffolder | `setup/new-project.ps1` | New projects via Kit 3 wizard |
| Session hook | SessionStart.sh detection | Existing projects opened in Claude Code |

## Test plan

- [x] `bash -n claude/hooks/SessionStart.sh` passes
- [x] `settings.json` is valid JSON
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)