### PR TITLE
feat: add workflow conformance checks to audit process

### DIFF
--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -1,7 +1,7 @@
 ---
 description: Known gotchas and platform-specific issues. Read when debugging unexpected behavior.
 tier: 2
-entry_count: 93
+entry_count: 94
 last_updated: "2026-03-05"
 ---
 
@@ -1355,3 +1355,35 @@ npx markdownlint-cli2 "**/*.md" "#node_modules" "#*/node_modules" "#.git"
 ```
 
 **Impact:** All projects using the DevKit git init template with markdownlint. The `.git/` directory should always be excluded from linting.
+
+## 94. GITHUB_TOKEN-Created Tags Don't Trigger Push Events
+
+**Added:** 2026-03-05 | **Source:** Runbooks | **Status:** active
+
+**Platform:** GitHub Actions
+**Issue:** When release-please (or any workflow) creates a git tag using `GITHUB_TOKEN`, the resulting `push` event does NOT trigger other workflows. This is a GitHub anti-recursion safeguard to prevent infinite workflow loops. A separate `release.yml` with `on: push: tags: v*` will never fire after release-please creates a tag.
+**Diagnosis:** Tags appear in the repo after release-please merges, but the publish/release workflow never runs. No workflow run appears in the Actions tab for the tag event. Releases are silently skipped.
+**Fix:** Chain the publish/deploy job inside the SAME workflow as release-please, using the `release_created` output:
+
+```yaml
+# Inside release-please.yml
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+
+  publish:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      # Build and publish using needs.release-please.outputs.tag_name
+```
+
+**Alternative:** Use `on: release: types: [published]` in a separate workflow (release-please creates GitHub Releases, which DO trigger the `release` event).
+**Anti-pattern:** `on: push: tags: v*` in a separate workflow -- will never fire when tags are created by `GITHUB_TOKEN`.

--- a/claude/skills/conformance-audit/SKILL.md
+++ b/claude/skills/conformance-audit/SKILL.md
@@ -6,11 +6,11 @@ user_invocable: true
 
 # Conformance Audit
 
-Cross-project conformance auditing against DevKit standards. Run a 13-point checklist across all projects, audit a single project, or auto-fix common gaps.
+Cross-project conformance auditing against DevKit standards. Run a 16-point checklist across all projects, audit a single project, or auto-fix common gaps.
 
 <essential_principles>
 
-**The 13-point checklist is the single source of truth for conformance.** All audit workflows reference `references/checklist.md` for check definitions, pass criteria, and fix references. Do not invent checks outside this list.
+**The 16-point checklist is the single source of truth for conformance.** All audit workflows reference `references/checklist.md` for check definitions, pass criteria, and fix references. Do not invent checks outside this list.
 
 **Stack detection determines which checks apply.** Go projects need `.golangci.yml`, Rust needs clippy in CI, Node needs `eslint.config.js`, etc. Checks that do not apply to the detected stack are reported as "skip", not "fail".
 
@@ -23,7 +23,7 @@ Cross-project conformance auditing against DevKit standards. Run a 13-point chec
 <intake>
 What kind of conformance audit do you need?
 
-1. **Full audit** -- Run 13-point conformance check across all projects
+1. **Full audit** -- Run 16-point conformance check across all projects
 2. **Single project** -- Audit one specific project
 3. **Fix gaps** -- Auto-fix common conformance gaps for a project
 

--- a/claude/skills/conformance-audit/references/checklist.md
+++ b/claude/skills/conformance-audit/references/checklist.md
@@ -1,6 +1,6 @@
 # Conformance Checklist
 
-13-point checklist for DevKit project conformance. Each check includes what to look for, which stacks need it, how to determine pass/fail, and which DevKit template provides the fix.
+16-point checklist for DevKit project conformance. Each check includes what to look for, which stacks need it, how to determine pass/fail, and which DevKit template provides the fix.
 
 ## Stack Detection
 
@@ -130,6 +130,31 @@ A project may match multiple stacks (e.g., Go backend + Node frontend). Apply ch
 - **Pass criteria**: File exists
 - **Fail indicators**: release-please is configured but no release-gate workflow
 - **Fix reference**: `project-templates/release-gate.yml`
+
+### 14. Workflow Trigger Patterns
+
+- **What to check**: No separate workflow uses `on: push: tags: v*` when release-please is configured
+- **Stacks**: Only if release-please is configured (check 8 passes)
+- **Pass criteria**: No workflow file (other than release-please.yml) contains a `tags:` trigger with `v*` pattern
+- **Fail indicators**: A separate `release.yml` or `publish.yml` has `on: push: tags: ['v*']` -- these will never fire because GITHUB_TOKEN-created tags don't trigger push events (see KG#92)
+- **Fix reference**: Move publish/deploy jobs into `release-please.yml` using the `release_created` output, or use `on: release: types: [published]` trigger
+
+### 15. Retrigger CI Workflow
+
+- **What to check**: `.github/workflows/retrigger-ci.yml` (or similar) exists
+- **Stacks**: Only if release-please is configured (check 8 passes)
+- **Pass criteria**: A workflow exists that triggers on `workflow_run` after Release Please and can close/reopen stale PRs
+- **Fail indicators**: release-please is configured but no retrigger workflow exists
+- **Fix reference**: `project-templates/retrigger-ci.yml`
+- **Note**: Without this, release-please PRs may have missing CI checks due to a GitHub Actions race condition (see KG#92 on #191 branch)
+
+### 16. Auto-Merge Enabled
+
+- **What to check**: Repository has auto-merge enabled
+- **Stacks**: Only if release-gate is configured (check 13 passes)
+- **Pass criteria**: `gh api repos/OWNER/REPO --jq '.allow_auto_merge'` returns `true`
+- **Fail indicators**: auto-merge is disabled, causing release-gate's auto-merge step to fail silently
+- **Fix reference**: `gh api repos/OWNER/REPO -X PATCH -f allow_auto_merge=true`
 
 ## Scoring
 

--- a/claude/skills/conformance-audit/workflows/full-audit.md
+++ b/claude/skills/conformance-audit/workflows/full-audit.md
@@ -1,6 +1,6 @@
 # Conformance Audit: Full Audit
 
-Run the 13-point conformance checklist across all projects in the DevSpace workspace.
+Run the 16-point conformance checklist across all projects in the DevSpace workspace.
 
 ## Steps
 
@@ -70,7 +70,7 @@ detect_stack() {
 
 Record the detected stack(s) alongside each project name.
 
-### 4. Run 13-Point Checklist
+### 4. Run 16-Point Checklist
 
 For each project, run every check from `references/checklist.md`. For each check:
 
@@ -121,6 +121,19 @@ ls "$project/.github/workflows/"*nightly* 2>/dev/null | grep -q . || grep -ql 's
 
 # Check 13: Release gate (only if check 8 passes)
 [ -f "$project/.github/workflows/release-gate.yml" ]
+
+# Check 14: Workflow trigger patterns (only if check 8 passes)
+# FAIL if any non-release-please workflow has 'tags: v*' or "tags: ['v*']"
+for wf in "$project/.github/workflows/"*.yml; do
+    [ "$(basename "$wf")" = "release-please.yml" ] && continue
+    grep -q "tags:.*v\*" "$wf" 2>/dev/null && echo "FAIL: $(basename "$wf") has tag trigger"
+done
+
+# Check 15: Retrigger CI (only if check 8 passes)
+ls "$project/.github/workflows/"*retrigger* 2>/dev/null | grep -q .
+
+# Check 16: Auto-merge enabled (only if check 13 passes)
+gh api "repos/$(gh repo view "$project" --json nameWithOwner -q .nameWithOwner 2>/dev/null)" --jq '.allow_auto_merge' 2>/dev/null | grep -q 'true'
 ```
 
 ### 5. Generate Summary Report
@@ -130,11 +143,11 @@ Present results as a table. Use checkmarks and X marks for visual clarity:
 ```text
 ## Conformance Audit Report
 
-| Project | Stack | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | Score |
-|---------|-------|---|---|---|---|---|---|---|---|---|----|----|----|----|-------|
-| SubNetree | go,node | + | + | + | + | + | + | + | + | + | + | + | + | + | 100% |
-| Runbooks | node | + | + | + | + | + | - | + | + | + | + | + | - | - | 77% |
-| DigitalRain | rust | + | - | + | + | + | - | + | + | + | + | + | - | - | 69% |
+| Project | Stack | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | Score |
+|---------|-------|---|---|---|---|---|---|---|---|---|----|----|----|----|----|----|-------|-------|
+| SubNetree | go,node | + | + | + | + | + | + | + | + | + | + | + | + | + | + | + | + | 100% |
+| Runbooks | node | + | + | + | + | + | - | + | + | + | + | + | - | - | + | + | + | 81% |
+| DigitalRain | rust | + | - | + | + | + | - | + | + | + | + | + | - | - | ~ | ~ | ~ | 69% |
 
 Legend: + = pass, - = fail, ~ = skip (not applicable)
 ```


### PR DESCRIPTION
## Summary

Expand conformance checklist from 13 to 16 points:

- **Check 14**: No separate workflow with tag triggers (broken with GITHUB_TOKEN)
- **Check 15**: Retrigger CI workflow exists when release-please is configured
- **Check 16**: Auto-merge enabled on repo when release-gate is configured

Add KG#92: GITHUB_TOKEN-created tags don't trigger push events in other workflows.

**Stacked on:** `feature/conformance-audit-skill`

Closes #192

## Test plan

- [ ] Verify checklist.md passes markdownlint
- [ ] Verify full-audit.md has inspection commands for all 16 checks
- [ ] Verify known-gotchas.md entry is well-formed

Generated with [Claude Code](https://claude.com/claude-code)