### PR TITLE
fix: replace static skills array with dynamic discovery (#221)

### DIFF
--- a/.sync-manifest.json
+++ b/.sync-manifest.json
@@ -21,28 +21,7 @@
         "claude/rules/subagent-ci-checklist.md",
         "claude/rules/workflow-preferences.md"
       ],
-      "skills": [
-        "claude/skills/autolearn",
-        "claude/skills/bash-linux",
-        "claude/skills/devkit-sync",
-        "claude/skills/docker-containerization",
-        "claude/skills/go-development",
-        "claude/skills/manage-github-issues",
-        "claude/skills/powershell-windows",
-        "claude/skills/quality-control",
-        "claude/skills/react-frontend-development",
-        "claude/skills/requirements-generator",
-        "claude/skills/security-review",
-        "claude/skills/server-management",
-        "claude/skills/setup-github-actions",
-        "claude/skills/systematic-debugging",
-        "claude/skills/webapp-testing",
-        "claude/skills/windows-development",
-        "claude/skills/code-review",
-        "claude/skills/plan-review",
-        "claude/skills/conformance-audit",
-        "claude/skills/rules-compact"
-      ],
+      "skills": "auto-discover",
       "agents": [
         "claude/agents/go-test-writer.md",
         "claude/agents/plan-reviewer.md",
@@ -61,6 +40,7 @@
         "devspace/",
         "machine/",
         "docs/",
+        "scripts/",
         "METHODOLOGY.md"
       ]
     },

--- a/setup/sync.ps1
+++ b/setup/sync.ps1
@@ -250,7 +250,19 @@ function Get-LinkPairs {
     }
 
     # Skill directories (directory symlinks)
-    foreach ($skillPath in $Manifest.shared.skills) {
+    # Support both static array and "auto-discover" mode
+    $skillEntries = $Manifest.shared.skills
+    if ($skillEntries -eq 'auto-discover') {
+        $skillsDir = Join-Path $DevKit 'claude' 'skills'
+        if (Test-Path $skillsDir) {
+            $skillEntries = Get-ChildItem -Path $skillsDir -Directory |
+                ForEach-Object { "claude/skills/$($_.Name)" }
+        }
+        else {
+            $skillEntries = @()
+        }
+    }
+    foreach ($skillPath in $skillEntries) {
         $targetPath = Join-Path $DevKit $skillPath
         $claudeRelative = $skillPath -replace '^claude/', ''
         $linkPath = Join-Path $ClaudeHome $claudeRelative


### PR DESCRIPTION
## Summary

- Replaces the static `skills` array in `.sync-manifest.json` with `"auto-discover"` — `sync.ps1` now enumerates all directories under `claude/skills/` at runtime
- Adding a new skill directory requires zero manifest updates
- Adds `scripts/` to the `reference` section (forge-wrappers.sh was missing)
- Backward compatible: static arrays still work if provided

## Test plan

- [ ] Run `setup/sync.ps1 -Link` — all 20 skills should be linked
- [ ] Create a test directory under `claude/skills/test-skill/`, run `-Link` again — should show `Linked: 1`
- [ ] Remove test directory, run `-Link` — no errors

Closes #221

Generated with [Claude Code](https://claude.com/claude-code)