### PR TITLE
chore: add KG#25 stash timing update and KG#87 Vitest browser exports

### DIFF
--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -1,7 +1,7 @@
 ---
 description: Known gotchas and platform-specific issues. Read when debugging unexpected behavior.
 tier: 2
-entry_count: 86
+entry_count: 87
 last_updated: "2026-03-02"
 ---
 


### PR DESCRIPTION
## Summary

- Extends **KG#25** (parallel agents share working tree) with stash timing gotcha: `git stash` while agents are still running causes `stash pop` to fail. Includes recovery steps.
- Adds **KG#87**: Vitest cannot resolve npm packages that only export via the `browser` field in `package.json`. Fix via `resolve.alias` in vitest config.
- Cross-references KG#81 <-> KG#87 (Docker-specific case vs general pattern).

Closes #154, Closes #156

## Test plan

- [ ] markdownlint passes (verified locally, 0 errors)
- [ ] CI lint job passes
- [ ] Entry numbering is sequential (87 follows 86)
- [ ] Cross-references are bidirectional (KG#81 -> KG#87, KG#87 -> KG#81)

🤖 Generated with [Claude Code](https://claude.com/claude-code)