### PR TITLE
fix: rename /reflect to /autolearn for consistency (#214)

### DIFF
--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -206,7 +206,7 @@ This project is NOT worth pursuing if:
 1. Write/update README
 2. Create GitHub release with changelog
 3. Submit to relevant lists/directories (if applicable)
-4. Run `/reflect` (session review) to capture all learnings
+4. Run `/autolearn` (session review) to capture all learnings
 5. Update devkit repo if new patterns or skills were created
 
 **Gate**: Is the README honest about what's shipped? Are the learnings captured? Ship it.
@@ -252,7 +252,7 @@ IPScan is the cautionary example: a network scanner that grew into a full monito
 
 ```text
 Session work
-  → /reflect captures learnings
+  → /autolearn captures learnings
     → MCP Memory (deep store, searchable)
     → Tier 2 rules files (fast path, auto-loaded)
     → DevKit issues for Tier 1 changes
@@ -264,7 +264,7 @@ Session work
 Projects discover improvements through daily work. Changes flow to
 DevKit through issues, not direct file edits:
 
-1. **During project work**: `/reflect` stores learnings in MCP Memory
+1. **During project work**: `/autolearn` stores learnings in MCP Memory
    and Tier 2 rules files (patterns, gotchas). For Tier 1 changes
    (workflow preferences, review policy), it creates DevKit issues.
 2. **During DevKit work**: Address accumulated issues, validate
@@ -309,7 +309,7 @@ The methodology should evolve. Version 1 is a starting point, not a final answer
 | Plan review (before implementation) | `/plan-review` skill | Manual review |
 | Code review (before commit) | `/code-review` skill | PR review plugins |
 | Full code review + security | `/quality-control` skill | PR review plugins |
-| Learning capture | `/reflect` (autolearn) | Manual rules file update |
+| Learning capture | `/autolearn` | Manual rules file update |
 | Competitive research | `gh api` + blog aggregation | Project-specific `/research-mode` skill |
 
 > **Windows users**: See known-gotchas.md #42-44 before using BMAD or Spec Kit.

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -74,7 +74,7 @@ When spawning subagents, include the [CORE] block from
 
 ## Autolearn
 
-Proactively suggest the user run `/reflect` when any of these occur:
+Proactively suggest the user run `/autolearn` when any of these occur:
 
 - You corrected a mistake or changed approach mid-task
 - A platform-specific gotcha or environment issue was encountered
@@ -83,8 +83,8 @@ Proactively suggest the user run `/reflect` when any of these occur:
 - Before the user ends a productive session
 
 Keep the suggestion brief and specific:
-"Tip: run `/reflect` to capture [what was learned]."
-Do NOT run /reflect automatically -- always let the user trigger it.
+"Tip: run `/autolearn` to capture [what was learned]."
+Do NOT run /autolearn automatically -- always let the user trigger it.
 
 ## Environment
 

--- a/claude/rules/archive/README.md
+++ b/claude/rules/archive/README.md
@@ -25,7 +25,7 @@ An entry should be archived when:
 
 - It is marked `**Status:** deprecated` (no longer applicable)
 - It is marked `**Status:** superseded-by-XX#NN` (replaced by another entry)
-- The `/reflect audit` workflow recommends archival and the user approves
+- The `/autolearn audit` workflow recommends archival and the user approves
 
 ## Reference
 

--- a/claude/rules/workflow-preferences.md
+++ b/claude/rules/workflow-preferences.md
@@ -118,7 +118,7 @@ Once found, always fix, never leave. Every error is an opportunity to improve th
 
 - No "pre-existing" bypass -- all errors get fixed or tracked with an issue immediately
 - Every error triggers a systemic assessment: why didn't our rules prevent this?
-- Learnings feed back to DevKit via `/reflect` for all-project benefit
+- Learnings feed back to DevKit via `/autolearn` for all-project benefit
 - Agents own every error they find, regardless of who introduced it
 
 ## 14. Mandatory Subagent Checklists
@@ -139,7 +139,7 @@ After fixing errors or discovering patterns, assess abstraction level:
 - Stack-specific (Go, React, etc.): promote to DevKit stack rules
 - Universal development principle: promote to DevKit core rules
 - Template-worthy: update project templates so future projects inherit it
-- Run `/reflect` to capture and propose promotion
+- Run `/autolearn` to capture and propose promotion
 
 ## 16. Cross-Project Boundary: Issues Not Edits
 

--- a/claude/skills/autolearn/SKILL.md
+++ b/claude/skills/autolearn/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reflect
+name: autolearn
 description: Reflect on the current session to extract learnings, update knowledge, and improve skills.
 user_invocable: true
 ---

--- a/claude/skills/autolearn/references/learning-categories.md
+++ b/claude/skills/autolearn/references/learning-categories.md
@@ -86,7 +86,7 @@ User workflow and style preferences. These ensure consistency across sessions.
 
 ## Priority Matrix
 
-| Category | Store in Memory? | Store in Rules? | Auto-detect? | Manual /reflect? |
+| Category | Store in Memory? | Store in Rules? | Auto-detect? | Manual /autolearn? |
 |----------|-----------------|----------------|-------------|-----------------|
 | Correction | Yes | Yes (patterns) | Yes (Stop hook) | Yes |
 | Pattern | Yes | Yes (patterns) | Sometimes | Yes |

--- a/claude/skills/autolearn/workflows/update-knowledge.md
+++ b/claude/skills/autolearn/workflows/update-knowledge.md
@@ -17,9 +17,9 @@ Check if the current working directory is the DevKit repo:
 This workflow writes directly to rules files and must run in the DevKit repo.
 
 To promote learnings from this project:
-1. Run `/reflect` (quick or session review) -- learnings go to MCP Memory
+1. Run `/autolearn` (quick or session review) -- learnings go to MCP Memory
 2. Universal learnings are filed as DevKit issues automatically
-3. In a DevKit session, run `/reflect` with "update knowledge" to merge them
+3. In a DevKit session, run `/autolearn` with "update knowledge" to merge them
 ```
 
 ### 1. Read Current Rules Files

--- a/claude/skills/devkit-sync/SKILL.md
+++ b/claude/skills/devkit-sync/SKILL.md
@@ -6,7 +6,7 @@ user_invocable: true
 
 # DevKit Sync
 
-Manual control for DevKit multi-machine synchronization. While auto-pull (SessionStart) and auto-push (/reflect) handle routine sync, this skill provides manual operations for setup, forced sync, conflict resolution, and portable snapshots.
+Manual control for DevKit multi-machine synchronization. While auto-pull (SessionStart) and auto-push (/autolearn) handle routine sync, this skill provides manual operations for setup, forced sync, conflict resolution, and portable snapshots.
 
 <essential_principles>
 

--- a/docs/ADR-0011-sync-architecture.md
+++ b/docs/ADR-0011-sync-architecture.md
@@ -14,7 +14,7 @@ DevKit stores Claude Code configuration (rules, skills, agents, hooks) in a git-
 
 This created a **drift problem** on multiple levels:
 
-- **Invisible edits**: Changes to `~/.claude/rules/autolearn-patterns.md` during a session (via `/reflect` or manual edits) were invisible to `git diff` in the DevKit clone. The user had to remember to copy files back.
+- **Invisible edits**: Changes to `~/.claude/rules/autolearn-patterns.md` during a session (via `/autolearn` or manual edits) were invisible to `git diff` in the DevKit clone. The user had to remember to copy files back.
 - **Multi-machine divergence**: On two machines, each accumulates its own patterns and gotchas independently. There was no mechanism to merge learnings from machine A into machine B.
 - **Manual sync tax**: The "Updating" section of the README described a manual `cp` workflow that was easy to forget, especially at the end of a productive session when new patterns were fresh.
 
@@ -51,14 +51,14 @@ Claude Code loads all `*.md` from `~/.claude/rules/` automatically. The local fi
 2. The `/devkit-sync push` skill commits changes and pushes to a `sync/<machine-id>` branch
 3. Pull requests are the merge point -- changes from each machine are reviewed before merging to main
 4. The `SessionStart.sh` hook auto-pulls main on every new Claude Code session (with a 5-second network timeout to avoid blocking)
-5. The `/reflect` and session review workflows check for uncommitted DevKit changes and prompt the user to run `/devkit-sync push`
+5. The `/autolearn` and session review workflows check for uncommitted DevKit changes and prompt the user to run `/devkit-sync push`
 
 ### Automatic triggers
 
 | Trigger | Action | Mechanism |
 |---------|--------|-----------|
 | Session start | Pull latest from main | `SessionStart.sh` hook |
-| `/reflect` or session review | Prompt to push if dirty | Workflow step 6 in `quick-reflect.md` |
+| `/autolearn` or session review | Prompt to push if dirty | Workflow step 6 in `quick-reflect.md` |
 | `/devkit-sync push` | Commit, push to sync branch, create PR | Skill workflow |
 | `/devkit-sync pull` | Fetch and merge main | Skill workflow |
 

--- a/docs/ADR-0012-three-tier-architecture.md
+++ b/docs/ADR-0012-three-tier-architecture.md
@@ -166,10 +166,10 @@ Project Tier                    Machine Tier                    Universal Tier
                            ^                                  ^
                            |                                  |
                       Manual copy                     /devkit-sync promote
-                      or /reflect                     (issue #86)
+                      or /autolearn                     (issue #86)
 ```
 
-- **Project -> Machine**: When `/reflect` captures a pattern during project work, it writes to the machine-tier `.local.md` file (already implemented)
+- **Project -> Machine**: When `/autolearn` captures a pattern during project work, it writes to the machine-tier `.local.md` file (already implemented)
 - **Machine -> Universal**: The `/devkit-sync promote` command (#86) scans `.local.md` files, shows candidates, and appends selected entries to the universal rules file
 
 Demotion (universal -> machine or machine -> project) is not automated. If a universal pattern is wrong, edit or remove it from the universal file directly.

--- a/docs/ADR-0014-rule-lifecycle.md
+++ b/docs/ADR-0014-rule-lifecycle.md
@@ -42,7 +42,7 @@ Fields:
 | `**Added:**` | Yes | `YYYY-MM-DD` | Date first committed (infer from git log) |
 | `**Source:**` | Yes | Project name | Where discovered: `SubNetree`, `devkit`, `global`, `samverk`, etc. |
 | `**Status:**` | Yes | See below | Lifecycle state |
-| `**Last relevant:**` | No | `YYYY-MM-DD` | Updated by `/reflect` when pattern is applied in a session |
+| `**Last relevant:**` | No | `YYYY-MM-DD` | Updated by `/autolearn` when pattern is applied in a session |
 | `**See also:**` | No | Entry references | Cross-references: `AP#17`, `KG#12`, etc. |
 
 ### Status Values

--- a/docs/copilot-integration.md
+++ b/docs/copilot-integration.md
@@ -308,7 +308,7 @@ Copilot and Claude Code serve different workflows and do not conflict:
 | Multi-file features | No | Yes -- main tool |
 | Architecture decisions | No | Yes -- `/create-plan` |
 | Codebase exploration | No | Yes -- Glob/Grep agents |
-| Rule learning (`/reflect`) | No | Yes -- autolearn pipeline |
+| Rule learning (`/autolearn`) | No | Yes -- autolearn pipeline |
 
 Both tools read different instruction files. `AGENTS.md` governs Copilot agent behavior.
 `CLAUDE.md` governs Claude Code behavior. Changes to one do not affect the other.

--- a/docs/hook-expansion-research.md
+++ b/docs/hook-expansion-research.md
@@ -36,7 +36,7 @@ The existing `SessionStart.sh` hook performs five functions:
 The current `UserPromptSubmit` hook uses the regex
 `^(?!/)(?!\d{1,2}$)` to skip slash commands and bare numeric menu
 selections (KG#10). It fires a `type: "prompt"` hook that passively
-monitors for autolearn opportunities and suggests `/reflect` when
+monitors for autolearn opportunities and suggests `/autolearn` when
 notable patterns are discovered.
 
 ### Known Gotchas
@@ -152,7 +152,7 @@ This includes context window pressure warnings.
 
 - **Context pressure detection** -- when a notification indicates the
   context window is nearing capacity, a hook could inject a reminder
-  to run `/reflect` before compaction erases learnings. This directly
+  to run `/autolearn` before compaction erases learnings. This directly
   addresses the compaction recovery rules.
 
 - **Coordination context surfacing** -- inject relevant coordination
@@ -164,13 +164,13 @@ This includes context window pressure warnings.
 **Analysis:** The value of notification hooks depends heavily on what
 notification content is available. If context window pressure
 notifications include a clear signal (e.g., percentage used), the
-`/reflect` reminder is straightforward and high-value. Coordination
+`/autolearn` reminder is straightforward and high-value. Coordination
 context surfacing is speculative without knowing the notification
 payload format.
 
 **Recommendation:** Investigate what notification events Claude Code
 actually emits. If context pressure notifications exist, implement
-the `/reflect` reminder. Defer coordination surfacing until the
+the `/autolearn` reminder. Defer coordination surfacing until the
 notification payload is better understood.
 
 ### d. SubagentStop Hooks
@@ -221,10 +221,10 @@ the session ends.
 
 **Candidate uses:**
 
-- **Reflect reminder** -- inject a brief reminder to run `/reflect`
+- **Reflect reminder** -- inject a brief reminder to run `/autolearn`
   if the session involved substantial work. This complements the
   autolearn pattern in CLAUDE.md that asks Claude to suggest
-  `/reflect` proactively.
+  `/autolearn` proactively.
 
 - **Uncommitted changes warning** -- run `git status` and warn if
   there are uncommitted changes that might be lost.
@@ -240,7 +240,7 @@ autolearn nudge was missed. The uncommitted changes warning is also
 valuable -- it prevents the user from closing a session with work
 in progress.
 
-**Recommendation:** Implement both the `/reflect` reminder and the
+**Recommendation:** Implement both the `/autolearn` reminder and the
 uncommitted changes check. These are independent, small, and
 immediately useful.
 
@@ -302,7 +302,7 @@ incidents demonstrate that the current controls are insufficient.
    pre-push hook with lightweight per-commit checks. Not a Claude Code
    hook but fills a gap in the git hooks story.
 
-5. **Notification: context pressure /reflect reminder** (Medium, M)
+5. **Notification: context pressure /autolearn reminder** (Medium, M)
    -- valuable but depends on notification payload investigation.
 
 6. **PreToolUse: dangerous operation guard** (Low, L) -- overlaps with
@@ -315,7 +315,7 @@ incidents demonstrate that the current controls are insufficient.
 - **Stop hook** -- add `Stop` entry to `settings.template.json` with
   a `type: "command"` hook that runs a bash script. The script checks
   `git status --porcelain` for uncommitted changes and echoes a
-  `/reflect` reminder. Create the script at
+  `/autolearn` reminder. Create the script at
   `claude/hooks/SessionStop.sh`.
 
 - **Pre-commit hook template** -- add
@@ -342,7 +342,7 @@ incidents demonstrate that the current controls are insufficient.
 
 - **Notification hooks** -- investigate what notification events
   Claude Code emits. If context pressure notifications are available,
-  implement a `/reflect` reminder. Document findings for future
+  implement a `/autolearn` reminder. Document findings for future
   implementation.
 
 ### Phase 4: Deferred (L effort, low priority)

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -7,7 +7,7 @@ How to adopt DevKit in an existing project. This guide assumes DevKit is already
 DevKit gives your project access to:
 
 - **Rules** (10 files, 135+ patterns) -- auto-loaded every Claude Code session
-- **Skills** (19 invokable workflows) -- `/plan-review`, `/code-review`, `/reflect`, etc.
+- **Skills** (19 invokable workflows) -- `/plan-review`, `/code-review`, `/autolearn`, etc.
 - **Agent templates** (7 agents) -- plan reviewer, code reviewer, security analyzer, etc.
 - **Hooks** -- SessionStart for automatic session orientation
 - **CI templates** -- GitHub Actions workflows, pre-push hooks, lint configs

--- a/docs/multi-workstation-guide.md
+++ b/docs/multi-workstation-guide.md
@@ -172,9 +172,9 @@ Every time you open a Claude Code session, `SessionStart.sh` runs automatically:
 
 You do not need to do anything -- this happens silently in the background.
 
-### Capture patterns with /reflect
+### Capture patterns with /autolearn
 
-During a session, when you learn something new (a gotcha, a pattern, a fix), run `/reflect`. This appends the learning to the appropriate rules file in `~/.claude/rules/`. Because of symlinks, the edit lands directly in your DevKit clone.
+During a session, when you learn something new (a gotcha, a pattern, a fix), run `/autolearn`. This appends the learning to the appropriate rules file in `~/.claude/rules/`. Because of symlinks, the edit lands directly in your DevKit clone.
 
 ### Push changes with /devkit-sync push
 

--- a/mcp/memory-seeds.md
+++ b/mcp/memory-seeds.md
@@ -67,7 +67,7 @@ Observations:
 Entity: pattern-autolearn-feedback-loop
 Type: Pattern
 Observations:
-- /reflect skill captures session learnings
+- /autolearn skill captures session learnings
 - Stores in MCP Memory (deep) and rules files (fast)
 - Rules files auto-load every session
 ```


### PR DESCRIPTION
## Summary

- Renames skill YAML `name: reflect` to `name: autolearn` (matches directory name)
- Updates all `/reflect` references across 16 files to `/autolearn`
- CHANGELOG entries left unchanged (historical record)
- Rationale documented in [issue comment](https://github.com/HerbHall/devkit/issues/214#issuecomment-4017472150)

## Test plan

- [ ] `/autolearn` invokes the skill correctly
- [ ] No remaining `/reflect` references (excluding CHANGELOG)
- [ ] Markdown lint passes

Closes #214

Generated with [Claude Code](https://claude.com/claude-code)