### PR TITLE
feat: standardize Copilot auto-review + contributor gating

### DIFF
--- a/docs/copilot-integration.md
+++ b/docs/copilot-integration.md
@@ -133,6 +133,81 @@ DevKit provides ready-to-copy templates in `project-templates/`:
 | copilot-setup-steps (Fullstack) | `project-templates/copilot-setup-steps-fullstack.yml` | Go + React combined |
 | CodeQL | `project-templates/codeql.yml` | Security scanning workflow |
 
+## Three-Layer Protection Model
+
+All projects use three complementary layers for PR quality:
+
+### Layer 1: Access Control (repo permissions)
+
+Contributors cannot merge -- only the owner has write access. This is the gatekeeper.
+No workflow or ruleset needed; repo permissions handle it.
+
+### Layer 2: CI Status Checks (branch protection)
+
+Branch protection requires CI jobs to pass before merge. Configured via the GitHub API:
+
+```bash
+gh api repos/OWNER/REPO/branches/main/protection -X PUT --input - << 'JSON'
+{
+  "required_status_checks": { "strict": true, "contexts": ["Build", "Lint", "Test"] },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+JSON
+```
+
+Branch protection handles CI checks **only** -- no review requirement here (that's Layer 3).
+Adding a review requirement to branch protection AND the ruleset creates a double gate.
+
+### Layer 3: Copilot Auto-Review (ruleset)
+
+A GitHub ruleset named "Copilot PR Review" handles code review:
+
+- **Owner PRs**: Copilot reviews automatically; auto-merge when CI + Copilot approve (hands-free)
+- **Contributor PRs**: Copilot reviews automatically; owner reviews after Copilot approves; owner merges manually
+- **Admin bypass**: Solo maintainers can merge even if Copilot hasn't reviewed yet
+
+Template: `project-templates/copilot-ruleset.json`
+
+Key settings:
+
+- `required_approving_review_count: 1` -- Copilot satisfies this for owner PRs
+- `dismiss_stale_reviews_on_push: true` -- forces re-review on new pushes
+- `copilot_code_review` with `review_on_push: true` -- triggers review on each push
+- Admin role (RepositoryRole id 5) as bypass actor
+- `allowed_merge_methods: ["squash"]` -- squash-only merge
+
+### Setup and Audit
+
+```bash
+# Set up Copilot auto-review on a repo
+bash scripts/copilot-review-setup.sh setup OWNER/REPO
+
+# Audit a single repo
+bash scripts/copilot-review-setup.sh audit OWNER/REPO
+
+# Audit all repos for an owner
+bash scripts/copilot-review-setup.sh audit-all OWNER
+```
+
+### Manual Steps After Setup
+
+The Copilot auto-review UI toggle cannot be set via API:
+
+1. Go to repo Settings > Rules > Rulesets > "Copilot PR Review"
+2. Click Edit on "Require a pull request before merging"
+3. Under "Additional settings", enable "Require review from GitHub Copilot"
+4. Also enable "Review new pushes" for re-review on each push
+5. Create a test PR with a real file change to verify Copilot reviews it
+
+### Why These Specific Settings
+
+- **`required_approving_review_count: 1`** (not 0 or 2): Copilot's approval counts as the 1 required review for owner PRs. Setting to 0 would skip review entirely. Setting to 2 would block solo maintainers.
+- **Admin bypass**: Required for solo maintainers who need to merge when Copilot is unavailable or reviewing incorrectly.
+- **No review in branch protection**: Branch protection review + ruleset review = double gate. Use rulesets only for reviews, branch protection only for CI checks.
+- **`review_on_push: true`**: Only fires on push events, not open/reopen. Forces re-review when code changes after initial review.
+
 ## Per-Project Rollout Checklist
 
 For each existing project, complete in order:

--- a/project-templates/copilot-ruleset.json
+++ b/project-templates/copilot-ruleset.json
@@ -1,5 +1,5 @@
 {
-  "name": "Copilot Code Review",
+  "name": "Copilot PR Review",
   "enforcement": "active",
   "target": "branch",
   "conditions": {
@@ -8,8 +8,26 @@
       "exclude": []
     }
   },
-  "bypass_actors": [],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
   "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["squash"]
+      }
+    },
     {
       "type": "copilot_code_review",
       "parameters": {

--- a/scripts/copilot-review-setup.sh
+++ b/scripts/copilot-review-setup.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# copilot-review-setup.sh -- Set up or audit Copilot auto-review on a GitHub repo.
+#
+# Usage:
+#   ./scripts/copilot-review-setup.sh audit  OWNER/REPO   # check compliance
+#   ./scripts/copilot-review-setup.sh setup  OWNER/REPO   # create ruleset + enable auto-merge
+#   ./scripts/copilot-review-setup.sh audit-all OWNER      # audit all non-archived repos
+#
+# Requires: gh (GitHub CLI) authenticated with admin access.
+
+ACTION="${1:-}"
+TARGET="${2:-}"
+
+if [[ -z "$ACTION" || -z "$TARGET" ]]; then
+  echo "Usage: $0 {audit|setup|audit-all} OWNER/REPO_OR_OWNER"
+  exit 1
+fi
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+pass() { echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { echo -e "  ${RED}FAIL${NC}: $1"; }
+warn() { echo -e "  ${YELLOW}WARN${NC}: $1"; }
+
+# -------------------------------------------------------------------
+# audit_repo -- check compliance for a single repo
+# -------------------------------------------------------------------
+audit_repo() {
+  local repo="$1"
+  local errors=0
+
+  echo "=== Auditing $repo ==="
+
+  # 1. Auto-merge enabled
+  local auto_merge
+  auto_merge=$(gh api "repos/$repo" --jq '.allow_auto_merge' 2>/dev/null || echo "false")
+  if [[ "$auto_merge" == "true" ]]; then
+    pass "Auto-merge enabled"
+  else
+    fail "Auto-merge not enabled"
+    errors=$((errors + 1))
+  fi
+
+  # 2. Copilot PR Review ruleset exists and is active
+  local ruleset_id=""
+  local ruleset_enforcement=""
+  while IFS=$'\t' read -r rid rname renf; do
+    if [[ "$rname" == "Copilot PR Review" || "$rname" == "Copilot Code Review" ]]; then
+      ruleset_id="$rid"
+      ruleset_enforcement="$renf"
+      break
+    fi
+  done < <(gh api "repos/$repo/rulesets" --jq '.[] | [.id, .name, .enforcement] | @tsv' 2>/dev/null || true)
+
+  if [[ -z "$ruleset_id" ]]; then
+    fail "No Copilot review ruleset found"
+    errors=$((errors + 1))
+  elif [[ "$ruleset_enforcement" != "active" ]]; then
+    fail "Copilot review ruleset exists but enforcement is '$ruleset_enforcement' (expected 'active')"
+    errors=$((errors + 1))
+  else
+    pass "Copilot review ruleset exists and is active (id: $ruleset_id)"
+
+    # 3. Check copilot_code_review rule with review_on_push
+    local has_copilot_review
+    has_copilot_review=$(gh api "repos/$repo/rulesets/$ruleset_id" \
+      --jq '.rules[] | select(.type == "copilot_code_review") | .parameters.review_on_push' 2>/dev/null || echo "")
+    if [[ "$has_copilot_review" == "true" ]]; then
+      pass "copilot_code_review rule with review_on_push: true"
+    else
+      fail "Missing or misconfigured copilot_code_review rule"
+      errors=$((errors + 1))
+    fi
+
+    # 4. Check pull_request rule with required_approving_review_count: 1
+    local review_count
+    review_count=$(gh api "repos/$repo/rulesets/$ruleset_id" \
+      --jq '.rules[] | select(.type == "pull_request") | .parameters.required_approving_review_count' 2>/dev/null || echo "")
+    if [[ "$review_count" == "1" ]]; then
+      pass "pull_request rule with required_approving_review_count: 1"
+    else
+      fail "pull_request rule missing or review count is '$review_count' (expected 1)"
+      errors=$((errors + 1))
+    fi
+
+    # 5. Check admin bypass actor
+    local has_admin_bypass
+    has_admin_bypass=$(gh api "repos/$repo/rulesets/$ruleset_id" \
+      --jq '.bypass_actors[] | select(.actor_id == 5 and .actor_type == "RepositoryRole") | .bypass_mode' 2>/dev/null || echo "")
+    if [[ "$has_admin_bypass" == "always" ]]; then
+      pass "Admin bypass actor configured"
+    else
+      fail "Admin bypass actor missing"
+      errors=$((errors + 1))
+    fi
+  fi
+
+  # 6. Branch protection does NOT have required_pull_request_reviews
+  local bp_reviews
+  bp_reviews=$(gh api "repos/$repo/branches/main/protection/required_pull_request_reviews" \
+    --jq '.required_approving_review_count' 2>/dev/null || echo "none")
+  if [[ "$bp_reviews" == "none" ]]; then
+    pass "Branch protection has no review requirement (avoids double review gate)"
+  else
+    warn "Branch protection has review requirement ($bp_reviews reviews) -- may conflict with ruleset"
+    errors=$((errors + 1))
+  fi
+
+  # 7. CODEOWNERS file exists
+  local has_codeowners="false"
+  for path in CODEOWNERS .github/CODEOWNERS docs/CODEOWNERS; do
+    if gh api "repos/$repo/contents/$path" --jq '.name' >/dev/null 2>&1; then
+      has_codeowners="true"
+      break
+    fi
+  done
+  if [[ "$has_codeowners" == "true" ]]; then
+    pass "CODEOWNERS file exists"
+  else
+    fail "CODEOWNERS file not found"
+    errors=$((errors + 1))
+  fi
+
+  echo ""
+  if [[ "$errors" -eq 0 ]]; then
+    echo -e "  ${GREEN}All checks passed${NC}"
+  else
+    echo -e "  ${RED}$errors check(s) failed${NC}"
+  fi
+  echo ""
+
+  return "$errors"
+}
+
+# -------------------------------------------------------------------
+# setup_repo -- create ruleset and enable auto-merge
+# -------------------------------------------------------------------
+setup_repo() {
+  local repo="$1"
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local template="$script_dir/../project-templates/copilot-ruleset.json"
+
+  echo "=== Setting up Copilot auto-review on $repo ==="
+
+  # Enable auto-merge
+  echo "Enabling auto-merge..."
+  gh api "repos/$repo" -X PATCH -f allow_auto_merge=true --silent
+  pass "Auto-merge enabled"
+
+  # Create ruleset from template
+  echo "Creating Copilot PR Review ruleset..."
+  if gh api "repos/$repo/rulesets" -X POST --input "$template" --silent 2>/dev/null; then
+    pass "Ruleset created"
+  else
+    warn "Ruleset creation failed (may already exist)"
+  fi
+
+  echo ""
+  echo -e "${YELLOW}MANUAL STEPS REQUIRED:${NC}"
+  echo "1. Go to repo Settings > Rules > Rulesets > 'Copilot PR Review'"
+  echo "2. Click Edit on the 'Require a pull request before merging' rule"
+  echo "3. Under 'Additional settings', enable 'Require review from GitHub Copilot'"
+  echo "   (This toggle is UI-only -- the API creates the copilot_code_review rule"
+  echo "    but the UI toggle may need to be confirmed)"
+  echo "4. Verify: Create a test PR with a real file change, confirm Copilot reviews it"
+  echo ""
+
+  # Run audit to verify
+  echo "Running compliance audit..."
+  audit_repo "$repo" || true
+}
+
+# -------------------------------------------------------------------
+# main
+# -------------------------------------------------------------------
+case "$ACTION" in
+  audit)
+    audit_repo "$TARGET"
+    ;;
+  setup)
+    setup_repo "$TARGET"
+    ;;
+  audit-all)
+    OWNER="$TARGET"
+    total=0
+    compliant=0
+    repos=$(gh repo list "$OWNER" --json name,isArchived --jq '.[] | select(.isArchived == false) | .name' | sort)
+    for repo_name in $repos; do
+      if audit_repo "$OWNER/$repo_name"; then
+        compliant=$((compliant + 1))
+      fi
+      total=$((total + 1))
+    done
+    echo "=== Summary: $compliant/$total repos compliant ==="
+    ;;
+  *)
+    echo "Unknown action: $ACTION"
+    echo "Usage: $0 {audit|setup|audit-all} OWNER/REPO_OR_OWNER"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Updated `copilot-ruleset.json` to combine PR review (1 required) + Copilot review + admin bypass + squash-only
- Added `scripts/copilot-review-setup.sh` with `audit`, `setup`, and `audit-all` modes
- Documented three-layer protection model in `docs/copilot-integration.md`

The setup script creates the ruleset and enables auto-merge. The audit script checks 7 compliance criteria per repo. `audit-all` scans all non-archived repos for an owner.

Closes #194

## Test plan

- [ ] `python -c "import json; json.load(open('project-templates/copilot-ruleset.json'))"` passes
- [ ] `docs/copilot-integration.md` passes markdownlint
- [ ] `bash scripts/copilot-review-setup.sh audit HerbHall/Runbooks` reports all checks passing
- [ ] Cross-project rollout issues created (see below)

Generated with [Claude Code](https://claude.com/claude-code)