### PR TITLE
fix: prevent silent stall when skills trigger on pasted input

### DIFF
--- a/claude/skills/autolearn/SKILL.md
+++ b/claude/skills/autolearn/SKILL.md
@@ -78,7 +78,9 @@ Type a number, keyword, or **skip** to dismiss.
 | 4, "skill improvement", "improve skills", "improve agents" | workflows/skill-improvement.md |
 | 5, "audit rules", "rules health", "stale rules" | workflows/audit-rules.md |
 
-If the input does not clearly match any option above, respond:
+If the user types **skip** or **dismiss**, briefly confirm cancellation (e.g., "reflect cancelled.") and end the skill without running any workflow.
+
+If the input does not clearly match any option above and is not "skip" or "dismiss", respond:
 "reflect was triggered but your input didn't match a workflow. Options: 1-5 (listed above). Type **skip** to dismiss."
 
 **After reading the workflow, follow it exactly.**

--- a/claude/skills/conformance-audit/SKILL.md
+++ b/claude/skills/conformance-audit/SKILL.md
@@ -40,7 +40,9 @@ Type a number, project name, or **skip** to dismiss.
 | 2, "single project", "check project", a project name | workflows/single-project.md |
 | 3, "fix gaps", "remediate", "apply fixes", "scaffold" | workflows/fix-gaps.md |
 
-If the input does not clearly match any option above, respond:
+If the user types **skip** or **dismiss**, briefly confirm cancellation (e.g., "conformance-audit cancelled.") and end the skill without running any workflow.
+
+If the input does not clearly match any option above and is not "skip" or "dismiss", respond:
 "conformance-audit was triggered but your input didn't match a workflow. Options: 1-3 (listed above). Type **skip** to dismiss."
 
 **After reading the workflow, follow it exactly.**

--- a/claude/skills/devkit-sync/SKILL.md
+++ b/claude/skills/devkit-sync/SKILL.md
@@ -56,7 +56,9 @@ Type a number, keyword, or **skip** to dismiss.
 | 11, "new project", "scaffold project", "create project" | workflows/new-project.md |
 | 12, "audit settings", "settings cleanup", "redundant permissions" | workflows/audit-settings.md |
 
-If the input does not clearly match any option above, respond:
+If the user types **skip** or **dismiss**, briefly confirm cancellation (e.g., "devkit-sync cancelled.") and end the skill without running any workflow.
+
+If the input does not clearly match any option above and is not "skip" or "dismiss", respond:
 "devkit-sync was triggered but your input didn't match a workflow. Options: 1-12 (listed above). Type **skip** to dismiss."
 
 **After reading the workflow, follow it exactly.**

--- a/claude/skills/manage-github-issues/SKILL.md
+++ b/claude/skills/manage-github-issues/SKILL.md
@@ -101,7 +101,9 @@ Type a number, keyword, or **skip** to dismiss.
 | 2, "audit issues", "review issues", "find gaps" | workflows/audit-issues.md |
 | 3, "triage issues", "prioritize issues", "sort backlog" | workflows/triage-and-prioritize.md |
 
-If the input does not clearly match any option above, respond:
+If the user types **skip** or **dismiss**, briefly confirm cancellation (e.g., "manage-github-issues cancelled.") and end the skill without running any workflow.
+
+If the input does not clearly match any option above and is not "skip" or "dismiss", respond:
 "manage-github-issues was triggered but your input didn't match a workflow. Options: 1-3 (listed above). Type **skip** to dismiss."
 
 **After reading the workflow, follow it exactly.**

--- a/claude/skills/quality-control/SKILL.md
+++ b/claude/skills/quality-control/SKILL.md
@@ -149,7 +149,9 @@ Type a number, keyword, or **skip** to dismiss.
 | 6, "pre-release", "release check", "before tag", "release ready" | workflows/pre-release-check.md |
 | 7, "file QC issues", "QC findings", "bugs found" | workflows/file-qc-issues.md |
 
-If the input does not clearly match any option above, respond:
+If the user types **skip** or **dismiss**, briefly confirm cancellation (e.g., "quality-control cancelled.") and end the skill without running any workflow.
+
+If the input does not clearly match any option above and is not "skip" or "dismiss", respond:
 "quality-control was triggered but your input didn't match a workflow. Options: 1-7 (listed above). Type **skip** to dismiss."
 
 **After reading the workflow, follow it exactly.**

--- a/claude/skills/requirements-generator/SKILL.md
+++ b/claude/skills/requirements-generator/SKILL.md
@@ -62,7 +62,9 @@ Type a number, keyword, or **skip** to dismiss.
 | 2, "update requirements", "modify requirements", "change requirements" | workflows/update-requirements.md |
 | 3, "review requirements", "audit requirements", "check requirements" | workflows/review-requirements.md |
 
-If the input does not clearly match any option above, respond:
+If the user types **skip** or **dismiss**, briefly confirm cancellation (e.g., "requirements-generator cancelled.") and end the skill without running any workflow.
+
+If the input does not clearly match any option above and is not "skip" or "dismiss", respond:
 "requirements-generator was triggered but your input didn't match a workflow. Options: 1-3 (listed above). Type **skip** to dismiss."
 
 **After reading the workflow, follow it exactly.**


### PR DESCRIPTION
## Summary

- Fixes silent stall bug where menu-based skills triggered on incidental keyword matches in pasted multi-line input, then blocked waiting for a menu selection with no visible output
- Applies 4 fixes across all 6 affected skills:
  1. **Visible acknowledgment** -- skill name shown immediately on trigger
  2. **Skip/dismiss escape** -- user can type `skip` to cancel unintentional triggers
  3. **Fallback response** -- unmatched input gets an explanatory message instead of silence
  4. **Tightened keywords** -- routing keywords changed from single words (`"check"`, `"fix"`, `"new"`) to compound phrases (`"check PR"`, `"fix CI"`, `"new project"`) to reduce false matches

## Affected skills

| Skill | Had explicit "Wait" | Keyword tightening examples |
|-------|--------------------|-----------------------------|
| quality-control | Yes | `"check"` → `"check PR"`, `"fix"` → `"fix CI"` |
| manage-github-issues | Yes | `"create"` → `"create issues"`, `"check"` → removed |
| autolearn (reflect) | Yes | `"fix"` → removed, `"rules"` → `"audit rules"` |
| requirements-generator | Yes | `"new"` → `"new requirements"`, `"check"` → `"check requirements"` |
| conformance-audit | No (but broad keywords) | `"check"` → `"check project"`, `"fix"` → `"fix gaps"` |
| devkit-sync | No (but broad keywords) | `"push"` → `"sync push"`, `"new"` → `"new project"` |

**Not affected:** plan-review (procedural, no menu/routing table)

## Test plan

- [ ] Paste a multi-line handoff into CC -- should not silently stall
- [ ] If a skill fires unexpectedly, user sees `"X triggered."` and can type `skip`
- [ ] `npx markdownlint-cli2` passes on all 6 files (verified: 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)