### PR TITLE
chore: add rules-compact and conformance-audit skills to sync manifest

### DIFF
--- a/.sync-manifest.json
+++ b/.sync-manifest.json
@@ -39,7 +39,9 @@
         "claude/skills/webapp-testing",
         "claude/skills/windows-development",
         "claude/skills/code-review",
-        "claude/skills/plan-review"
+        "claude/skills/plan-review",
+        "claude/skills/conformance-audit",
+        "claude/skills/rules-compact"
       ],
       "agents": [
         "claude/agents/go-test-writer.md",


### PR DESCRIPTION
## Summary

- Add `claude/skills/rules-compact` to `.sync-manifest.json` universal skills
- Add `claude/skills/conformance-audit` to `.sync-manifest.json` universal skills (was also missing)

Both skills exist in the repo but were not listed in the sync manifest, so they wouldn't be symlinked to `~/.claude/skills/` on sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)