### PR TITLE
chore: backfill lifecycle metadata on 166 rule entries

### DIFF
--- a/claude/rules/autolearn-patterns.md
+++ b/claude/rules/autolearn-patterns.md
@@ -24,6 +24,8 @@ RoleCredentialStore = "credential_store" //nolint:gosec // G101: role name, not 
 
 ## 2. gocritic rangeValCopy for Large Structs
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** lint-fix
 **Context:** `for _, v := range slice` copies the struct on each iteration. Structs over 64 bytes trigger gocritic rangeValCopy.
 **Fix:** Use index-based iteration: `for i := range slice { ... slice[i].Field ... }`
@@ -31,11 +33,15 @@ RoleCredentialStore = "credential_store" //nolint:gosec // G101: role name, not 
 
 ## 3. golangci-lint install-mode for CI
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** ci-config
 **Context:** Pre-built golangci-lint binaries (`install-mode: binary`) may be compiled with an older Go version than the project requires.
 **Fix:** Use `install-mode: goinstall` in the golangci-lint GitHub Action to build from source with the project's Go version.
 
 ## 4. go-licenses Blocked License Check
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** ci-config
 **Context:** `go-licenses check --allowed_licenses` strict allowlist fails on packages with non-standard license file locations or unrecognized licenses (BSL 1.1).
@@ -67,6 +73,8 @@ claims, err := h.tokens.ValidateAccessToken(token)
 
 ## 6. GoReleaser Release Workflow Prerequisites
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** ci-config
 **Context:** GoReleaser v2 with Docker and SBOM support requires explicit setup steps in GitHub Actions that are NOT included automatically.
 **Fix:** Add these steps before `goreleaser/goreleaser-action`:
@@ -79,11 +87,15 @@ claims, err := h.tokens.ValidateAccessToken(token)
 
 ## 8. Dockerfile ldflags Must Match Go Variable Names
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** ci-config
 **Context:** Dockerfile ARG names for version injection via `-ldflags -X` must exactly match the Go `var` names in `internal/version/version.go`. Mismatch causes version info to show "unknown".
 **Fix:** Cross-reference Dockerfile ldflags with version.go. Common mismatch: `version.Commit` vs `version.GitCommit`, `version.BuildTime` vs `version.BuildDate`.
 
 ## 9. React Flow Test Mocking Pattern
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** testing
 **Context:** `@xyflow/react` components require DOM measurements and `ReactFlowProvider`. Unit tests fail without comprehensive mocking.
@@ -91,11 +103,15 @@ claims, err := h.tokens.ValidateAccessToken(token)
 
 ## 10. Slash Command / Skill Overlap Prevention
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** tooling
 **Context:** Creating a slash command (`commands/foo.md`) that overlaps with an existing skill (`skills/foo/SKILL.md`) causes duplicate entries in the skill list and user confusion.
 **Fix:** Always check existing skills before creating a new command. If a skill already handles the use case, don't create a redundant command. Skills are the preferred format for complex functionality; commands are for simple one-shot prompts.
 
 ## 11. Python as jq Replacement on Windows MSYS
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** platform-workaround
 **Context:** `jq` is not available on Windows MSYS by default. Bash scripts needing JSON escaping/parsing fail. Python's `json` + `urllib.request` modules provide equivalent functionality and are more commonly available.
@@ -116,17 +132,23 @@ print(json.loads(resp.read()).get('response', ''))
 
 ## 12. Astro Image Optimization: src/assets vs public/
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** framework-pattern
 **Context:** Astro's `<Image />` component from `astro:assets` only optimizes images imported from `src/assets/`. Images in `public/` are served as-is without optimization.
 **Fix:** Place images in `src/assets/` and import them: `import img from '../assets/photo.jpg'`. Pass to `<Image src={img} />` with width/height. Astro converts to WebP at build time with dramatic size reduction (67KB JPEG -> 3KB WebP, 53KB PNG -> 1KB WebP).
 
 ## 13. Astro Static on Cloudflare Pages (No Adapter)
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** framework-pattern
 **Context:** Astro v5 with `output: 'static'` produces plain HTML/CSS/JS in `dist/`. Cloudflare Pages serves static files natively.
 **Fix:** No Cloudflare adapter needed for static-only Astro sites. Set Cloudflare Pages build command: `npm run build`, output: `dist`. Only add `@astrojs/cloudflare` adapter if using SSR/server routes.
 
 ## 14. gocritic builtinShadow for Go Builtins
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** lint-fix
 **Context:** Go has predeclared identifiers (builtins) that trigger gocritic `builtinShadow` when used as parameter or variable names. This includes Go 1.0 builtins (`new`, `make`, `len`, `cap`, `close`, `delete`, `copy`, `append`, `panic`, `recover`, `print`, `println`, `error`, `complex`, `real`, `imag`) and Go 1.21+ additions (`min`, `max`, `clear`). Common in diff functions (`ComputeDiff(old, new string)`), functional options (`WithMaxTokens(max int)`), and factory patterns.
@@ -147,6 +169,8 @@ func WithMaxTokens(n int) CallOption { ... }
 
 ## 15. gocritic httpNoBody for GET/HEAD Requests
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** lint-fix
 **Context:** `http.NewRequestWithContext(ctx, http.MethodGet, url, nil)` triggers gocritic `httpNoBody` lint. The `nil` body is ambiguous -- the linter wants explicit intent.
 **Fix:** Use `http.NoBody` instead of `nil` for requests that have no body (GET, HEAD, DELETE without body).
@@ -161,6 +185,8 @@ req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 ```
 
 ## 16. Remove Heavy Dependencies for Unfixable Vulnerabilities
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** architecture-pattern
 **Context:** When a Go dependency has a vulnerability with no fix available (e.g., server-side code in a client library), `govulncheck` and CI will flag it forever. If the API surface is small, rewriting with `net/http` is faster than waiting for an upstream fix.
@@ -183,11 +209,15 @@ This eliminates the entire type definition block from the swagger spec. Also pin
 
 ## 18. Documentation Drift Audit After PR Bursts
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** process-pattern
 **Context:** After merging many PRs in a burst (e.g., release prep, multi-PR features), roadmap checklists, README claims, and architecture docs drift from reality. Aspirational language implies features exist that haven't shipped yet.
 **Fix:** After a burst of merges, audit: 1) List all merged PRs since last doc update, 2) Cross-reference with roadmap checklist items, 3) Check README claims against actual capabilities, 4) Fix aspirational language for unimplemented features. Found 8 unchecked items that were done, false claims in README for unimplemented features, and missing modules in architecture docs.
 
 ## 19. golangci-lint nilerr: Must Propagate Non-Nil Errors
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** lint-fix
 **Context:** When a function receives a non-nil error and returns `(result, nil)` -- encoding the error into the result struct instead of propagating it -- golangci-lint `nilerr` flags the return. Common in check/probe patterns where you want to return a "failure result" rather than an error.
@@ -212,6 +242,8 @@ if result == nil { return }
 
 ## 20. staticcheck SA4023: Concrete Type Assigned to Interface Is Never Nil
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** lint-fix
 **Context:** Assigning a concrete (non-nil) pointer to an interface variable, then checking `if iface == nil` is always false. The interface wraps a non-nil type pointer, making the nil check dead code.
 **Fix:** Remove the nil check, or check the concrete type before assignment.
@@ -228,17 +260,23 @@ checker := NewICMPChecker(5*time.Second, 3)
 
 ## 21. Don't Start() Modules in Tests That Only Query the Store
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** testing
 **Context:** Tests for module methods that only query the store (e.g., `Status()`, `GetXxx()`) don't need `Start()`. Calling `Start()` launches background goroutines (scheduler, maintenance, checker workers) that race with the test by executing real checks, creating failure results/alerts, and corrupting expected state. This caused a flaky `TestHandleDeviceStatus_WithData` in the Pulse module.
 **Fix:** Only call `Start()`/`Stop()` when testing behavior that depends on background workers. For query-only methods, `newTestModule(t)` provides a fully functional store without races.
 
 ## 22. Git Stash Before Branch Switch During Parallel Feature Work
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow
 **Context:** When using subagents to work on parallel feature branches, uncommitted working tree changes carry across `git checkout`. A subagent modifying `devices/index.tsx` for issue #89 leaked those changes into the #87 branch, causing CI failures (`Cannot find module '@/hooks/use-keyboard-shortcuts'`).
 **Fix:** Always `git stash` (or commit) before switching branches when multiple features are in progress. Especially critical when subagents modify shared files across branches.
 
 ## 23. Go Slice Assignment Creates Alias, Not Copy
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** correction
 **Context:** In Go, `oldSlice := someStruct.slice` creates a new slice header pointing to the SAME backing array. If the original is zeroed (e.g., `ZeroBytes(someStruct.slice)`), the "copy" sees zeroed data. Discovered in `KeyManager.RotateKEK` -- a rewrap closure holding `oldKEK` failed with "cipher: message authentication failed" because `ZeroBytes(km.kek)` zeroed the shared backing array.
@@ -257,11 +295,15 @@ ZeroBytes(km.kek) // oldKEK is unaffected
 
 ## 24. Name Parameters You Might Reference Later
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** correction
 **Context:** Writing `func handler(w http.ResponseWriter, _ *http.Request)` with blank identifier for an unused parameter, then later adding `r.Context()` in the body, causes an "undefined: r" compile error. Common when expanding stub handlers into full implementations across PRs.
 **Fix:** Always name parameters in handler signatures, even if currently unused. Use `r` not `_` for `*http.Request`. If truly unused, the compiler won't complain about a named-but-unused parameter (unlike variables).
 
 ## 25. Consumer-Side Adapter for Cross-Internal Imports
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** architecture-pattern
 **Context:** A plugin in `internal/X` needs functionality from `internal/Y` (e.g., Gateway needs auth.TokenService). Direct import creates coupling between internal packages. Go doesn't allow import cycles, and even one-way coupling makes packages harder to test and reason about.
@@ -280,6 +322,8 @@ func (a *tokenAdapter) ValidateAccessToken(t string) (*gateway.TokenClaims, erro
 
 ## 26. WebSocket Plugin Routes Need SimpleRouteRegistrar
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** architecture-pattern
 **Context:** Plugin `Routes()` mounts under `/api/v1/{plugin}/` with auth middleware. WebSocket endpoints need JWT via query parameter (browser WS API can't send headers) and the auth middleware already skips `/api/v1/ws/`. So WebSocket endpoints can't go through the standard plugin route system.
 **Fix:** Create a separate struct implementing `server.SimpleRouteRegistrar` with `RegisterRoutes(mux *http.ServeMux)`. Pass it as an extra registrar to `server.New()`. Wire the plugin module reference into the registrar in `main.go`. Register the WebSocket route under `/api/v1/ws/{plugin}/...`.
@@ -291,6 +335,8 @@ func (a *tokenAdapter) ValidateAccessToken(t string) (*gateway.TokenClaims, erro
 Archived to `claude/rules/archive/autolearn-patterns.md`. See KG#17 for the consolidated entry.
 
 ## 28. Go 1.22+ ServeMux Ambiguous Route Pattern Panic
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** gotcha
 **Context:** Go 1.22+ enhanced `ServeMux` detects structurally ambiguous route patterns at registration time and panics. Two patterns conflict when they can both match the same path and neither is more specific. Example: `GET /credentials/{id}/data` and `GET /credentials/device/{device_id}` both match `/credentials/device/data`.
@@ -305,12 +351,16 @@ Archived to `claude/rules/archive/autolearn-patterns.md`. See KG#17 for the cons
 
 ## 31. ESLint Catches Unused Imports That TypeScript Misses
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** ci-fix
 **Context:** `npx tsc --noEmit` passes locally but CI fails because ESLint's `@typescript-eslint/no-unused-vars` catches unused named imports (e.g., `type ThemeDefinition` imported but not referenced, or `CardHeader`/`CardTitle` imported but not used in JSX). TypeScript itself doesn't flag unused imports unless `noUnusedLocals` is enabled in tsconfig.
 **Fix:** After creating new files or modifying imports, run `pnpm run lint` (or `npx eslint .`) locally before pushing. When adding imports speculatively (e.g., for components you plan to use), verify every named import is actually referenced in the file.
 **Common culprits:** Type-only imports (`type Foo`) copied from other files, UI component imports (`CardHeader`, `CardTitle`) from template code that were trimmed during implementation.
 
 ## 32. gosimple S1016: Use Type Conversion for Identical Structs
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** lint-fix
 **Context:** When two Go structs have identical fields (e.g., `ActiveThemeRequest{ThemeID string}` and `ActiveThemeResponse{ThemeID string}`), constructing the target with a struct literal (`ActiveThemeResponse{ThemeID: req.ThemeID}`) triggers gosimple S1016.
@@ -326,6 +376,8 @@ writeJSON(w, http.StatusOK, ActiveThemeResponse(req))
 
 ## 33. Always Search GitHub Before Claiming "No Competitors"
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** research-methodology
 **Context:** Market research that only analyzes community pain points (Reddit, forums) can miss established competitors on GitHub. Our HomeLab research concluded "zero automated infrastructure discovery tools exist" while Scanopy had 3,000+ stars. The project was also renamed (NetVisor -> Scanopy), creating a search blind spot.
 **Fix:** Before claiming "no competitors" or "first-mover advantage":
@@ -339,6 +391,8 @@ writeJSON(w, http.StatusOK, ActiveThemeResponse(req))
 **Prevention:** Search by function ("network topology visualization"), not just by known product names. Project renames (trademark conflicts) make name-based searches unreliable.
 
 ## 34. Deep Competitive Analysis via gh CLI
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** research-pattern
 **Context:** Comprehensive competitor analysis is achievable entirely through `gh` CLI without needing to clone repos or manually browse GitHub.
@@ -382,11 +436,15 @@ writeJSON(w, http.StatusOK, ActiveThemeResponse(req))
 
 ## 36. Dependabot PR CI Fix Merge Ordering
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** process-pattern
 **Context:** When a Dependabot PR fails CI due to a workflow bug (not the dependency itself), you cannot fix CI directly on the Dependabot branch. Dependabot manages those branches and may overwrite your commits.
 **Fix:** Fix the CI on a separate branch, merge to main first, then rebase the Dependabot PR with `gh pr update-branch <number>`. This re-triggers CI with the fix included. Never push directly to a Dependabot branch.
 
 ## 37. git rebase --onto for Precise Stacked PR Cleanup
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** workflow
 **Context:** After squash-merging a base PR, downstream stacked branches contain the original pre-squash commits (different hashes from the squash commit on main). `git rebase origin/main` requires manual `--skip` for each duplicate commit. `git rebase --onto` is more precise.
@@ -407,6 +465,8 @@ git push --force-with-lease
 
 ## 38. Gitignored Generated Files Break CI Compilation
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** ci-fix
 **Context:** Generated files (e.g., `*.pb.go` from protobuf) that are listed in `.gitignore` won't exist in CI. If CI doesn't regenerate them (no `make proto` step, no protoc installed), any package importing the generated code fails with "no required module provides package". This manifests as a vulnerability check or build failure, not a missing-file error.
 **Fix:** Either commit generated files to git (remove from `.gitignore`) or add a CI step to regenerate them. Committing is simpler when the generation tool (protoc) requires external installation. Add a comment in `.gitignore` to explain:
@@ -418,6 +478,8 @@ git push --force-with-lease
 **Prevention:** When adding code generation to a project, decide upfront: commit artifacts or regenerate in CI. Don't gitignore files that CI needs to compile.
 
 ## 40. Go-Side Time-Bucket Aggregation Over SQL
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** architecture-pattern
 **Context:** Time-series metric aggregation needs adaptive downsampling (1min/5min/1hour buckets based on query range). SQLite's `strftime` fails on RFC3339Nano timestamps (returns NULL), making SQL-side bucketing unreliable. Even databases with robust time functions add complexity for adaptive bucket sizes.
@@ -445,6 +507,8 @@ func aggregatePoints(points []MetricDataPoint, interval time.Duration) []MetricD
 
 ## 41. Subagent Recovery After Rate Limit or Session Break
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow
 **Context:** When a background subagent completes but the main context hits a rate limit or session break, the orchestrator loses track of what was done. Resuming blindly risks re-doing completed work or skipping verification steps.
 **Fix:** On resume, check what the subagent actually accomplished before continuing:
@@ -458,6 +522,8 @@ func aggregatePoints(points []MetricDataPoint, interval time.Duration) []MetricD
 **Key insight:** The subagent's work persists in the working tree even if the main context was interrupted. Don't re-launch the subagent -- just verify and commit its output.
 
 ## 42. Gap Exploitation Report Structure for Competitive Research
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** research-methodology
 **Context:** When analyzing a competitor's weaknesses for strategic positioning, structure the report to connect user pain directly to your competitive advantages.
@@ -474,6 +540,8 @@ func aggregatePoints(points []MetricDataPoint, interval time.Duration) []MetricD
 **Key insight:** Every weakness claim must link to evidence (issue #, comment count, user quote). Unsubstantiated claims like "their UX is bad" are worthless; "Issue #477 (10 comments) shows multi-NIC hosts appear as duplicates" is actionable.
 
 ## 43. Viper Nested Mapstructure Keys Must Match Struct Hierarchy
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** correction
 **Context:** When a Go config struct uses nested sub-structs with `mapstructure` tags (e.g., `ModuleConfig{Provider string; Ollama OllamaConfig}`), `viper.Set()` calls in tests must use the full dotted path matching the struct hierarchy. Tests using flat keys break silently when the config struct is refactored from flat to nested form.
@@ -495,6 +563,8 @@ v.Set("ollama.timeout", "30s")
 
 ## 44. React Nullable Local Override for Server State Sync
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** pattern
 **Context:** React's `react-hooks/set-state-in-effect` lint rule flags `useEffect(() => setState(serverData), [serverData])`. This common pattern for syncing TanStack Query data to form state gets rejected by the React compiler linter.
 **Fix:** Use a nullable local override instead of useEffect sync. The override is `null` when the user hasn't edited yet, falls back to server data:
@@ -515,6 +585,8 @@ onSuccess: () => { setLocalOverride(null); queryClient.invalidateQueries(['confi
 
 ## 45. Blog Aggregation for Blocked Community Platforms
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** research-methodology
 **Context:** Reddit blocks WebFetch (robots.txt), Discord requires auth, and direct community access is often restricted. Blog aggregation provides equivalent community sentiment data.
 **Approach:**
@@ -528,6 +600,8 @@ onSuccess: () => { setLocalOverride(null); queryClient.invalidateQueries(['confi
 **Key insight:** Blog articles that synthesize "what Reddit recommends" are often more reliable than reading threads directly -- the authors have already filtered noise and identified patterns. The gh api JSON endpoint works for primary source verification of specific threads.
 
 ## 46. Curated List Ecosystem Mapping for Market Positioning
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** research-methodology
 **Context:** Curated "awesome" GitHub lists (awesome-selfhosted 273k stars, awesome-sysadmin) are primary discovery channels for self-hosted software. Analyzing their category structure reveals market taxonomy gaps and listing opportunities.
@@ -548,6 +622,8 @@ onSuccess: () => { setLocalOverride(null); queryClient.invalidateQueries(['confi
 
 ## 47. Check Existing Assets Before Scoping "Create X" Issues
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** pattern
 **Context:** Issues titled "Create X" or "Design X" may already have partial or complete deliverables in the codebase. Planning without checking leads to overscoped work and wasted agent context.
 **Fix:** Before planning implementation, always run targeted searches:
@@ -564,6 +640,8 @@ grep -r "<keyword>" --include="*.svg" --include="*.png" --include="*.md" .
 
 ## 48. Parallel Agents Self-Recover from Shared Working Tree
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow-pattern
 **Context:** When parallel background agents share the same git working directory (known gotcha #25), agents can autonomously detect and recover from file/branch interference without main context intervention. Previously required main context to sort files after agents completed.
 **Pattern:** Agents detect leaked files from other agents via `git status` or unexpected file contents, then clean up with `git checkout -- <leaked files>`. Agents on the wrong branch detect it and recover with `git stash && git checkout <correct-branch> && git stash pop`.
@@ -571,6 +649,8 @@ grep -r "<keyword>" --include="*.svg" --include="*.png" --include="*.md" .
 **Example:** v0.6.0 Wave 2: Agent D found Agent E's `internal/insight/*` files and ran `git checkout -- internal/insight/handlers.go internal/insight/store.go`. Agent E found itself on D's branch and ran `git stash && git checkout feature/issue-282-analytics-dashboard && git stash pop`. Both completed successfully.
 
 ## 50. VS Code Auto-Open File on Workspace Start
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** tooling
 **Context:** Want a specific file (like DASHBOARD.md) to open automatically when VS Code loads a workspace, without requiring an extension.
@@ -594,6 +674,8 @@ grep -r "<keyword>" --include="*.svg" --include="*.png" --include="*.md" .
 
 ## 51. Two-Tier Session Startup: Static File + Interactive Hook
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow-pattern
 **Context:** Want a fully automated session startup experience where both the IDE and Claude Code are oriented on project state. Neither VS Code nor Claude Code can do it alone -- VS Code can auto-open files but not run Claude, Claude can auto-run skills but only after user input.
 **Fix:** Combine two independent mechanisms:
@@ -604,6 +686,8 @@ grep -r "<keyword>" --include="*.svg" --include="*.png" --include="*.md" .
 The static file orients the human while waiting; the interactive skill provides live routing once the user types anything. Together they create a seamless "open IDE and go" experience.
 
 ## 52. Main.go Split for Parallel Agent Branches
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** workflow-pattern
 **Context:** When 2+ parallel agents both modify `cmd/subnetree/main.go` (adding imports, module registration, startup code), the changes land in the same working tree. Each branch needs only its own changes to main.go.
@@ -623,12 +707,16 @@ The static file orients the human while waiting; the interactive skill provides 
 
 ## 53. Dependency PR Merge Ordering in Parallel Waves
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow-pattern
 **Context:** When parallel PRs exist and one adds a new `go.mod` dependency while the other uses only stdlib, merging order matters for avoiding go.mod/go.sum conflicts.
 **Fix:** Merge the PR with the new dependency FIRST, then rebase the stdlib-only PR onto updated main. The rebase will be clean because go.mod/go.sum changes don't overlap.
 **Example:** v0.5.0: MQTT (#298, adds `paho.mqtt.golang`) merged before Tier (#303, stdlib only). Tier rebased with zero conflicts.
 
 ## 57. JSX Short-Circuit with `unknown` Type Is Not ReactNode
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** typescript-fix
 **Context:** `{expanded && entry.details && (<div>...</div>)}` in JSX evaluates to `entry.details` (typed as `unknown`) when truthy. TypeScript error: `Type 'unknown' is not assignable to type 'ReactNode'`. The `&&` operator returns the last truthy operand's value, not `true`.
@@ -643,6 +731,8 @@ The static file orients the human while waiting; the interactive skill provides 
 ```
 
 ## 59. gocritic commentedOutCode on Math-Like Comments
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** lint-fix
 **Context:** gocritic's `commentedOutCode` checker flags comments containing expressions that look like code -- especially math with parentheses and operators. Test comments explaining expected confidence scores like `// OUI(15) + Port(15) + BRIDGE-MIB(35) = 65` trigger it because they look like function calls and arithmetic.
@@ -661,12 +751,16 @@ The static file orients the human while waiting; the interactive skill provides 
 
 ## 60. Sequential Agents for Dependent Issues in Same Module
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow-pattern
 **Context:** When two issues modify the same files and one depends on the other's types/functions (e.g., #359 composite classifier defines `DeviceSignals` used by #360 unmanaged switch detection), parallel agents fail because the second can't compile without the first's code.
 **Fix:** Run sequentially: implement #1, commit/push/merge, rebase #2's branch onto updated main, then implement #2. If time is critical, rebase #2's branch onto #1's branch (not main) so the code is available, then rebase onto main after #1 merges. Use `git rebase --skip` when the squash-merged commit conflicts with the pre-merge version.
 **Proven:** v0.6.0 Wave 3: #359 merged as PR #372, #360 rebased onto main (skip squash conflict), implemented, merged as PR #373.
 
 ## 61. gocritic unnamedResult: Named Returns Require = Not :=
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** lint-fix
 **Context:** gocritic `unnamedResult` flags functions returning `(float64, string)` without named returns. When fixing by adding names like `(score float64, detail string)`, the variables are now pre-declared. Any internal `score := ...` or `detail := ...` becomes a redeclaration error: "no new variables on left side of :=". Similarly, `var score float64` before a switch statement is redundant.
@@ -692,6 +786,8 @@ func compute(data []float64) (score float64, detail string) {
 
 ## 62. gocritic appendCombine: Merge Consecutive Appends
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** lint-fix
 **Context:** Two consecutive `append()` calls to the same slice with no intervening logic (only comments) triggers gocritic `appendCombine`. Common when building a slice of factors/items one at a time.
 **Fix:** Combine into a single `append` with multiple elements.
@@ -708,6 +804,8 @@ factors = append(factors, HealthScoreFactor{Name: "rtt", ...},
 ```
 
 ## 63. Recharts Custom Tooltip Needs Partial Props
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** frontend-pattern
 **Context:** When passing a custom React tooltip component as JSX to recharts `<Tooltip content={<CustomTooltip />} />`, the component initially receives empty props `{}` before recharts injects `active`, `payload`, etc. Using `TooltipContentProps` directly causes TypeScript error: "Type '{}' is missing required properties". This extends gotcha #28.
@@ -726,6 +824,8 @@ function CustomTooltip({ active, payload }: Partial<TooltipContentProps<number, 
 ```
 
 ## 64. gocritic paramTypeCombine: Consecutive Same-Type Params
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** lint-fix
 **Context:** When consecutive function parameters have the same type, gocritic `paramTypeCombine` requires them to be combined into a single declaration. Common in utility functions with multiple int/string params.
@@ -746,6 +846,8 @@ func RunTraceroute(target string, maxHops, hopTimeoutMs int) {}
 
 ## 65. gocritic dupBranchBody: Identical If/Else Branches
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** lint-fix
 **Context:** When both branches of an `if/else` have identical bodies, gocritic `dupBranchBody` flags it. Often happens when copy-pasting conditional logic and forgetting to differentiate branches.
 **Fix:** Remove the conditional entirely and keep just the body, or fix the logic to actually differ.
@@ -765,6 +867,8 @@ proto := 1
 
 ## 66. gocritic emptyStringTest: Prefer != "" Over len() > 0
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** lint-fix
 **Context:** `len(s) > 0` for string emptiness checks triggers gocritic `emptyStringTest`. The idiomatic Go way is to compare directly with empty string.
 **Fix:** Replace `len(s) > 0` with `s != ""` and `len(s) == 0` with `s == ""`.
@@ -780,6 +884,8 @@ if hostname != "" { ... }
 
 ## 67. Agent Autonomous Commit Disrupts Parallel Agent Work
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow-pattern
 **Context:** When a background agent is given autonomy to commit, push, and create a PR (rather than just writing files), it runs `git checkout <branch>` which changes HEAD. This discards other parallel agents' unstaged changes to **tracked** files. Untracked files (new directories/files) survive because `git checkout` only restores tracked files.
 **Scenario:** Sprint 2 Wave 1: Agent H committed on `feature/issue-399-snmp-fdb-walks` and pushed. Agent B had unstaged changes to `main.go` (tracked) and new `internal/seed/` directory (untracked). After H's commit, `main.go` changes were lost; `internal/seed/` survived.
@@ -791,6 +897,8 @@ if hostname != "" { ... }
 **Proven:** Sprint 2 used approach 2. Agent H created PR #403 autonomously. Agent B's `main.go` changes were manually re-applied from its completion summary (~3 edits).
 
 ## 68. E2E Tests: Assert Core Structure, Not Specific Widget Names
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** testing-pattern
 **Context:** E2E tests for data-driven pages (dashboards, analytics) that assert specific widget names ("Scout Agents", "Active Alerts") or exact data values fail when the UI changes widget labels or when seed data differs. These tests are brittle and require constant maintenance.
@@ -820,6 +928,8 @@ await expect(page.getByRole('button', { name: /scan network/i })).toBeVisible()
 
 ## 69. GitHub API as CLI Template Fallback
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** tooling-workaround
 **Context:** CLI tools that scaffold/init projects sometimes fail on Windows MSYS (interactive prompts hanging, Unicode crashes, Python Rich library issues). Rather than debugging the CLI, fetch templates directly from the GitHub repo.
 **Fix:** Use `gh api` to fetch file contents from the repo:
@@ -840,6 +950,8 @@ gh api repos/github/spec-kit/contents/templates/commands/specify.md \
 
 ## 70. SDD Tool Abstraction Level Check Before Integration
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** research-methodology
 **Context:** When evaluating whether two SDD (spec-driven development) tools can integrate, the first check should be abstraction level compatibility. BMAD PRD operates at product-level (entire product requirements). Spec Kit `/speckit.specify` operates at feature-level (one feature per spec). Direct piping between different levels fails.
 **Fix:** Before attempting tool integration, map each tool's primary abstraction level:
@@ -854,6 +966,8 @@ If tools are at different levels, identify a **bridge artifact** (e.g., Spec Kit
 **Proven:** B3 integration test -- BMAD PRD cannot pipe into Spec Kit specify; constitution seeding is the viable bridge.
 
 ## 71. Scope CI Lint to Maintained Files on First Introduction
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** ci-config
 **Context:** Adding CI linting (markdownlint, eslint) to a repo with many pre-existing files produces hundreds of violations (930 errors across 69 files in devkit). Making CI fail on all files means CI is permanently red until a massive cleanup PR is done.
@@ -877,6 +991,8 @@ globs: |
 
 ## 72. Three-Layer Project Initialization Chain
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow-pattern
 **Context:** Ensuring every new project gets a proper CLAUDE.md requires multiple safety nets because no single mechanism covers all cases.
 **Pattern:** Three complementary layers:
@@ -888,6 +1004,8 @@ globs: |
 Each layer catches what the previous missed. Layer 1 is passive, layer 2 is active, layer 3 is interactive.
 
 ## 73. Three-Stream Redirect for VS Code CLI in PowerShell Scripts
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** platform-workaround
 **Context:** Running `& code --list-extensions` or `& code --install-extension` in a PowerShell script opens `code-stdin-*` editor tabs. Redirecting only stdout and stderr (`-RedirectStandardOutput`, `-RedirectStandardError`) is NOT sufficient -- VS Code still reads from the inherited parent stdin handle and creates the tab.
@@ -912,6 +1030,8 @@ $tmpIn, $tmpOut, $tmpErr | Remove-Item -Force -ErrorAction SilentlyContinue
 
 ## 74. Iterative Bootstrap Debugging on New Machines
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow-pattern
 **Context:** First-time bootstrap runs on a new machine surface cascading issues that can't all be caught in advance: parameter binding edge cases, false negatives from system queries, stale PATH, tools running via unexpected paths. Each phase may expose issues that are invisible until prior phases complete.
 **Pattern:** Run bootstrap end-to-end, capture full output, fix all failures in a single pass:
@@ -924,6 +1044,8 @@ $tmpIn, $tmpOut, $tmpErr | Remove-Item -Force -ErrorAction SilentlyContinue
 **Key insight:** Don't fix one issue and re-run — read the full output first. Multiple failures may share a root cause (e.g., PATH staleness affects 5+ tool checks). Fixing them individually wastes cycles.
 
 ## 75. Start-Job Timeout for Commands That Might Hang
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** platform-workaround
 **Context:** Some commands hang indefinitely on Windows -- notably Windows Store Python aliases (`py.exe`, `python.exe` in `WindowsApps/`) that prompt for Store installation and block forever. `command -v` and `Get-Command` resolve them as valid, so pre-checks pass but `& py --version` blocks the entire script.
@@ -948,6 +1070,8 @@ $job | Remove-Job -Force
 
 ## 76. PowerShell Temp File for Complex Commands from MSYS Bash
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** platform-workaround
 **Context:** Running PowerShell commands inline from MSYS bash (`powershell.exe -Command "..."`) breaks when the command contains `$env:PATH`, special characters, or multi-line logic. Bash's `\$` escaping conflicts with PowerShell's `$` syntax. Using `cmd.exe /c` from MSYS swallows output entirely.
 **Fix:** Write to a temp `.ps1` file using a bash heredoc (with single-quoted delimiter to prevent bash interpolation), then execute with `-File`:
@@ -970,11 +1094,15 @@ powershell.exe -NoProfile -File /tmp/my-command.ps1 2>&1
 
 ## 77. Small Wave 3 Without Subagent for Focused Changes
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow-pattern
 **Context:** Wave-based parallel sprint execution normally uses subagents for each wave. But when a wave has a single focused task (one file, well-understood changes), implementing directly in the main context is faster than the subagent overhead (prompt construction, context loading, result verification).
 **Threshold:** If the task modifies 1-2 files with <50 lines of changes and the main context already has the file loaded, skip the subagent.
 
 ## 78. golangci-lint exhaustive: List All Enum Cases in Switch
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** lint-fix
 **Context:** The `exhaustive` linter requires every value of a type-defined enum to appear in a `switch` statement, even when the function has a `default` return. Common in helper functions like `isInfrastructureType(dt DeviceType) bool` where only 4 of 15 enum values return `true`.
@@ -1012,6 +1140,8 @@ func isInfrastructureType(dt models.DeviceType) bool {
 
 ## 79. Cross-Language Enum Exhaustiveness Audit
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** pattern
 **Context:** Shared enum types (e.g., `DeviceType`) exist in both Go (`pkg/models/`) and TypeScript (`web/src/api/types.ts`). Adding new values requires updates in BOTH languages. Go's `exhaustive` linter catches missing switch cases. TypeScript's compiler catches missing `Record<DeviceType, ...>` keys. But these only fail in CI -- the agent may not check both.
 **Fix:** When adding new enum values to a shared type, audit ALL downstream usage:
@@ -1024,6 +1154,8 @@ Add the new values to every location found.
 **Prevention:** Include "cross-language enum audit" in subagent prompts when the task adds new enum values.
 
 ## 80. E2E getByText Regex Matches Multiple UI Elements After Feature Additions
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** gotcha
 **Context:** Playwright's `getByText(/\d+ devices?/)` resolved to 1 element originally but broke after adding per-group counts (e.g., "25 devices" header + "20 devices" and "5 devices" per group). Strict mode violation: "resolved to 3 elements."
@@ -1040,6 +1172,8 @@ await expect(page.getByText(/\d+ devices?/).first()).toBeVisible({ timeout: 10_0
 **General rule:** Any `getByText` with a generic regex pattern is fragile. New UI features can add matching text anywhere. Prefer scoped locators or `.first()` with a comment explaining why.
 
 ## 81. Union Return Type Requires Type Guard at ALL Call Sites
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** correction
 **Context:** When changing a function's return type to a union (e.g., `loginApi()` from `TokenPair` to `TokenPair | MFAChallengeResponse`), every call site must narrow with a type guard before accessing type-specific properties. TypeScript reports `TS2339: Property 'access_token' does not exist on type 'LoginResponse'`. Easy to miss call sites in: (1) page components that call the function directly, (2) test files that mock the function (must export the type guard in the mock too).
@@ -1070,6 +1204,8 @@ vi.mock('@/api/auth', () => ({
 
 ## 82. Rebase Conflict Resolution: Keep Both Features' Additions
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow-pattern
 **Context:** When two PRs both add content to the same file (e.g., settings.tsx -- new tabs, imports, components) and one merges first, rebasing the second PR produces multiple conflict blocks. Each conflict has feature A's additions (from HEAD/main) on one side and feature B's additions (from the incoming commit) on the other.
 **Fix:** At each conflict block, keep BOTH sides by concatenating. Typical conflict points in a tabbed settings page and their resolution:
@@ -1085,12 +1221,16 @@ vi.mock('@/api/auth', () => ({
 
 ## 83. Sprint Scope Reduction via Codebase Exploration
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow-pattern
 **Context:** When planning a sprint from issue trackers and roadmap checklists, planned items may already be partially or fully implemented in the codebase. Planning without exploring first leads to overscoped sprints, wasted agent context, and unnecessary PRs.
 **Fix:** Before executing a sprint, launch an Explore agent to check each planned deliverable against the actual codebase. Search for existing components, API endpoints, and UI patterns that match planned features.
 **Extends:** Pattern #47 (check existing assets before scoping issues) -- same principle applied at sprint level instead of individual issue level.
 
 ## 84. Subagents Skip Lint Despite CI Checklist Warnings
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** correction
 **Context:** Go agent CI checklist says "watch for: gocritic rangeValCopy, prealloc" but agents still produce these violations because they run `go build` and `go test` but not `golangci-lint`. The "watch for" phrasing is advisory, not mandatory.
@@ -1112,6 +1252,8 @@ This can eliminate significant planned work when items are already implemented b
 
 ## 86. Two-Layer Permission Strategy for Claude Code Projects
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow-pattern
 **Context:** Claude Code settings do NOT cascade from parent directories (unlike .editorconfig). Each project is independent. The `~/.claude/settings.json` (user-level) provides global defaults that merge into every project's permissions. Over time, interactive approvals accumulate hundreds of specific command entries (e.g., `Bash(gh pr merge 30 --squash --admin)`) instead of broad wildcards.
 **Fix:** Two-layer approach:
@@ -1124,6 +1266,8 @@ Periodically clean up user-level settings.json to remove accumulated specific ap
 
 ## 87. Linter/Hook Leaks Cross-Branch Changes in Parallel Agent Work
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow-pattern
 **Context:** When parallel agents both modify the same file (e.g., SKILL.md routing table) and a linter or hook runs on the working tree, it can merge both agents' changes into a single file state. If you commit that file on one branch, the other agent's additions leak in. CI then fails because the branch references files that don't exist on it (e.g., `workflows/update.md` referenced in SKILL.md but only created by the other agent).
 **Fix:** After sorting parallel agents' changes into branches via stash/pop, diff the shared file against main to verify only the current branch's additions are present. Remove cross-branch additions before committing.
@@ -1131,11 +1275,15 @@ Periodically clean up user-level settings.json to remove accumulated specific ap
 
 ## 88. Agent-Generated Markdown Needs MD038 Check
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** correction
 **Context:** Subagents generating markdown workflow files commonly produce code spans with trailing spaces like `` `## ` `` which triggers markdownlint MD038 (no-space-in-code). This is especially common when the agent writes instructions referencing heading syntax.
 **Fix:** After receiving agent-generated `.md` files, grep for MD038 violations before committing: `grep -n '` [^`]' file.md` or run `npx markdownlint-cli2 file.md`.
 
 ## 89. Parallel Plain-Text Renderer for TUI Transition Animations
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** architecture-pattern
 **Context:** A Bubbletea TUI has a styled `View()` (lipgloss styles, borders, centering via `lipgloss.Place`) and a transition animation that needs to reveal the menu text character-by-character. Stripping ANSI from `View()` output fails due to width calculation mismatches between lipgloss and terminals (emoji, variation selectors, border chars).
@@ -1160,6 +1308,8 @@ func (m Model) TransitionText() string {
 
 ## 90. golangci-lint v2 Requires version Field in Config
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** correction
 **Context:** golangci-lint v2 requires `version: "2"` as the first field in `.golangci.yml`. Without it, the linter exits with `Error: can't load config: unsupported version of the configuration: ""`. This error is NOT caught by `go build` or `go test` -- only by running golangci-lint directly. A config that worked with v1 silently breaks when upgrading to v2.
 **Fix:** Add `version: "2"` as the first line of `.golangci.yml`. Also note that v2 changed the module path from `github.com/golangci/golangci-lint/cmd/golangci-lint` to `github.com/golangci/golangci-lint/v2/cmd/golangci-lint`.
@@ -1181,6 +1331,8 @@ run:
 
 ## 91. go run for Pinned Tool Versions
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow-pattern
 **Context:** Installing Go tools locally (`go install ...@latest`) creates version drift between developers, PATH issues on Windows MSYS (gotcha #60), and `@latest` risks surprise breakage in CI.
 **Fix:** Use `go run github.com/.../tool@vX.Y.Z` in Makefiles and hooks instead of relying on a local binary. Benefits: exact version guaranteed, no install step, no PATH issues, works identically in Makefile targets, pre-push hooks, and CI.
@@ -1198,11 +1350,15 @@ lint:
 
 ## 92. DevKit Scaffolding Must Include Executable Templates
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** process-pattern
 **Context:** DevKit v2.0 had comprehensive profiles describing WHAT projects should do (linting, testing, CI) but zero HOW scaffolding (no Makefile templates, no CI workflow templates, no pre-push hooks, no .golangci.yml template). Projects set up from devkit required manual creation of all CI infrastructure, leading to preventable failures (Samverk had 8/10 CI runs failing from pre-existing errors).
 **Fix:** DevKit should include ready-to-copy templates for: (1) pre-push hook (`git-templates/hooks/pre-push`), (2) golangci-lint config (`project-templates/golangci.yml`), (3) Makefile (`project-templates/Makefile.go`), (4) CI workflow (`project-templates/ci.yml`). Added in devkit PR #104.
 
 ## 93. Advisory Rules Without Enforcement Are Ignored Under Pressure
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** process-pattern
 **Context:** DevKit v2.0 has 88 autolearn patterns and 62 gotchas loaded into every session. They are advisory-only -- no mechanism enforces them. Under time pressure (sprints, parallel agent waves), subagent prompts omit CI checklists, errors get classified as "pre-existing" and left unfixed, and agents repeat known mistakes. On Samverk, errors were dismissed as pre-existing despite DevKit being applied to the workspace.
@@ -1210,17 +1366,23 @@ lint:
 
 ## 94. Autolearn Must Validate Before Writing Rules
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** process-pattern
 **Context:** Autolearn writes directly to rules files with minimal validation (deduplication + format only). A bad learning (e.g., "suppress this lint warning" instead of "fix the root cause") becomes a permanent rule cascading to all projects. With autonomous workers, this risk is amplified -- an agent's workaround could weaken the guardrails that keep other agents on track.
 **Fix:** Five-stage validation pipeline before any rule is written: (1) Evidence check -- was the fix verified? (2) Core principle alignment -- does it contradict immutable rules? (3) Best practices review -- root cause fix or workaround? (4) Conflict check -- does it contradict existing rules? (5) Risk classification -- LOW auto-accepts, MEDIUM/HIGH needs human approval, CRITICAL is rejected. Hard-coded dangerous pattern list ("skip", "bypass", "ignore", "suppress", "disable", "--no-verify") always triggers human review. See DevKit issue #116.
 
 ## 95. Fix-Forward Replaces Pre-Existing Error Classification
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** process-pattern
 **Context:** The quality-control skill classified CI failures as "pre-existing" when they existed in main before the current PR. This classification had no follow-through -- errors were noted and ignored indefinitely. Technical debt accumulated as each new PR inherited the failures.
 **Fix:** Replace "pre-existing" with "fix-forward" workflow: (1) Can fix inline in < 5 min? Fix it, add `chore: fix pre-existing <issue>`. (2) Can't fix inline? File a GitHub issue immediately with priority label. (3) Systemic? Also identify the DevKit gap (missing rule/checklist/template) and update it. Never acceptable: "noted as pre-existing, moving on" without a fix OR tracking issue. See DevKit issue #108.
 
 ## 96. Interactive Q&A Then Background Agent for Human-Dependent Issues
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** workflow-pattern
 **Context:** Issues tagged `agent:human` require design decisions before implementation. Processing them one at a time wastes user attention. Processing them all at once risks context overload.
@@ -1229,11 +1391,15 @@ lint:
 
 ## 97. Combine Complementary Issues Into Single PR
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow-pattern
 **Context:** Two issues may produce complementary outputs where one's research directly feeds the other's requirements (e.g., #12 Ollama orchestration research informs #13 system requirements hardware tiers).
 **Fix:** Combine into a single PR with both deliverables. Close both issues using repeated keyword syntax (`Closes #12, Closes #13`). Reduces: CI runs, review overhead, merge conflict risk. Keep individual issue tracking granular -- the combined PR references both.
 
 ## 98. 4-PR Contributor Config Rollout Sequence
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** workflow-pattern
 **Context:** Setting up a repo for external contributors requires ESLint, CI, community health files, branch protection, and repo settings. These have dependency ordering that must be respected.
@@ -1249,6 +1415,8 @@ PRs 1 and 2 have zero file overlap and can merge in parallel. PR 3 must wait for
 
 ## 99. Dependabot Triage: Batch Check, Merge Green, Close Failing
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow-pattern
 **Context:** When Dependabot is first enabled on a repo, it creates multiple PRs at once. Some pass CI, others fail due to ecosystem incompatibilities (e.g., ESLint 10 breaking react-hooks plugin peer dep).
 **Fix:** Check CI status on ALL Dependabot PRs first, then batch process:
@@ -1261,6 +1429,8 @@ PRs 1 and 2 have zero file overlap and can merge in parallel. PR 3 must wait for
 **Proven:** Runbooks: 7 Dependabot PRs triaged in ~5 min. 4 merged (checkout v6, setup-node v6, vite 7, react-swc 4), 3 closed (ESLint 10 x2, React bump).
 
 ## 100. Vitest Setup for React + Vite Projects
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** testing-pattern
 **Context:** Setting up unit tests for a React + MUI + Vite project (like a Docker Desktop extension) with TypeScript strict mode.
@@ -1276,6 +1446,8 @@ PRs 1 and 2 have zero file overlap and can merge in parallel. PR 3 must wait for
 **Key insight:** `mergeConfig` from `vitest/config` is required to inherit the Vite config (SWC plugin, define blocks). Using a standalone `defineConfig` misses these.
 
 ## 101. Zero-Rework Sprint via Subagent CI Checklists
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** workflow-pattern
 **Context:** Sprint with 5 PRs across 4 waves achieved zero rework (all CI-green first pass). Previous sprints on other projects had 1-3 fix-push cycles per PR.
@@ -1297,6 +1469,8 @@ PRs 1 and 2 have zero file overlap and can merge in parallel. PR 3 must wait for
 
 ## 102. noctx: Database Operations Must Use Context-Aware Variants
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** lint-fix
 **Context:** golangci-lint `noctx` flags `db.Exec()`, `db.Query()`, and `db.QueryRow()` calls that don't pass a context. Even in init/migration code where `context.Background()` is appropriate, the context-aware variants must be used. Agents miss this because `db.Exec` compiles fine -- it's lint-only.
 **Fix:** Always use `ExecContext`, `QueryContext`, `QueryRowContext` with explicit context. For migration/init code, use `context.Background()`.
@@ -1313,6 +1487,8 @@ rows, err := db.QueryContext(ctx, "SELECT id FROM sessions WHERE status = ?", st
 ```
 
 ## 103. errcheck: resp.Body.Close Requires Explicit Error Discard
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** lint-fix
 **Context:** `errcheck` flags both `resp.Body.Close()` (direct) and `defer resp.Body.Close()` (deferred). The deferred form requires a closure because `defer` evaluates args immediately -- `defer _ = resp.Body.Close()` doesn't work syntactically.
@@ -1331,6 +1507,8 @@ defer func() { _ = resp.Body.Close() }()
 
 ## 104. gosec G704: SSRF Nolint for Trusted Base URL Clients
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** lint-fix
 **Context:** gosec G704 flags `httpClient.Do(req)` as potential SSRF via tainted URL. In provider/adapter clients where the base URL is set once during initialization from trusted configuration, this is a false positive.
 **Fix:** Add `//nolint:gosec // G704: URL is from trusted baseURL config` on the flagged line.
@@ -1345,6 +1523,8 @@ resp, err := c.httpClient.Do(req) //nolint:gosec // G704: URL is from trusted ba
 ```
 
 ## 105. gocritic sloppyReassign: Named Return Shadow in If Statement
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** lint-fix
 **Context:** `if err = f(); err != nil` inside a function with named return `err` triggers gocritic `sloppyReassign`. The `=` silently overwrites the named return, which can mask earlier error values. Common in adapter methods with multiple fallible calls.
@@ -1367,6 +1547,8 @@ func (c *Client) SetLabels(ctx context.Context, number int, labels []string) (er
 
 ## 106. Mandatory Lint Step Language Eliminates Fix-Push Cycles
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Category:** workflow-pattern
 **Context:** Go agent CI checklist previously said "Self-check your code for these MANDATORY lint patterns" but agents interpreted "self-check" as advisory and skipped running golangci-lint. Result: lint violations shipped, requiring fix-push cycles in CI.
 **Fix:** Promote golangci-lint to a numbered mandatory step with explicit enforcement language: "Step 4: `golangci-lint run ./path/...` -- This is NOT optional. Agents that skip this step cause fix-push cycles in CI. If golangci-lint reports errors, fix ALL of them before finishing."
@@ -1374,6 +1556,8 @@ func (c *Client) SetLabels(ctx context.Context, number int, labels []string) (er
 **Key insight:** Agent compliance depends on enforcement language, not just presence in rules. "Self-check" = skip under pressure. "Step 4, NOT optional, fix ALL" = comply.
 
 ## 107. Stash Untracked Files Before Cross-Branch Push
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** workflow-pattern
 **Context:** After parallel agents complete, all files are in the working tree on main. When sorting into branches via stash/pop, `go build ./...` in the pre-push hook compiles untracked files from other agents. If those files reference symbols only on another branch, the push fails with "undefined" errors.
@@ -1390,6 +1574,8 @@ git stash pop
 **Proven:** Samverk sprint: profile branch push failed until dispatcher files were stashed. After stash, push succeeded with 0 issues.
 
 ## 108. Phased Research-Gate Workflow for New Projects
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Category:** process-pattern
 **Context:** Jumping from a flat issue backlog straight to implementation leads to underresearched designs and no validation checkpoints. Issues get implemented without understanding the ecosystem (SDKs, libraries, communication patterns), causing rework.

--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -19,6 +19,8 @@ Platform-specific issues, tool quirks, and surprising behaviors discovered throu
 
 ## 2. GitHub Branch Protection Requires --admin for Merge
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** GitHub
 **Issue:** When branch protection rules require PR reviews or status checks, `gh pr merge` fails even when all checks pass if you're the only maintainer.
 **Workaround:** Use `gh pr merge --admin` to bypass branch protection (only for repo admins).
@@ -26,11 +28,15 @@ Platform-specific issues, tool quirks, and surprising behaviors discovered throu
 
 ## 3. Git Stash Before PR Merge
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Git
 **Issue:** `gh pr merge` with `--merge` or `--squash` can fail if there are uncommitted local changes, even if they're unrelated to the PR.
 **Workaround:** `git stash` before merging, `git stash pop` after.
 
 ## 4. Force Push to Already-Merged Branch Creates Orphan
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** GitHub
 **Issue:** If a PR branch was already merged and you `git push --force` to it, GitHub creates a new remote branch (orphaned from the PR). The PR remains merged.
@@ -39,11 +45,15 @@ Platform-specific issues, tool quirks, and surprising behaviors discovered throu
 
 ## 5. Incomplete Range Variable Replacement in Loop Refactoring
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Go (all)
 **Issue:** When changing `for _, v := range slice` to `for i := range slice`, it's easy to miss references to `v` deeper in the loop body. The compiler will catch `undefined: v` but only if you try to build.
 **Fix:** After changing the range declaration, search the entire loop body for the old variable name. Replace ALL occurrences with `slice[i]`.
 
 ## 6. React Compiler Lint: Cannot Access Refs During Render
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** React 19+ / ESLint react-hooks/refs rule
 **Issue:** Mutating `ref.current` at the top level of a custom hook (during render) is flagged by the React compiler ESLint plugin. Common pattern `onMessageRef.current = onMessage` triggers "Cannot update ref during render". Also applies to storing function implementations in refs.
@@ -58,6 +68,8 @@ useEffect(() => { onMessageRef.current = onMessage }, [onMessage])
 ```
 
 ## 7. React Compiler Lint: Recursive useCallback Self-Reference
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** React 19+ / ESLint react-hooks/immutability rule
 **Issue:** A `useCallback` function that calls itself recursively (e.g., a `connect()` function calling `connect()` inside an `onclose` handler) triggers "Cannot access variable before it is declared". The linter sees the variable used before its `const` declaration completes.
@@ -74,6 +86,8 @@ useEffect(() => {
 
 ## 8. Windows Python Aliases Shadow Real Python
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Windows (MSYS_NT)
 **Issue:** `python3`, `python`, and `py` all resolve to Windows Store alias stubs (at `~/AppData/Local/Microsoft/WindowsApps/python*.exe`) that just prompt "Install from Microsoft Store" instead of running Python. `command -v` reports them as found, but they don't actually work.
 **Diagnosis:** `python --version` outputs "Python was not found; run without arguments to install from the Microsoft Store" and exits non-zero.
@@ -87,11 +101,15 @@ done
 
 ## 9. jq Not Available on Windows MSYS by Default
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Windows (MSYS_NT)
 **Issue:** `jq` is not included in Git for Windows / MSYS2 by default. Scripts that use `jq` for JSON processing fail with "command not found".
 **Fix:** Use Python's `json` module instead of `jq` for bash scripts that need JSON escaping/parsing. Python is more commonly available (once you work around gotcha #8).
 
 ## 10. UserPromptSubmit Hooks Block Slash Commands and Menu Selections
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Claude Code (all platforms)
 **Issue:** `UserPromptSubmit` hooks with `type: "prompt"` block slash commands (`/reflect`, `/whats-next`, etc.) and bare numeric inputs (`1`, `7`, `12`) used as menu selections. The small model evaluating the hook prompt interprets these as "not a valid or actionable request" and generates refusal messages.
@@ -111,6 +129,8 @@ done
 Regular prompts containing numbers still fire normally (e.g., "fix issue #297").
 
 ## 11. GitHub API Returns Empty Without User-Agent Header
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** All (curl, fetch)
 **Issue:** GitHub REST API requires a `User-Agent` header. Requests without it return empty or 403 responses. Curl on some platforms sends a User-Agent by default; others don't.
@@ -132,11 +152,15 @@ TimeToThreshold *time.Duration `json:"time_to_threshold,omitempty" swaggertype:"
 
 ## 13. Swagger Drift After Any Handler/Model Change
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Go (swaggo/swag)
 **Issue:** ANY change to Go types referenced in swagger-annotated handlers requires regenerating the swagger spec. This includes: adding new types (e.g., `ThemeLayer`), adding/removing fields on existing structs (e.g., `Layers` on `ThemeDefinition`), changing response types, or removing routes. The CI Swagger Drift Check catches stale specs but costs a round-trip.
 **Fix:** Always run `swag init -g cmd/subnetree/main.go -o api/swagger --parseDependency --parseInternal` (or `make swagger`) after modifying any handler, request/response struct, or type used in swagger annotations. Commit the regenerated files alongside the Go changes.
 
 ## 14. Go Nil Guard: Split Chained Nil Checks Into Separate Blocks
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Go (all)
 **Issue:** When guarding against nil with `if obj.Field == nil || obj.Field.Sub == 0`, any code in the same block that accesses `obj.Field.X` (e.g., logging) will panic when `obj.Field` is nil. The `||` short-circuits the condition, but the log statement still executes before the return.
@@ -162,11 +186,15 @@ if len(de.Device.IPAddresses) == 0 {
 
 ## 15. Squash-Merged Branches Don't Appear in `git branch --merged`
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Git (all)
 **Issue:** After squash-merging a PR, the local branch tip and the squash commit on main have different hashes. `git branch --merged main` won't list the branch because the original commits aren't ancestors of main.
 **Fix:** Use `git branch -D` (force delete) instead of `git branch -d` for cleanup. Verify safety by checking that the remote tracking ref was already pruned (`git remote prune origin` first), confirming the PR was merged and the remote branch was deleted.
 
 ## 16. GitHub `Closes #N` Comma Syntax Only Closes First Issue
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** GitHub
 **Issue:** `Closes #1, #2, #3` in a PR body only auto-closes #1. GitHub requires the keyword before **each** issue number. The comma-separated list without repeated keywords is silently ignored for all but the first reference.
@@ -205,6 +233,8 @@ if err != nil {
 
 ## 18. Windows Start-Process Gives Child a Real Console (ModeCharDevice)
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Windows (PowerShell)
 **Issue:** `Start-Process` in PowerShell gives the child process a real console, even with `-WindowStyle Hidden` and `-RedirectStandardOutput/-StandardError`. Go's `os.Stdin.Stat()` returns `ModeCharDevice=true`, so code that checks for an interactive terminal (e.g., vault passphrase prompt) will still prompt on stdin, blocking the process.
 **Contrast:** On Linux, backgrounding with `&` or piping stdin makes `ModeCharDevice=false`, so terminal-detection code correctly skips interactive prompts.
@@ -218,6 +248,8 @@ $proc = Start-Process -FilePath $binary -ArgumentList $args -PassThru -WindowSty
 For bash scripts, `export VAR=value` before backgrounding the process achieves the same effect.
 
 ## 19. PowerShell 5.1 ConvertFrom-Json Drops Empty Arrays
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Windows (PowerShell 5.1)
 **Issue:** `ConvertFrom-Json` on an empty JSON array `[]` returns `$null` instead of an empty PowerShell array `@()`. This means `$null -ne $result` evaluates to `$false` even when the API returned HTTP 200 with a valid empty response.
@@ -236,6 +268,8 @@ if ($resp.StatusCode -eq 200) { ... }  # always works
 
 ## 20. Stacked PR Rebase After Squash-Merge Requires Skip
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Git / GitHub
 **Issue:** When squash-merging a base PR (e.g., PR #143) to main, downstream stacked branches (e.g., PR #144, #145) still contain the original pre-squash commits. Running `git rebase origin/main` on the downstream branch produces conflicts for every already-merged commit because the squash commit hash differs from the original commits.
 **Fix:** Use `git rebase --skip` for each conflicting commit that was part of the squash-merged PR. Git will drop the already-applied commits and keep only the unique downstream commits. For a 3-PR stack (A->B->C) merged bottom-up:
@@ -249,6 +283,8 @@ if ($resp.StatusCode -eq 200) { ... }  # always works
 
 ## 21. VS Code YAML Extension Conflict: jumpToSchema
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** VS Code (all)
 **Issue:** Codecov VS Code extension (v0.1.1) and Red Hat YAML both bundle `yaml-language-server` internally. Both try to register the `jumpToSchema` command at startup. The second to load crashes with `command 'jumpToSchema' already exists`, preventing the Codecov extension from initializing.
 **Diagnosis:** Error in Codecov Extension output channel: `Server initialization failed. Error: command 'jumpToSchema' already exists`.
@@ -257,12 +293,16 @@ if ($resp.StatusCode -eq 200) { ... }  # always works
 
 ## 22. Project Renames Create Competitive Research Blind Spots
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** GitHub / All
 **Issue:** When GitHub projects rename (often for trademark reasons), searches for the OLD name return nothing and searches for the NEW name miss historical context. Docker Hub images, Proxmox community scripts, and Unraid app listings may retain old names for months. Example: Scanopy was "NetVisor" (mayanayza/netvisor) from Sep-Dec 2025, renamed to scanopy/scanopy on Dec 15, 2025. Docker images still show `mayanayza/netvisor-server`.
 **Impact:** Competitive research using keyword searches misses renamed projects entirely. Our research concluded "no competitors" while Scanopy had 3k+ stars.
 **Fix:** When researching a competitive space: (1) Search by function, not product name ("network topology visualization self-hosted" not "NetVisor"), (2) Check Docker Hub for related images (old names persist), (3) Look at GitHub topics/tags, (4) Check star counts on GitHub search results to find established projects, (5) Re-scan monthly.
 
 ## 23. GitHub Rulesets Return 404 on Branch Protection API
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** GitHub
 **Issue:** Repos using GitHub **rulesets** (Settings > Rules > Rulesets) instead of classic **branch protection** (Settings > Branches) return 404 from `gh api repos/{owner}/{repo}/branches/main/protection`. This makes it look like there's no protection when there actually is. Rulesets are the newer system and repos may have been migrated without the maintainer realizing.
@@ -271,6 +311,8 @@ if ($resp.StatusCode -eq 200) { ... }  # always works
 **Related:** Required review count is nested under "Require a pull request before merging" > "Show additional settings" in the ruleset UI -- easy to miss.
 
 ## 24. cla-assistant.io Blocks Dependabot PRs
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** GitHub
 **Issue:** The external cla-assistant.io integration creates a `license/cla` status check that stays permanently "pending" on Dependabot PRs because `dependabot[bot]` cannot sign a CLA. This is separate from a GitHub Actions CLA workflow (`cla.yml`) which can allowlist bots. Having both creates duplicate CLA checks with different results.
@@ -300,6 +342,8 @@ if ($resp.StatusCode -eq 200) { ... }  # always works
 
 ## 26. Sequential Same-File PR Merge Requires Rebase Between Each
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Git / GitHub
 **Issue:** When multiple PRs modify the same file (e.g., README.md), merging one immediately conflicts the others -- even if all had passing CI when created. The second PR's diff is computed against the old main, not the post-merge main.
 **Diagnosis:** `gh pr merge` fails with "Pull Request is not mergeable" after a sibling PR was just merged.
@@ -316,6 +360,8 @@ if ($resp.StatusCode -eq 200) { ... }  # always works
 
 ## 27. SQLite strftime Returns NULL for RFC3339Nano Timestamps
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** SQLite (all)
 **Issue:** `strftime('%Y-%m-%dT%H', timestamp_col)` returns NULL when the timestamp column contains RFC3339Nano format (`2026-02-14T10:30:00.123456789Z`). SQLite's strftime only recognizes a subset of ISO 8601 formats -- specifically, it expects `YYYY-MM-DD HH:MM:SS` or `YYYY-MM-DDTHH:MM:SS` without fractional seconds beyond milliseconds.
 **Diagnosis:** SQL queries using `GROUP BY strftime(...)` return zero rows even when the table has data. The grouping key is NULL for every row.
@@ -328,6 +374,8 @@ bucket := ts.Truncate(interval).UTC().Format(time.RFC3339)
 Query all points within the time range with a simple `WHERE timestamp BETWEEN ? AND ?` (string comparison works for RFC3339), then aggregate in Go.
 
 ## 28. Recharts v3 Uses TooltipContentProps, Not TooltipProps
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** React / recharts 3.x
 **Issue:** In recharts v3 (3.7.0+), the `<Tooltip content={...} />` callback receives `TooltipContentProps`, not `TooltipProps`. Using `TooltipProps` causes TypeScript errors: `Property 'payload' does not exist on type` and same for `label`. The properties `payload`, `label`, `active` are context-provided and only exist on `TooltipContentProps`.
@@ -347,6 +395,8 @@ function CustomTooltip({ active, payload, label }: TooltipContentProps<number, s
 
 ## 29. Build-Tag Files Invisible to Local Lint on Different OS
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Go (cross-platform development)
 **Issue:** Files with `//go:build !windows` tags are completely excluded from `golangci-lint` when running on Windows (and vice versa). Lint errors in these files -- `gocritic filepathJoin` (absolute paths in `filepath.Join`), `gosec G115` (int->int32 overflow), `gocritic paramTypeCombine`, `prealloc` -- only appear in Linux CI. This caused 2 fix-push cycles on PR #262 (Linux Scout).
 **Common errors in `!windows` files caught only by Linux CI:**
@@ -359,6 +409,8 @@ function CustomTooltip({ active, payload, label }: TooltipContentProps<number, s
 
 ## 30. Background Agents Can't Prompt for Tool Permissions
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Claude Code (all platforms)
 **Issue:** Background agents launched with `Task(run_in_background=true)` inherit the session's current tool permission state. If a tool hasn't been approved yet (user hasn't clicked "allow"), the background agent gets denied silently and cannot prompt the user for approval. The agent burns tool calls futilely trying alternatives.
 **Diagnosis:** Agent output shows repeated "Permission to use [tool] has been denied" for WebSearch, WebFetch, Bash, MCP tools, etc. One agent burned 27 tool calls (all denied) before giving up.
@@ -366,6 +418,8 @@ function CustomTooltip({ active, payload, label }: TooltipContentProps<number, s
 **Prevention:** Launch a "warm-up" foreground call using each tool type before going parallel. Or accept partial failure by launching redundant agents across different tool types -- if 2 of 3 succeed, you still get actionable data.
 
 ## 31. Reddit Blocks WebFetch but gh api Works
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** All (Claude Code)
 **Issue:** Reddit's robots.txt blocks WebFetch and most scraping tools. `WebFetch("https://www.reddit.com/...")` and `WebFetch("https://old.reddit.com/...")` both fail. Web search with `allowed_domains: ["reddit.com"]` also returns nothing.
@@ -388,6 +442,8 @@ gh api -X GET "$URL.json" --jq '.[1].data.children[].data | {author, body, score
 
 ## 32. SessionStart Hook: Use `type: "command"` Not `type: "prompt"`
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Claude Code (all)
 **Issue:** `SessionStart` hooks with `type: "prompt"` send the prompt text to a small model for yes/no evaluation. If the prompt is an instruction ("Run /dashboard to display..."), the small model doesn't know what to do with it and the hook produces no useful output. The hook appears to fire but nothing happens.
 **Diagnosis:** No `SessionStart hook success` message appears in system reminders despite the hook being correctly configured in settings.json.
@@ -406,11 +462,15 @@ gh api -X GET "$URL.json" --jq '.[1].data.children[].data | {author, body, score
 
 ## 33. Claude Code Hooks Cannot Initiate Conversation
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Claude Code (all)
 **Issue:** Hooks (including `SessionStart`) inject context as system reminders but cannot make Claude proactively start a conversation. Claude only sees hook output when the user sends their first message. This means "auto-run X on startup" requires the user to type something first.
 **Workaround:** Accept this as a two-step startup: (1) hook fires silently, (2) user types anything (even "go"), (3) Claude sees the hook output and acts. Pair with a static file that auto-opens (VS Code task with `runOn: folderOpen`) so the user has orientation while the hook waits for input.
 
 ## 34. Chrome Ignores autocomplete="off" on Form Fields
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** All browsers (Chrome since v34, Firefox/Safari similar)
 **Issue:** Setting `autocomplete="off"` on form inputs has no effect -- browsers ignore it. Additionally, non-standard `name` attributes (e.g., `name="new-username"`) prevent browsers from correctly identifying form field roles. When Chrome fills a saved password, it looks for a companion username field and picks the nearest text/email input, causing autofill to overwrite the wrong field.
@@ -435,12 +495,16 @@ gh api -X GET "$URL.json" --jq '.[1].data.children[].data | {author, body, score
 
 ## 35. Go Race Detection Requires CGO on Windows MSYS
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Windows (MSYS_NT)
 **Issue:** `go test -race ./...` fails immediately with `go: -race requires cgo; enable cgo by setting CGO_ENABLED=1`. The race detector is implemented in C and requires CGO, which isn't available in the standard MSYS/Git-for-Windows Go installation.
 **Impact:** Local Windows verification cannot include race detection. Race bugs are only caught by CI (Linux runners have CGO enabled).
 **Workaround:** Run `go test ./...` locally (without `-race`). Rely on CI's Linux runner for race detection. If race detection is critical locally, use WSL2 or Docker with a Linux Go image.
 
 ## 36. Go uint64 Subtraction Wraps Instead of Going Negative
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Go (all)
 **Issue:** `uint64` subtraction wraps around to a huge positive number when the result would be negative (e.g., `50 - 100` becomes `~2^64 - 50`). A subsequent `float64()` conversion produces a huge positive float, not a negative one. This means `if float64(a - b) < 0` is **always false** for uint64 values -- the check is dead code.
@@ -461,6 +525,8 @@ cpuDelta := float64(newUsage - oldUsage)
 
 ## 37. VS Code Locks Workspace Root Directories
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Windows (VS Code)
 **Issue:** `rm -rf` on a directory that VS Code has open as a workspace root fails with "Device or resource busy". VS Code's file watcher holds handles on the directory. Individual files inside CAN be removed, but the empty directory shell persists until VS Code reloads with an updated workspace file that no longer references that root.
 **Diagnosis:** After updating `subnetree.code-workspace` from 3-root to single-root, the old `.coordination/` directory (previously a workspace root) couldn't be deleted despite all its files being removed.
@@ -468,6 +534,8 @@ cpuDelta := float64(newUsage - oldUsage)
 **Prevention:** When restructuring workspaces, plan to reload VS Code between removing directory contents and deleting the directory itself.
 
 ## 38. Playwright getByLabel Resolves Multiple Elements with Toggle Buttons
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Playwright (all browsers)
 **Issue:** `page.getByLabel('Password')` resolves to 2+ elements when a password input has a companion show/hide toggle button whose `aria-label` contains "password" (e.g., "Show password", "Hide password"). Playwright's `getByLabel` matches both the input (via `for=` attribute) and the button (via `aria-label` substring).
@@ -477,11 +545,15 @@ cpuDelta := float64(newUsage - oldUsage)
 
 ## 39. Docker Extension `update` Fails After Image Rebuild
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Docker Desktop Extensions (all)
 **Issue:** `docker extension update <tag>` returns "the extension is not installed" after rebuilding the Docker image, even if the extension was previously installed with the same tag. This happens because rebuilding replaces the image SHA, and Docker Desktop tracks extensions by image digest, not tag.
 **Fix:** Use `docker extension install <tag>` instead of `update` when the image has been rebuilt. The install command works whether or not the extension is currently registered. Pipe `echo "y"` to auto-confirm the prompt in scripts.
 
 ## 40. User Manual Commits During Context Compaction Gap
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Claude Code (all)
 **Issue:** When context compacts and the session is continued, the user may have made manual git commits between the old session ending and the new session starting. The continuation summary says "files need committing" but the working tree is clean -- the user already committed (possibly with a different message or extra files bundled in).
@@ -490,11 +562,15 @@ cpuDelta := float64(newUsage - oldUsage)
 
 ## 41. .claude/settings.local.json Should Be Gitignored
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Claude Code (all)
 **Issue:** `.claude/settings.local.json` contains local Claude Code tool permission settings. If not in `.gitignore`, it can be accidentally committed via `git add -A` or manual commits, exposing local configuration to the repo.
 **Fix:** Add `.claude/` to `.gitignore`. If already committed, remove with `git rm --cached .claude/settings.local.json` and add to `.gitignore`.
 
 ## 42. BMAD Method Generates 42 Slash Commands in .claude/commands/
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Claude Code (all)
 **Issue:** `npx bmad-method install --modules bmm --tools claude-code` generates 42 slash commands (all prefixed `bmad-bmm-*` or `bmad-*`) in `.claude/commands/`. This can overwhelm Claude Code's command namespace if the project already has its own commands, making tab-completion and command discovery harder. Spec Kit only generates 9 commands for comparison.
@@ -503,6 +579,8 @@ cpuDelta := float64(newUsage - oldUsage)
 **Note:** BMAD's `/bmad-help` command provides guidance on which workflows to use, but the sheer volume of 42 commands is intimidating for new users.
 
 ## 43. Spec Kit `specify init` Hangs on Windows MSYS
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Windows (MSYS_NT) / Python Rich library
 **Issue:** `specify init <path> --ai claude --no-git --force` hangs indefinitely on Windows MSYS. The Rich library's interactive prompt blocks even with `PYTHONIOENCODING=utf-8 NO_COLOR=1` env vars, `echo "" |` piping, and `2>&1 | cat` redirection. The `specify version` command also crashes with `UnicodeEncodeError` from `legacy_windows_render`.
@@ -522,6 +600,8 @@ This bypasses the CLI entirely and gives you the raw template files. For `specif
 
 ## 44. BMAD npm Package Name Is Not Obvious
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** npm / Node.js
 **Issue:** The BMAD Method v6 npm package is `bmad-method`. Common wrong guesses: `@anthropics/bmad-cli`, `bmad-cli`, `@bmadcode/bmad`, `bmad-builder`. There are 15+ BMAD-related packages on npm from different authors.
 **Fix:** The correct install command is:
@@ -535,6 +615,8 @@ Key flag names (easy to get wrong): `install` (not `init`), `--modules` (not `--
 
 ## 45. markdownlint-cli2 Config Must Be at Repo Root for CI
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** GitHub Actions / markdownlint-cli2
 **Issue:** `DavidAnson/markdownlint-cli2-action@v19` `config` parameter does not reliably override the config file lookup. markdownlint-cli2 discovers `.markdownlint.json` by walking up from each file's directory. If the config is only in a subdirectory (e.g., `devspace/.markdownlint.json`), CI uses default rules instead.
 **Diagnosis:** CI fails with MD013 (line-length) errors even though the config has `"MD013": false`. Locally, lint passes because the parent directory's config is found via filesystem walk.
@@ -542,12 +624,16 @@ Key flag names (easy to get wrong): `install` (not `init`), `--modules` (not `--
 
 ## 46. markdownlint MD060 Auto-Enabled by Default: True
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** markdownlint v0.40.0+
 **Issue:** MD060 (table-column-style) is a newer rule that gets auto-enabled when config has `"default": true`. It flags tables where separator rows use compact style (`|---|`) but content rows use padded style (`| text |`). If your config was written before this rule existed, it will suddenly appear in CI after a markdownlint version upgrade.
 **Diagnosis:** CI shows dozens of `MD060/table-column-style` errors on tables that look fine visually. The errors say "Table pipe is missing space to the left/right for style compact".
 **Fix:** Add `"MD060": false` to `.markdownlint.json` to disable, or fix all table pipe spacing to be consistent. When using `"default": true`, review release notes after markdownlint upgrades for newly added rules.
 
 ## 47. PowerShell [Mandatory] Validates Each Element in String Arrays
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** PowerShell 7+
 **Issue:** `[Parameter(Mandatory)] [string[]]$Param` validates EACH element in the array, not just the array itself. Empty strings `''` used as visual separator lines in instruction arrays fail with "Cannot bind argument to parameter because it is an empty string."
@@ -563,6 +649,8 @@ Key flag names (easy to get wrong): `install` (not `init`), `--modules` (not `--
 **Note:** `[AllowNull()]` is different — it allows `$null`, not empty strings. You need `[AllowEmptyString()]` specifically.
 
 ## 48. Win32_Processor.VirtualizationFirmwareEnabled False When Hypervisor Running
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Windows (Hyper-V)
 **Issue:** `(Get-CimInstance Win32_Processor).VirtualizationFirmwareEnabled` returns `$false` when Hyper-V (or any hypervisor) is already active. The CPU reports VT-x as "not available" because the hypervisor has already claimed it. This creates a false negative in virtualization readiness checks.
@@ -580,6 +668,8 @@ if ($virtCheck.Met -or $hyperVMet) {
 
 ## 49. PowerShell Get-ChildItem Misses Dotfiles Without -Force
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** PowerShell (all versions)
 **Issue:** `Get-ChildItem -Filter 'credentials*'` does NOT match `.credentials.json` because dotfiles (files starting with `.`) are treated as hidden on Windows. Without `-Force`, they're invisible. Additionally, the filter `credentials*` doesn't match `.credentials*` — the dot prefix is significant.
 **Diagnosis:** Claude Code auth check reports "not authenticated" despite `~/.claude/.credentials.json` existing and containing valid tokens.
@@ -594,6 +684,8 @@ $dotCredFiles = Get-ChildItem -Path $dir -Filter '.credentials*' -File -Force -E
 **General rule:** Always use `-Force` when searching for config/credential files that might be dotfiles.
 
 ## 50. Winget Exit Code -1978335189 Means Already Installed
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Windows (winget)
 **Issue:** `winget install <id>` returns exit code `-1978335189` (`0x8A150011` = `APPINSTALLER_CLI_ERROR_UPDATE_NOT_APPLICABLE`) when the package is already installed and no upgrade is available. Scripts treating non-zero exit codes as failures incorrectly report these as installation failures.
@@ -615,6 +707,8 @@ if ($exitCode -eq 0) {
 
 ## 51. Winget Installs Update Registry PATH but Current Session Is Stale
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Windows (PowerShell / MSYS)
 **Issue:** When winget installs tools (gh, go, rustup, cmake), they add to the registry `PATH` (`HKLM\...\Environment` or `HKCU\...\Environment`). But the current PowerShell or bash session still has the old `$env:PATH` from process start. Newly installed tools appear as "not found" in the same session.
 **Diagnosis:** Phase 6 verification reports tools as missing immediately after Phase 2 installed them. Restarting the terminal resolves it.
@@ -634,6 +728,8 @@ export PATH="/c/Program Files/GitHub CLI:$PATH"
 
 ## 52. Physical Drive Migration Preserves Old User SID
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Windows 11
 **Issue:** Moving a physical drive from one PC to another preserves the old user's SID on all files and directories. Windows shows security warnings about untrusted files. Applications may fail to read/write files they previously owned. Copying files (via network share or Explorer) creates new ownership; moving/migrating the physical drive does not.
 **Diagnosis:** Windows security popup says "we can't verify who created this file" on files from the migrated drive.
@@ -648,6 +744,8 @@ icacls D:\* /reset /T /C /Q   # Reset ACLs to inherited defaults
 **Gotcha:** `icacls <drive>:\` on the drive root may fail with "un-usable ACL" — use `<drive>:\*` instead to skip the root directory's special system ACLs. Stale symlinks (e.g., old pnpm links) will fail — these are harmless.
 
 ## 53. VS Code CLI Opens Editor Tabs When Stdin Not Redirected
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Windows (PowerShell)
 **Issue:** `Start-Process -FilePath 'code' -RedirectStandardOutput ... -RedirectStandardError ...` (without `-RedirectStandardInput`) still opens `code-stdin-*` editor tabs. VS Code's CLI wrapper inherits the parent process's stdin handle and interprets pending input as a file to open. This happens with `--list-extensions`, `--install-extension`, and any other `code` subcommand.
@@ -670,6 +768,8 @@ $proc = Start-Process -FilePath 'code' `
 
 ## 54. PowerShell param() Must Be First Executable Statement
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** PowerShell 7+
 **Issue:** `Set-StrictMode -Version Latest` placed before `param()` causes: "The function or command was called as if it were a method. Parameters should be separated by spaces." Only comments and `#Requires` directives are allowed before `param()`.
 **Diagnosis:** Script fails on first invocation with a confusing error message that doesn't mention `param()` at all.
@@ -690,6 +790,8 @@ Set-StrictMode -Version Latest  # Must come AFTER param()
 **Note:** This is a PowerShell language requirement, not a style preference. The parser treats the script block differently when `param()` is not the first statement.
 
 ## 55. VS 2022 Bundled Node.js as Fallback for Frontend Builds
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Windows (MSYS_NT)
 **Issue:** Node.js, npm, and pnpm may not be on the system PATH or MSYS PATH, but Visual Studio 2022 bundles Node.js v20.x at `C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VisualStudio\NodeJs\`. Running commands via `cmd.exe` from MSYS swallows output; `\$env:PATH` escaping breaks in bash heredocs.
@@ -712,6 +814,8 @@ powershell.exe -NoProfile -File /tmp/frontend-cmd.ps1 2>&1
 - `npx pnpm` downloads pnpm on the fly but pnpm then needs `node` on PATH -- set PATH before the npx call
 
 ## 56. Subagent pnpm-lock.yaml Drift When Node.js Unavailable
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Claude Code (Windows)
 **Issue:** When a subagent adds npm dependencies to `package.json` but cannot run `pnpm install` because Node.js/pnpm aren't on PATH, CI fails with `ERR_PNPM_OUTDATED_LOCKFILE Cannot install with "frozen-lockfile"`. The agent's changes are correct but incomplete.
@@ -737,6 +841,8 @@ grep -c "x-enum-descriptions" api/swagger/*
 ```
 
 ## 58. Local Main Diverges After Squash-Merge When Merge Commits Exist
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Git (all)
 **Issue:** If local `main` has merge commits (e.g., from `git pull` without `--ff-only`), squash-merging a PR on GitHub creates a new commit on `origin/main` that isn't an ancestor of local `main`. `git pull --ff-only` then fails with "Not possible to fast-forward, aborting" because the histories diverged.
@@ -793,6 +899,8 @@ go run github.com/swaggo/swag/cmd/swag@v1.16.4 init -g cmd/app/main.go -o api/sw
 
 ## 61. Claude Code settings.local.json Does NOT Cascade from Parent Directories
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Claude Code (all)
 **Issue:** Unlike `.editorconfig` which walks up directories, Claude Code `settings.local.json` and `settings.json` do NOT cascade from parent directories. `D:\DevSpace\.claude\settings.local.json` does NOT apply to `D:\DevSpace\ProjectA\`. Each project is an independent scope.
 **Impact:** Every new project requires manually approving every tool use, even when broad permissions exist in a parent directory.
@@ -807,6 +915,8 @@ Permission arrays **merge** across scopes. Deny rules take precedence.
 **Prevention:** When scaffolding new projects, copy `project-templates/settings.json` to `<project>/.claude/settings.json`. See DevKit issue #131 and [Settings Strategy](../docs/settings-strategy.md).
 
 ## 62. Windows CRLF Breaks Bash grep Value Extraction in CI
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** GitHub Actions (Ubuntu runners) / Windows-committed files
 **Issue:** Files committed from Windows have `\r\n` line endings. When a CI bash script uses `grep -oP` to extract values (e.g., status fields from markdown metadata), the extracted string includes a trailing `\r`. This causes: (1) string comparisons to fail silently (`"active\r" != "active"`), (2) arithmetic expressions to fail with `syntax error in expression (error token is "0")` when `grep -cP` returns `"77\r"`, and (3) `::error` annotations to display split across two lines.
@@ -825,6 +935,8 @@ rm -f "$clean_file"
 
 ## 63. Lipgloss Emoji Variation Selector Width Mismatch
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Go (charmbracelet/lipgloss, all terminals)
 **Issue:** Emoji with variation selector U+FE0F (e.g., U+2328+FE0F `⌨️`) renders as 2 cells wide in terminals, but lipgloss counts U+2328 (Misc Technical block) as 1 cell. This causes a 1-character width discrepancy on any line containing the emoji, pushing content past the border and creating a stray disconnected right border bar.
 **Diagnosis:** A vertical `│` appears detached to the right of the panel border, at the same row as the mismatched emoji.
@@ -842,6 +954,8 @@ rm -f "$clean_file"
 
 ## 64. lipgloss.Place Output Is Not Safely ANSI-Strippable
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Go (charmbracelet/lipgloss)
 **Issue:** `lipgloss.Place(w, h, Center, Center, panel)` produces a full-terminal output with ANSI styling, borders rendered as box-drawing characters, and space-based centering. Stripping ANSI codes from this output to get "plain text positions" fails because: (1) lipgloss's internal width calculations account for styled content widths that change after stripping, (2) border characters become depositable content (not just chrome), and (3) emoji width mismatches compound across styled vs plain rendering.
 **Diagnosis:** Transition animation deposits characters (including border chars) at wrong positions. The revealed text doesn't align with the real View() when it takes over.
@@ -857,6 +971,8 @@ menuText := m.menu.TransitionText()
 
 ## 65. golangci-lint v2 Silent Config Failure Without version Field
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Go (all)
 **Issue:** `.golangci.yml` files written for golangci-lint v1 lack the `version: "2"` field required by v2. Running golangci-lint v2 with a v1 config produces `Error: can't load config: unsupported version of the configuration: ""` and exits non-zero. This only manifests when running golangci-lint itself -- `go build` and `go test` pass fine, so the issue isn't caught until CI or a pre-push hook runs linting.
 **Diagnosis:** Linting step fails but build and test steps pass. Error message mentions "unsupported version" but doesn't suggest the fix.
@@ -864,6 +980,8 @@ menuText := m.menu.TransitionText()
 **Prevention:** Use the devkit template `project-templates/golangci.yml` which includes the version field. Pin the golangci-lint version in CI with `version: v2.10.1` instead of `version: latest`.
 
 ## 66. golangci-lint-action v7 Runs config verify (Schema Enforcement)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** GitHub Actions (all)
 **Issue:** `golangci-lint-action@v7` runs `golangci-lint config verify` before linting, which enforces strict JSON schema on `.golangci.yml`. Action v6 did NOT do this. Config keys that worked with v6 fail with `additional properties '<key>' not allowed` on v7. Known schema changes between v2.1 and v2.10: top-level `linters-settings:` moved under `linters:` as `settings:`, and `issues: exclude-rules:` moved to `linters: exclusions: rules:`.
@@ -896,6 +1014,8 @@ linters:
 
 ## 67. Agent-Generated Markdown Tables: Pipes in Cells and Missing Columns
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** All (markdownlint)
 **Issue:** Subagent-generated markdown tables have two common MD056 (table-column-count) errors: (1) pipe characters `|` inside code spans in table cells are interpreted as column separators, creating extra columns; (2) agents sometimes omit columns when cell content is wide, generating 2-column rows in 3-column tables.
 **Diagnosis:** `markdownlint` reports MD056 with "Expected: N columns, found: M columns" on specific table rows.
@@ -903,6 +1023,8 @@ linters:
 **Prevention:** Include in markdown agent checklist: "Verify all table rows have the same number of columns. Do not use pipe characters inside table cells."
 
 ## 68. Proxmox Installer Injects noapic Which Blocks IOMMU
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Proxmox VE (all versions)
 **Issue:** The Proxmox installer writes `noapic` to `/etc/default/grub.d/installer.cfg` which is silently appended to `GRUB_CMDLINE_LINUX`. This blocks IOMMU even when `intel_iommu=on iommu=pt` is correctly set in `/etc/default/grub`. The main grub file looks clean, so you don't suspect a drop-in config.
@@ -921,6 +1043,8 @@ update-grub && reboot
 
 ## 69. Proxmox VM Re-Boots Into ISO Installer After Guest OS Install
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Proxmox VE (QEMU/KVM)
 **Issue:** After a guest OS (Ubuntu, Debian) finishes installing in a Proxmox VM, clicking "Reboot" in the installer boots back into the ISO installer instead of the installed OS. The ISO is still attached to ide2 and has higher boot priority.
 **Fix:** Detach the ISO and set boot order to the installed disk:
@@ -932,6 +1056,8 @@ qm reboot <vmid>
 
 ## 70. Ubuntu Point Release URLs 404 When Superseded
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Ubuntu / Proxmox ISO downloads
 **Issue:** Ubuntu ISO download URLs include the point release version (e.g., `ubuntu-24.04.2-live-server-amd64.iso`). When a newer point release ships (24.04.4), the old URL returns 404. Proxmox `wget` commands referencing the old version fail silently or with a cryptic error.
 **Fix:** Check the current filename before downloading:
@@ -941,6 +1067,8 @@ curl -s https://releases.ubuntu.com/24.04/ | grep -oP 'ubuntu-24\.04\.\d+-live-s
 ```
 
 ## 71. NVIDIA Driver Package Names Vary by Ubuntu PPA
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Ubuntu (Proxmox VMs)
 **Issue:** `apt install nvidia-driver-560` may fail with "package not found" because the exact driver version depends on which PPA is enabled and the Ubuntu release. The `ppa:graphics-drivers/ppa` PPA has newer versions than the default repos.
@@ -954,6 +1082,8 @@ apt-cache search nvidia-driver | grep -E '^nvidia-driver-[0-9]' | sort -t- -k3 -
 ```
 
 ## 72. ESLint react-hooks/set-state-in-effect Cannot Be Inline-Disabled
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** React / ESLint (eslint-plugin-react-hooks v7+)
 **Issue:** The `react-hooks/set-state-in-effect` rule does NOT support `// eslint-disable-next-line` inline comments. Adding the directive produces "Unused eslint-disable directive" while the underlying error persists. This is unusual -- most ESLint rules support inline disable.
@@ -970,11 +1100,15 @@ rules: {
 
 ## 73. ESLint 10 Breaks react-hooks Plugin Peer Dependency
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** npm / React ecosystem
 **Issue:** Running `npm install eslint` without version pinning pulls ESLint 10.x. `eslint-plugin-react-hooks` (v7.x as of 2026-02) requires `eslint@^9` as a peer dependency. The install succeeds but lint commands fail with peer dependency warnings or crashes.
 **Fix:** Pin ESLint to v9: `npm install --save-dev eslint@^9 @eslint/js@^9`. Check peer requirements of all ESLint plugins before installing.
 
 ## 74. gh repo edit Lacks --disable-* Flags
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** GitHub CLI (gh)
 **Issue:** `gh repo edit` has `--enable-squash-merge`, `--enable-discussions`, etc. but does NOT have `--disable-merge-commit`, `--disable-rebase-merge`, or `--disable-wiki`. Running with `--disable-*` flags gives "unknown flag" errors.
@@ -996,11 +1130,15 @@ gh api repos/{owner}/{repo}/private-vulnerability-reporting -X PUT
 
 ## 75. Branch Protection Requires Pre-Existing CI Check Names
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** GitHub
 **Issue:** `required_status_checks.contexts` in branch protection must reference job names that have already appeared in at least one CI run on the repo. Setting protection before the CI workflow runs with those job names causes all PRs to be blocked with "Expected — Waiting for status to be reported."
 **Fix:** Merge the CI workflow PR first, verify the job names appear in the Actions tab, THEN apply branch protection. This creates a dependency ordering: CI config must ship before protection can reference it.
 
 ## 76. go build Compiles Untracked Files in Working Tree
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Go (all)
 **Issue:** `go build ./...` compiles ALL `.go` files in the module directory tree, including untracked files. When parallel agents create files for different branches (gotcha #25), untracked files from Agent B can reference symbols that only exist on Agent A's branch. Pre-push hooks running `go build` fail with "undefined" errors even though the committed code on the current branch is correct.
@@ -1017,12 +1155,16 @@ git stash pop
 
 ## 77. Docker Hub Shows Extension Images as Regular Containers
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** Docker Hub / Docker Desktop
 **Issue:** Pushing a Docker Desktop Extension image to Docker Hub with correct labels (`com.docker.desktop.extension.api.version`, etc.) does NOT make it appear as an extension on Docker Hub. It shows as a regular container image. Users who `docker pull` or `docker run` it get a container, not an extension.
 **Fix:** The image is correct for `docker extension install` from CLI. To appear in the Docker Desktop Extensions Marketplace, submit via [docker/extensions-submissions](https://github.com/docker/extensions-submissions) repo (open an issue with the automatic_review template). Automated validation runs `docker extension validate`. If it passes, the extension appears in the marketplace within hours (12h cache).
 **Pre-submit:** Run `docker extension validate <image:tag>` locally first. Test light/dark mode, cross-platform. Manual review by Docker is currently paused.
 
 ## 78. hadolint False Positives on Docker Desktop Extension Dockerfiles
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** Docker / hadolint
 **Issue:** Docker Desktop extension Dockerfiles use vendor-specific labels (`com.docker.desktop.extension.*`, `com.docker.extension.*`) and `COPY` without `WORKDIR` as standard patterns. hadolint flags these as DL3048 (invalid label key) and DL3045 (COPY to relative path without WORKDIR), but both are correct for extensions.
@@ -1038,11 +1180,15 @@ ignored:
 
 ## 79. GitHub Secrets UI Is Buried Under Expandable Sidebar
 
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+
 **Platform:** GitHub
 **Issue:** Repository secrets for GitHub Actions are under Settings > Secrets and variables > Actions. The "Secrets and variables" item has a dropdown arrow that must be clicked to expand and reveal the "Actions" submenu. Easy to miss when looking at the Settings sidebar.
 **Fix:** Use CLI instead: `gh secret set SECRETNAME` (prompts for value). `gh secret list` to verify.
 
 ## 80. PowerShell StrictMode Throws on Nonexistent Property Access in Conditionals
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
 **Platform:** PowerShell 7+
 **Issue:** Under `Set-StrictMode -Version Latest`, accessing a property that doesn't exist on a `PSCustomObject` throws `PropertyNotFoundException` -- even inside a boolean conditional like `if (-not $obj.prop)`. The error fires before the `-not` operator evaluates. This breaks backward-compatibility shims that check for a property before adding it (e.g., `if (-not $manifest.shared) { Add-Member ... }`).


### PR DESCRIPTION
## Summary

- Adds `**Added:** / **Source:** / **Status:**` metadata to all 166 entries missing it
- autolearn-patterns.md: 93 entries updated (108 total, all now have metadata)
- known-gotchas.md: 73 entries updated (98 total, all now have metadata)
- Used `2026-02-17` as estimated date, `SubNetree` as source for older entries
- Frontmatter `entry_count` values unchanged

Closes #185

## Test plan

- [ ] CI `validate-rule-metadata` job passes (validates Added line format, dates, status values)
- [ ] Spot-check: every `## N.` heading is followed by an `**Added:**` line

Generated with [Claude Code](https://claude.com/claude-code)