### PR TITLE
feat: add release gate and nightly build templates

### DIFF
--- a/claude/skills/devkit-sync/workflows/new-project.md
+++ b/claude/skills/devkit-sync/workflows/new-project.md
@@ -102,10 +102,16 @@ Scaffold a new project directory with DevKit templates and an optional stack pro
    - `project-templates/instructions/react.instructions.md` to `<project>/.github/instructions/react.instructions.md`
      - Replace `{{FRONTEND_PATH}}` with `web` (or the project's frontend path)
    - `project-templates/copilot-setup-steps-fullstack.yml` to `<project>/.github/workflows/copilot-setup-steps.yml`
+   - `project-templates/nightly-go.yml` to `<project>/.github/workflows/nightly.yml`
+     - Replace `{{DOCKER_IMAGE}}`, `{{VERSION_PACKAGE}}`, `{{BINARY_NAME}}`, `{{BINARY_CMD}}`
+     - Keep FRONTEND blocks (project has a frontend)
 
    If `go-cli` profile, copy:
 
    - `project-templates/copilot-setup-steps-go.yml` to `<project>/.github/workflows/copilot-setup-steps.yml`
+   - `project-templates/nightly-go.yml` to `<project>/.github/workflows/nightly.yml`
+     - Replace `{{DOCKER_IMAGE}}`, `{{VERSION_PACKAGE}}`, `{{BINARY_NAME}}`, `{{BINARY_CMD}}`
+     - Remove all lines marked `# FRONTEND:` (CLI-only, no frontend)
 
    Create the `.github/workflows/` directory first:
 
@@ -114,6 +120,18 @@ Scaffold a new project directory with DevKit templates and an optional stack pro
    ```
 
    CodeQL, instructions, and setup-steps files are copied as-is unless noted.
+
+   **Release gate (all profiles with release-please):**
+
+   - `project-templates/release-gate.yml` to `<project>/.github/workflows/release-gate.yml`
+     - No substitutions needed (language-agnostic)
+
+   **Nightly builds for non-Go profiles:**
+
+   - `node` or Docker extension profile: copy `project-templates/nightly-node.yml` to `<project>/.github/workflows/nightly.yml`
+     - Replace `{{DOCKER_IMAGE}}`
+   - `rust` profile: copy `project-templates/nightly-rust.yml` to `<project>/.github/workflows/nightly.yml`
+     - Replace `{{BINARY_NAME}}`
 
 8. **Optionally create a GitHub repo:**
 

--- a/docs/ADR-0016-release-gating.md
+++ b/docs/ADR-0016-release-gating.md
@@ -1,0 +1,123 @@
+# ADR-0016: Release Gating Strategy
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-04
+
+## Context
+
+ADR-0015 introduced release-please for automated release management. release-please
+creates a Release PR on every push to main, but those PRs require manual merging.
+For active projects with frequent commits, this creates friction:
+
+- Patch-only releases (single typo fix) don't warrant a human merge ceremony
+- Security fixes should ship immediately without waiting for a maintainer
+- Minor releases with features should ship promptly
+- But trivial patch releases can be batched until they reach a significance threshold
+
+SubNetree PR #525 implemented a release gate workflow that evaluates release-please
+PRs and auto-merges based on changelog significance. This ADR documents the strategy
+and provides it as a DevKit template for all projects.
+
+## Decision
+
+Add a **Release Gate** workflow that runs on release-please PRs and classifies them
+into three tiers based on the changelog content and version bump:
+
+### Release Tiers
+
+| Tier | Criteria | Action |
+|------|----------|--------|
+| Immediate | `fix!:`, `BREAKING CHANGE`, CVE, security/vulnerability keywords | Auto-merge now |
+| Threshold | Major or minor version bump, OR 5+ accumulated fix commits | Auto-merge now |
+| Batched | Below threshold (few patches, no features) | Label and wait for manual merge |
+
+### How It Works
+
+1. release-please creates/updates a Release PR with the `autorelease: pending` label
+2. The Release Gate workflow triggers on PR open/sync/reopen/label events
+3. It reads `.release-please-manifest.json` to compare current vs proposed version
+4. It counts conventional commits since the last release tag by type (feat/fix)
+5. Based on the tier classification, it either enables auto-merge or labels as batched
+6. A structured comment is posted on the PR with the decision and reasoning
+7. Previous bot comments are cleaned up to avoid spam
+
+### Labels
+
+- `release:auto` (green) -- auto-merge enabled, will merge when CI passes
+- `release:batched` (yellow) -- below threshold, waiting for more changes or manual merge
+
+### Integration with release-please
+
+```text
+Feature PRs merge to main
+  -> release-please creates/updates Release PR
+  -> Release Gate evaluates the PR
+  -> Immediate/Threshold: auto-merge enabled, merges when CI green
+  -> Batched: stays open, accumulates more commits
+  -> On merge: release-please creates git tag + GitHub Release
+  -> Tag triggers release.yml (GoReleaser, Docker, cargo)
+```
+
+The gate workflow is language-agnostic. It only reads the release-please manifest
+and git history -- no build tools or language runtimes required.
+
+## Nightly Builds
+
+Alongside the release gate, DevKit provides nightly build templates for continuous
+testing of the main branch between formal releases:
+
+- **Go variant**: Docker image + cross-platform binary matrix
+- **Node variant**: Docker image only (for Docker Desktop extensions)
+- **Rust variant**: Cross-platform binary matrix
+
+Nightly builds run at 2 AM UTC, skip if no commits in 24 hours, and can be
+triggered manually. They push to GHCR with `nightly` and `nightly-YYYYMMDD` tags.
+Artifacts have 7-day retention.
+
+## Alternatives Considered
+
+### Always Auto-Merge
+
+Auto-merge every release-please PR regardless of content. Rejected because trivial
+single-fix patches create noise in the release history and notification fatigue for
+watchers.
+
+### Manual-Only
+
+Keep all release merges manual (status quo before this ADR). Rejected because it
+creates friction for security fixes and feature releases that should ship promptly.
+
+### Time-Based Batching
+
+Auto-merge if the Release PR has been open for N days. Rejected because time-based
+rules don't account for content significance -- a security fix shouldn't wait 3 days.
+
+## Consequences
+
+### Positive
+
+- Security and breaking changes ship immediately without human intervention
+- Feature releases auto-ship, reducing merge ceremony
+- Trivial patches batch naturally until they reach significance
+- PR labels and comments provide visibility into the gating decision
+- Language-agnostic -- works for Go, Rust, Node.js, C#, and PowerShell projects
+
+### Negative
+
+- Adds another workflow file to maintain per project
+- Auto-merge requires branch protection to allow GitHub Actions to merge
+- The fix threshold (5) is a judgment call that may not suit all projects
+- Batched releases can accumulate indefinitely if no features are added
+
+### Risks
+
+- A mislabeled commit (e.g., `fix:` for what should be `feat:`) could batch
+  a release that should auto-merge. Mitigated by conventional commit enforcement
+  in CI.
+- Auto-merge on security keywords could be gamed. Low risk for private/small-team
+  repos; larger teams should review the keyword list.

--- a/project-templates/nightly-go.yml
+++ b/project-templates/nightly-go.yml
@@ -1,0 +1,203 @@
+# Nightly Build — Go + Docker
+#
+# Builds nightly Docker image and cross-platform binaries from main.
+# Does NOT create a GitHub Release or git tag.
+#
+# Prerequisites:
+#   - Dockerfile at repo root
+#   - Go module with go.mod
+#   - internal/version package with Version, GitCommit, BuildDate vars
+#
+# Template variables (replace before use):
+#   {{DOCKER_IMAGE}}    — full GHCR image path (e.g., ghcr.io/owner/repo)
+#   {{VERSION_PACKAGE}} — Go import path for ldflags (e.g., github.com/owner/repo/internal/version)
+#   {{BINARY_NAME}}     — binary name (e.g., myapp)
+#   {{BINARY_CMD}}      — path to main package (e.g., ./cmd/myapp/)
+#
+# Optional sections (remove if not needed):
+#   - Frontend build steps (lines marked FRONTEND) — remove for CLI-only projects
+#   - Additional binaries — duplicate the go build block for each binary
+
+name: Nightly Build
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # Every day at 2 AM UTC
+  workflow_dispatch: # Manual trigger
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  check-changes:
+    name: Check for Changes
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for commits since last nightly
+        id: check
+        run: |
+          # Skip build if no commits in the last 24 hours
+          RECENT=$(git log --since="24 hours ago" --oneline origin/main | head -1)
+          if [ -n "$RECENT" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Changes found since last nightly"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No changes in last 24 hours, skipping build"
+          fi
+
+  build:
+    name: Nightly Docker Image
+    needs: check-changes
+    if: needs.check-changes.outputs.has_changes == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # FRONTEND: Remove this block for CLI-only projects
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      # FRONTEND: Remove this block for CLI-only projects
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      # FRONTEND: Remove this block for CLI-only projects
+      - name: Build frontend
+        working-directory: web
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run build
+
+      # FRONTEND: Remove this block for CLI-only projects
+      - name: Embed frontend in Go binary
+        run: |
+          rm -rf internal/dashboard/dist
+          cp -r web/dist internal/dashboard/dist
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate build metadata
+        id: meta
+        run: |
+          DATE=$(date -u +%Y%m%d)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            {{DOCKER_IMAGE}}:nightly
+            {{DOCKER_IMAGE}}:nightly-${{ steps.meta.outputs.date }}
+          build-args: |
+            VERSION=nightly-${{ steps.meta.outputs.date }}-${{ steps.meta.outputs.short_sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  binaries:
+    name: Nightly Binaries
+    needs: check-changes
+    if: needs.check-changes.outputs.has_changes == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # FRONTEND: Remove this block for CLI-only projects
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      # FRONTEND: Remove this block for CLI-only projects
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      # FRONTEND: Remove this block for CLI-only projects
+      - name: Build frontend
+        working-directory: web
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run build
+
+      # FRONTEND: Remove this block for CLI-only projects
+      - name: Embed frontend in Go binary
+        run: |
+          rm -rf internal/dashboard/dist
+          cp -r web/dist internal/dashboard/dist
+
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: '0'
+        run: |
+          DATE=$(date -u +%Y%m%d)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          EXT=""
+          if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
+
+          go build -ldflags "\
+            -s -w \
+            -X {{VERSION_PACKAGE}}.Version=nightly-${DATE}-${SHORT_SHA} \
+            -X {{VERSION_PACKAGE}}.GitCommit=${SHORT_SHA} \
+            -X {{VERSION_PACKAGE}}.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -o "{{BINARY_NAME}}-${GOOS}-${GOARCH}${EXT}" {{BINARY_CMD}}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: |
+            {{BINARY_NAME}}-*
+          retention-days: 7

--- a/project-templates/nightly-node.yml
+++ b/project-templates/nightly-node.yml
@@ -1,0 +1,87 @@
+# Nightly Build — Node.js / Docker Desktop Extension
+#
+# Builds and pushes a nightly Docker image from main.
+# Designed for Docker Desktop extensions and Node.js containerized apps.
+# Does NOT create a GitHub Release or git tag.
+#
+# Prerequisites:
+#   - Dockerfile at repo root
+#   - package.json with build script
+#
+# Template variables (replace before use):
+#   {{DOCKER_IMAGE}} — full GHCR image path (e.g., ghcr.io/owner/repo)
+
+name: Nightly Build
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # Every day at 2 AM UTC
+  workflow_dispatch: # Manual trigger
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  check-changes:
+    name: Check for Changes
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for commits since last nightly
+        id: check
+        run: |
+          # Skip build if no commits in the last 24 hours
+          RECENT=$(git log --since="24 hours ago" --oneline origin/main | head -1)
+          if [ -n "$RECENT" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Changes found since last nightly"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No changes in last 24 hours, skipping build"
+          fi
+
+  build:
+    name: Nightly Docker Image
+    needs: check-changes
+    if: needs.check-changes.outputs.has_changes == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate build metadata
+        id: meta
+        run: |
+          DATE=$(date -u +%Y%m%d)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            {{DOCKER_IMAGE}}:nightly
+            {{DOCKER_IMAGE}}:nightly-${{ steps.meta.outputs.date }}
+          build-args: |
+            VERSION=nightly-${{ steps.meta.outputs.date }}-${{ steps.meta.outputs.short_sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/project-templates/nightly-rust.yml
+++ b/project-templates/nightly-rust.yml
@@ -1,0 +1,103 @@
+# Nightly Build — Rust
+#
+# Cross-compiles nightly binaries from main.
+# Does NOT create a GitHub Release or git tag.
+#
+# Prerequisites:
+#   - Cargo.toml at repo root
+#   - cross (https://github.com/cross-rs/cross) for cross-compilation targets
+#
+# Template variables (replace before use):
+#   {{BINARY_NAME}} — binary name from Cargo.toml (e.g., digital-rain)
+
+name: Nightly Build
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # Every day at 2 AM UTC
+  workflow_dispatch: # Manual trigger
+
+permissions:
+  contents: read
+
+jobs:
+  check-changes:
+    name: Check for Changes
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for commits since last nightly
+        id: check
+        run: |
+          # Skip build if no commits in the last 24 hours
+          RECENT=$(git log --since="24 hours ago" --oneline origin/main | head -1)
+          if [ -n "$RECENT" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Changes found since last nightly"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No changes in last 24 hours, skipping build"
+          fi
+
+  binaries:
+    name: Nightly Binaries
+    needs: check-changes
+    if: needs.check-changes.outputs.has_changes == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross (Linux cross-compilation)
+        if: matrix.os == 'ubuntu-latest' && matrix.target == 'aarch64-unknown-linux-gnu'
+        run: cargo install cross --locked
+
+      - name: Build binary
+        run: |
+          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
+            cross build --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
+        shell: bash
+
+      - name: Package artifact
+        run: |
+          TARGET="${{ matrix.target }}"
+          if [[ "$TARGET" == *"windows"* ]]; then
+            EXT=".exe"
+          else
+            EXT=""
+          fi
+          cp "target/${TARGET}/release/{{BINARY_NAME}}${EXT}" "{{BINARY_NAME}}-${TARGET}${EXT}"
+        shell: bash
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-${{ matrix.target }}
+          path: |
+            {{BINARY_NAME}}-*
+          retention-days: 7

--- a/project-templates/release-gate.yml
+++ b/project-templates/release-gate.yml
@@ -1,0 +1,181 @@
+# Release Gate
+#
+# Evaluates release-please PRs and auto-merges based on release tier.
+# Language-agnostic — only reads release-please manifest and git history.
+#
+# Prerequisites:
+#   - release-please configured (see release-please-config.json template)
+#   - .release-please-manifest.json at repo root
+#
+# Release tiers:
+#   Immediate  — Critical/security fix (fix!:, CVE, breaking change) → auto-merge
+#   Threshold  — Minor+ version bump OR 5+ accumulated fixes → auto-merge
+#   Batched    — Below threshold → labeled, waits for manual merge
+#
+# Customization:
+#   - Fix threshold: change the "5" in FIX_COUNT comparison (line ~67)
+#   - Merge method: change --squash to --merge or --rebase (line ~116)
+
+name: Release Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  evaluate:
+    name: Evaluate Release
+    if: >-
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    runs-on: ubuntu-latest
+    outputs:
+      decision: ${{ steps.gate.outputs.decision }}
+      reason: ${{ steps.gate.outputs.reason }}
+      version_from: ${{ steps.gate.outputs.version_from }}
+      version_to: ${{ steps.gate.outputs.version_to }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Evaluate release criteria
+        id: gate
+        run: |
+          set -euo pipefail
+
+          # Get version info
+          CURRENT=$(git show origin/main:.release-please-manifest.json | jq -r '."."')
+          NEW=$(jq -r '."."' .release-please-manifest.json)
+          echo "version_from=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "version_to=$NEW" >> "$GITHUB_OUTPUT"
+
+          CUR_MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+          CUR_MINOR=$(echo "$CURRENT" | cut -d. -f2)
+          NEW_MAJOR=$(echo "$NEW" | cut -d. -f1)
+          NEW_MINOR=$(echo "$NEW" | cut -d. -f2)
+
+          # Get commits since last release tag
+          LAST_TAG=$(git describe --tags --abbrev=0 origin/main 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ]; then
+            COMMIT_LOG=$(git log "${LAST_TAG}..origin/main" --format="%s" 2>/dev/null || echo "")
+          else
+            COMMIT_LOG=$(git log origin/main --format="%s" 2>/dev/null || echo "")
+          fi
+
+          # Count changelog entries by type
+          FEAT_COUNT=$(echo "$COMMIT_LOG" | grep -c "^feat" || true)
+          FIX_COUNT=$(echo "$COMMIT_LOG" | grep -c "^fix" || true)
+          TOTAL=$((FEAT_COUNT + FIX_COUNT))
+
+          echo "Commits since $LAST_TAG: feat=$FEAT_COUNT fix=$FIX_COUNT total=$TOTAL"
+          echo "Version: $CURRENT -> $NEW"
+
+          # Tier 1: Immediate — critical/security fix
+          HAS_CRITICAL=false
+          if echo "$COMMIT_LOG" | grep -qiE '^fix!:|BREAKING CHANGE'; then
+            HAS_CRITICAL=true
+          fi
+          if echo "$COMMIT_LOG" | grep -qiE 'CVE-|security|vulnerability|critical'; then
+            HAS_CRITICAL=true
+          fi
+
+          if [ "$HAS_CRITICAL" = "true" ]; then
+            echo "decision=immediate" >> "$GITHUB_OUTPUT"
+            echo "reason=Critical or security fix detected" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Tier 2: Threshold — minor/major bump OR 5+ accumulated fixes
+          if [ "$NEW_MAJOR" -gt "$CUR_MAJOR" ]; then
+            echo "decision=threshold" >> "$GITHUB_OUTPUT"
+            echo "reason=Major version bump ($CURRENT -> $NEW)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$NEW_MINOR" -gt "$CUR_MINOR" ]; then
+            echo "decision=threshold" >> "$GITHUB_OUTPUT"
+            echo "reason=Minor version bump with $FEAT_COUNT feature(s) ($CURRENT -> $NEW)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$FIX_COUNT" -ge 5 ]; then
+            echo "decision=threshold" >> "$GITHUB_OUTPUT"
+            echo "reason=$FIX_COUNT bug fixes accumulated ($CURRENT -> $NEW)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Below threshold — stay batched
+          echo "decision=batched" >> "$GITHUB_OUTPUT"
+          echo "reason=Patch only with $TOTAL change(s), below threshold ($CURRENT -> $NEW)" >> "$GITHUB_OUTPUT"
+
+      - name: Label PR with decision
+        run: |
+          DECISION="${{ steps.gate.outputs.decision }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          # Remove old release labels
+          gh pr edit "$PR_NUMBER" --remove-label "release:auto" 2>/dev/null || true
+          gh pr edit "$PR_NUMBER" --remove-label "release:batched" 2>/dev/null || true
+
+          if [ "$DECISION" = "immediate" ] || [ "$DECISION" = "threshold" ]; then
+            gh label create "release:auto" --color "0E8A16" --description "Auto-release approved" --force 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --add-label "release:auto"
+          else
+            gh label create "release:batched" --color "FBCA04" --description "Batched, waiting for threshold" --force 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --add-label "release:batched"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post decision comment
+        run: |
+          DECISION="${{ steps.gate.outputs.decision }}"
+          REASON="${{ steps.gate.outputs.reason }}"
+          FROM="${{ steps.gate.outputs.version_from }}"
+          TO="${{ steps.gate.outputs.version_to }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          if [ "$DECISION" = "immediate" ] || [ "$DECISION" = "threshold" ]; then
+            ICON="+"
+            ACTION="Auto-merge enabled."
+          else
+            ICON="*"
+            ACTION="Waiting for more changes or manual merge."
+          fi
+
+          BODY=$(cat <<EOF
+          ### $ICON Release Gate: \`$DECISION\`
+
+          **Version**: $FROM -> $TO
+          **Reason**: $REASON
+          **Action**: $ACTION
+          EOF
+          )
+
+          # Delete previous bot gate comments to avoid spam
+          gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("Release Gate"))) | .id' \
+            | xargs -I{} gh api -X DELETE "repos/${{ github.repository }}/issues/comments/{}" 2>/dev/null || true
+
+          gh pr comment "$PR_NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  auto-merge:
+    name: Auto-merge Release
+    needs: evaluate
+    if: needs.evaluate.outputs.decision == 'immediate' || needs.evaluate.outputs.decision == 'threshold'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        run: |
+          gh pr merge "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --squash --auto
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add tiered release gate workflow template (Immediate/Threshold/Batched auto-merge for release-please PRs)
- Add nightly build templates: Go+Docker, Node/Docker extension, and Rust variants
- Document the release gating strategy in ADR-0016
- Update new-project scaffolding to include release-gate and nightly templates per stack profile

## Files

| File | Description |
|------|-------------|
| `project-templates/release-gate.yml` | Language-agnostic release gate (3-tier auto-merge) |
| `project-templates/nightly-go.yml` | Go + Docker nightly (with FRONTEND markers) |
| `project-templates/nightly-node.yml` | Node/Docker Desktop extension nightly |
| `project-templates/nightly-rust.yml` | Rust cross-compile nightly |
| `docs/ADR-0016-release-gating.md` | Architecture decision record |
| `claude/skills/devkit-sync/workflows/new-project.md` | Updated scaffolding checklist |

Closes #178

## Test plan

- [x] All 4 YAML templates have valid structure (name/on/jobs)
- [x] Zero hardcoded SubNetree/HerbHall references in templates
- [x] 130 markdown files lint clean (0 errors)
- [ ] CI passes (markdown lint + skill routing validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)