### PR TITLE
fix: remove trailing blank line from README (MD012)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,4 +281,3 @@ Claude.ai Chat uses a separate skill store - install via Settings > Skills in th
 ## License
 
 MIT
-


### PR DESCRIPTION
## Summary

- Remove extra blank line at end of README.md that causes MD012 lint failure

## Test plan

- [ ] CI markdown lint passes

Generated with [Claude Code](https://claude.com/claude-code)