### PR TITLE
feat: add retrigger-ci template and auto-merge gotchas

### DIFF
--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -1,7 +1,7 @@
 ---
 description: Known gotchas and platform-specific issues. Read when debugging unexpected behavior.
 tier: 2
-entry_count: 94
+entry_count: 96
 last_updated: "2026-03-05"
 ---
 
@@ -1387,3 +1387,29 @@ jobs:
 
 **Alternative:** Use `on: release: types: [published]` in a separate workflow (release-please creates GitHub Releases, which DO trigger the `release` event).
 **Anti-pattern:** `on: push: tags: v*` in a separate workflow -- will never fire when tags are created by `GITHUB_TOKEN`.
+
+## 95. Release-Please Branch Updates Don't Always Trigger CI
+
+**Added:** 2026-03-05 | **Source:** Runbooks | **Status:** active
+
+**Platform:** GitHub Actions
+**Issue:** When release-please pushes a new commit to its PR branch, the `pull_request: synchronize` event sometimes doesn't fire. This is a GitHub Actions race condition with workflow-generated commits. The release-please PR ends up with stale or missing status checks, and branch protection blocks the merge.
+**Diagnosis:** Release-please PR shows no CI checks or checks against an old commit SHA, not the current HEAD. `gh pr view N --json statusCheckRollup` shows empty or stale entries.
+**Fix:** Deploy a `retrigger-ci.yml` workflow that triggers on `workflow_run` after Release Please completes. It finds the open release-please PR, checks if CI ran on the current HEAD, and close/reopens the PR to force a re-trigger if missing.
+**Manual workaround:** `gh pr close N && sleep 2 && gh pr reopen N` to force CI re-trigger.
+**Template:** `project-templates/retrigger-ci.yml`
+
+## 96. Auto-Merge Requires Explicit Repo Setting
+
+**Added:** 2026-03-05 | **Source:** Runbooks | **Status:** active
+
+**Platform:** GitHub
+**Issue:** `gh pr merge --auto` fails silently when auto-merge is not enabled on the repository. The release-gate workflow's auto-merge step requires this setting. By default, new GitHub repos have auto-merge disabled.
+**Diagnosis:** Release-gate workflow runs successfully but the PR is not auto-merged. No error in workflow logs -- the `gh pr merge --auto` command exits 0 but the PR stays open.
+**Fix:** Enable auto-merge on the repo before deploying release-gate:
+
+```bash
+gh api repos/OWNER/REPO -X PATCH -f allow_auto_merge=true
+```
+
+**Prevention:** Include this step in the repo setup checklist. The release-gate template header now documents this prerequisite.

--- a/project-templates/release-gate.yml
+++ b/project-templates/release-gate.yml
@@ -6,6 +6,9 @@
 # Prerequisites:
 #   - release-please configured (see release-please-config.json template)
 #   - .release-please-manifest.json at repo root
+#   - Auto-merge enabled on the repo:
+#     gh api repos/OWNER/REPO -X PATCH -f allow_auto_merge=true
+#   - retrigger-ci.yml deployed (see retrigger-ci.yml template)
 #
 # Release tiers:
 #   Immediate  — Critical/security fix (fix!:, CVE, breaking change) → auto-merge

--- a/project-templates/retrigger-ci.yml
+++ b/project-templates/retrigger-ci.yml
@@ -1,0 +1,72 @@
+# Re-trigger CI
+#
+# Fixes a GitHub Actions race condition where release-please branch
+# updates don't always trigger CI (pull_request: synchronize event
+# sometimes doesn't fire on workflow-generated commits).
+#
+# How it works:
+#   1. Triggers after Release Please workflow completes
+#   2. Finds the open release-please PR (if any)
+#   3. Checks if CI checks are present on the current HEAD
+#   4. If missing, closes and reopens the PR to force CI re-trigger
+#
+# Prerequisites:
+#   - release-please configured (see release-please-config.json template)
+#   - Auto-merge enabled on the repo:
+#     gh api repos/OWNER/REPO -X PATCH -f allow_auto_merge=true
+
+name: Re-trigger CI
+
+on:
+  workflow_run:
+    workflows: ["Release Please"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  retrigger:
+    name: Re-trigger Stale Release PR
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Find and re-trigger release PR
+        run: |
+          set -euo pipefail
+
+          # Find open release-please PR
+          PR_NUMBER=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head "release-please--branches--main" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open release-please PR found"
+            exit 0
+          fi
+
+          echo "Found release-please PR #$PR_NUMBER"
+
+          # Check if CI checks exist on current HEAD
+          # Replace "Build" with your CI job name
+          CI_STATUS=$(gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json statusCheckRollup \
+            --jq '[.statusCheckRollup[] | select(.name == "Build")] | length')
+
+          if [ "$CI_STATUS" -gt 0 ]; then
+            echo "CI checks already present, no action needed"
+            exit 0
+          fi
+
+          echo "No CI checks found, re-triggering via close/reopen..."
+          gh pr close "$PR_NUMBER" --repo "${{ github.repository }}"
+          sleep 2
+          gh pr reopen "$PR_NUMBER" --repo "${{ github.repository }}"
+          echo "PR #$PR_NUMBER re-opened, CI should trigger"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Create `retrigger-ci.yml` template for fixing GitHub Actions race condition
- Add KG#92: release-please branch updates don't always trigger CI
- Add KG#93: auto-merge requires explicit repo setting
- Update `release-gate.yml` header with new prerequisites

**Merge order note:** This branch adds KG#92-93 entries that will conflict with #189's KG#92-93. Merge #189 first, then rebase this and renumber to KG#94-95.

Closes #191

## Test plan

- [ ] Verify retrigger-ci.yml template is valid YAML
- [ ] Verify known-gotchas.md passes markdownlint
- [ ] Verify release-gate.yml header lists prerequisites

Generated with [Claude Code](https://claude.com/claude-code)