### PR TITLE
feat: standardize Copilot auto-review across all projects

### DIFF
--- a/claude/skills/conformance-audit/SKILL.md
+++ b/claude/skills/conformance-audit/SKILL.md
@@ -6,11 +6,11 @@ user_invocable: true
 
 # Conformance Audit
 
-Cross-project conformance auditing against DevKit standards. Run a 16-point checklist across all projects, audit a single project, or auto-fix common gaps.
+Cross-project conformance auditing against DevKit standards. Run a 19-point checklist across all projects, audit a single project, or auto-fix common gaps.
 
 <essential_principles>
 
-**The 16-point checklist is the single source of truth for conformance.** All audit workflows reference `references/checklist.md` for check definitions, pass criteria, and fix references. Do not invent checks outside this list.
+**The 19-point checklist is the single source of truth for conformance.** All audit workflows reference `references/checklist.md` for check definitions, pass criteria, and fix references. Do not invent checks outside this list.
 
 **Stack detection determines which checks apply.** Go projects need `.golangci.yml`, Rust needs clippy in CI, Node needs `eslint.config.js`, etc. Checks that do not apply to the detected stack are reported as "skip", not "fail".
 
@@ -23,7 +23,7 @@ Cross-project conformance auditing against DevKit standards. Run a 16-point chec
 <intake>
 What kind of conformance audit do you need?
 
-1. **Full audit** -- Run 16-point conformance check across all projects
+1. **Full audit** -- Run 19-point conformance check across all projects
 2. **Single project** -- Audit one specific project
 3. **Fix gaps** -- Auto-fix common conformance gaps for a project
 

--- a/claude/skills/conformance-audit/references/checklist.md
+++ b/claude/skills/conformance-audit/references/checklist.md
@@ -1,6 +1,6 @@
 # Conformance Checklist
 
-16-point checklist for DevKit project conformance. Each check includes what to look for, which stacks need it, how to determine pass/fail, and which DevKit template provides the fix.
+19-point checklist for DevKit project conformance. Each check includes what to look for, which stacks need it, how to determine pass/fail, and which DevKit template provides the fix.
 
 ## Stack Detection
 
@@ -155,6 +155,31 @@ A project may match multiple stacks (e.g., Go backend + Node frontend). Apply ch
 - **Pass criteria**: `gh api repos/OWNER/REPO --jq '.allow_auto_merge'` returns `true`
 - **Fail indicators**: auto-merge is disabled, causing release-gate's auto-merge step to fail silently
 - **Fix reference**: `gh api repos/OWNER/REPO -X PATCH -f allow_auto_merge=true`
+
+### 17. Copilot PR Review Ruleset
+
+- **What to check**: A ruleset named "Copilot PR Review" (or similar) exists and is `active`
+- **Stacks**: All
+- **Pass criteria**: `gh api repos/OWNER/REPO/rulesets --jq '.[] | select(.name | test("copilot|Copilot")) | .enforcement'` returns `active`
+- **Fail indicators**: No ruleset with copilot-related name, or ruleset is `disabled`
+- **Fix reference**: `project-templates/copilot-ruleset.json` (create via API, then confirm UI toggle)
+- **Note**: The Copilot auto-review UI toggle must be confirmed manually after API creation (see KG#92 on #193 branch)
+
+### 18. Branch Protection Has No Review Requirement
+
+- **What to check**: Branch protection does not include `required_pull_request_reviews` when a Copilot ruleset exists (check 17 passes)
+- **Stacks**: Only if check 17 passes
+- **Pass criteria**: `gh api repos/OWNER/REPO/branches/main/protection --jq '.required_pull_request_reviews'` returns `null` or 404
+- **Fail indicators**: Branch protection has review requirements alongside the Copilot ruleset, creating a double review gate
+- **Fix reference**: Remove `required_pull_request_reviews` from branch protection, keeping only status checks
+
+### 19. CODEOWNERS
+
+- **What to check**: `CODEOWNERS` or `.github/CODEOWNERS` file exists
+- **Stacks**: All
+- **Pass criteria**: File exists and contains at least one ownership rule
+- **Fail indicators**: No CODEOWNERS file
+- **Fix reference**: `project-templates/CODEOWNERS`
 
 ## Scoring
 

--- a/claude/skills/conformance-audit/workflows/full-audit.md
+++ b/claude/skills/conformance-audit/workflows/full-audit.md
@@ -1,6 +1,6 @@
 # Conformance Audit: Full Audit
 
-Run the 16-point conformance checklist across all projects in the DevSpace workspace.
+Run the 19-point conformance checklist across all projects in the DevSpace workspace.
 
 ## Steps
 
@@ -134,6 +134,18 @@ ls "$project/.github/workflows/"*retrigger* 2>/dev/null | grep -q .
 
 # Check 16: Auto-merge enabled (only if check 13 passes)
 gh api "repos/$(gh repo view "$project" --json nameWithOwner -q .nameWithOwner 2>/dev/null)" --jq '.allow_auto_merge' 2>/dev/null | grep -q 'true'
+
+# Check 17: Copilot PR Review ruleset exists
+REPO_SLUG=$(gh repo view "$project" --json nameWithOwner -q .nameWithOwner 2>/dev/null)
+gh api "repos/$REPO_SLUG/rulesets" --jq '.[] | select(.name | test("copilot|Copilot")) | .enforcement' 2>/dev/null | grep -q 'active'
+
+# Check 18: Branch protection has no review requirement (only if check 17 passes)
+# Returns null or 404 = pass, non-null = fail
+REVIEWS=$(gh api "repos/$REPO_SLUG/branches/main/protection" --jq '.required_pull_request_reviews' 2>/dev/null)
+[ "$REVIEWS" = "null" ] || [ -z "$REVIEWS" ]
+
+# Check 19: CODEOWNERS exists
+[ -f "$project/CODEOWNERS" ] || [ -f "$project/.github/CODEOWNERS" ] || [ -f "$project/docs/CODEOWNERS" ]
 ```
 
 ### 5. Generate Summary Report
@@ -143,11 +155,11 @@ Present results as a table. Use checkmarks and X marks for visual clarity:
 ```text
 ## Conformance Audit Report
 
-| Project | Stack | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | Score |
-|---------|-------|---|---|---|---|---|---|---|---|---|----|----|----|----|----|----|-------|-------|
-| SubNetree | go,node | + | + | + | + | + | + | + | + | + | + | + | + | + | + | + | + | 100% |
-| Runbooks | node | + | + | + | + | + | - | + | + | + | + | + | - | - | + | + | + | 81% |
-| DigitalRain | rust | + | - | + | + | + | - | + | + | + | + | + | - | - | ~ | ~ | ~ | 69% |
+| Project | Stack | 1-7 | 8 | 9-11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | Score |
+|---------|-------|-----|---|------|----|----|----|----|----|----|----|----|-------|
+| SubNetree | go,node | 7/7 | + | 3/3 | + | + | + | + | + | + | + | + | 100% |
+| Runbooks | node | 6/7 | + | 3/3 | - | + | + | + | + | + | + | + | 89% |
+| DigitalRain | rust | 5/7 | + | 3/3 | - | - | ~ | ~ | ~ | - | ~ | - | 63% |
 
 Legend: + = pass, - = fail, ~ = skip (not applicable)
 ```

--- a/project-templates/copilot-ruleset.json
+++ b/project-templates/copilot-ruleset.json
@@ -1,0 +1,39 @@
+{
+  "name": "Copilot PR Review",
+  "enforcement": "active",
+  "target": "branch",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["squash"]
+      }
+    },
+    {
+      "type": "copilot_code_review",
+      "parameters": {
+        "review_on_push": true,
+        "review_draft_pull_requests": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Expand conformance checklist from 16 to 19 points:

- **Check 17**: Copilot PR Review ruleset exists and is active
- **Check 18**: Branch protection has no review requirement (avoids double gate)
- **Check 19**: CODEOWNERS file exists

Add `copilot-ruleset.json` template with admin bypass, squash-only, and Copilot review-on-push.

**Stacked on:** `feat/issue-192-workflow-conformance` -> `feature/conformance-audit-skill`

Closes #194

## Test plan

- [ ] Verify checklist.md passes markdownlint
- [ ] Verify copilot-ruleset.json is valid JSON
- [ ] Verify full-audit.md has inspection commands for checks 17-19

Generated with [Claude Code](https://claude.com/claude-code)