### PR TITLE
fix: devkit-sync push auto-creates PR after git push

### DIFF
--- a/claude/skills/devkit-sync/workflows/push.md
+++ b/claude/skills/devkit-sync/workflows/push.md
@@ -1,6 +1,14 @@
 # DevKit Sync: Push
 
-Commit and push local DevKit changes, create or update a PR.
+Commit and push local DevKit changes, then automatically create or update a PR. No separate human instruction is needed for PR creation -- it happens as part of the push flow.
+
+## Prerequisites
+
+Source the forge abstraction wrappers before running any forge commands:
+
+```bash
+source "$(git -C <devkit> rev-parse --show-toplevel)/scripts/forge-wrappers.sh"
+```
 
 ## Steps
 
@@ -39,25 +47,28 @@ Commit and push local DevKit changes, create or update a PR.
 
    If the branch doesn't exist remotely, this creates it.
 
-6. **Create or update PR:**
+6. **Create or update PR (automatic -- no confirmation needed):**
 
    ```bash
-   # Check if PR already exists
-   gh pr list -R HerbHall/devkit --head sync/<machine-id> --json number,url
+   # Check if PR already exists for this branch
+   devkit-pr-list --head sync/<machine-id> --json number,url
 
-   # If no PR exists, create one
-   gh pr create -R HerbHall/devkit \
-     --head sync/<machine-id> \
+   # If no PR exists, create one with issue references
+   devkit-pr-create \
      --title "chore(sync): <machine-id> learnings" \
-     --body "Auto-synced DevKit changes from <machine-id>."
+     --body "Auto-synced DevKit changes from <machine-id>." \
+     --head "sync/<machine-id>"
    ```
 
-   If PR already exists, the push updates it automatically.
+   If PR already exists, the push updates it automatically -- skip creation.
 
-7. **Report** the PR URL to the user.
+   For feature branches (not sync branches), derive the PR title from the conventional commit on HEAD and add `Closes #NNN` references extracted from the branch name (e.g., `feature/issue-42-foo` yields `Closes #42`).
+
+7. **Report** the PR URL to the user. CI and Copilot auto-review take it from here.
 
 ## Edge Cases
 
 - No `.machine-id`: prompt user to run `/devkit-sync init` first
 - Push fails (auth/network): report error, suggest manual resolution
 - Conflicting remote changes: suggest `/devkit-sync pull` first
+- Forge wrappers not found: fall back to `gh` directly with a warning


### PR DESCRIPTION
## Summary

- Update `push.md` workflow to automatically create PRs using forge wrappers (`devkit-pr-list`, `devkit-pr-create`) instead of calling `gh` directly
- PR creation is now automatic after `git push` -- no separate human instruction needed
- Feature branches derive PR title from HEAD conventional commit and extract `Closes #NNN` references from the branch name
- Add fallback edge case for when forge wrappers are not found
- Add prerequisite section to source `scripts/forge-wrappers.sh`

**Dependency:** Requires #213 (forge wrappers) to merge first.

## Test plan

- [x] `npx markdownlint-cli2 claude/skills/devkit-sync/workflows/push.md` -- 0 errors
- [ ] After #213 merges: verify `/devkit-sync push` creates PR automatically

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)