### PR TITLE
fix: Gitea CI checking blind spot in quality-control (#215)

### DIFF
--- a/claude/skills/quality-control/SKILL.md
+++ b/claude/skills/quality-control/SKILL.md
@@ -25,6 +25,23 @@ This skill provides systematic quality verification for code changes. It catches
 | Branch Freshness | PR branch is up to date with base | `gh pr view <number> --json mergeStateStatus` |
 | CLA Compliance | CLA check passes for all contributors | Check CLA status in checks |
 
+**Forge Compatibility**
+
+On Gitea-hosted repos, `gh pr checks` has no equivalent. Before running
+any workflow that checks CI status, detect the forge:
+
+```bash
+source scripts/forge-wrappers.sh
+if [[ "$(devkit-forge-detect)" == "gitea" ]]; then
+  echo "[WARN] Gitea detected. CI status checking is unavailable via CLI."
+  echo "       Verify CI manually at: <repo-url>/actions"
+fi
+```
+
+Affected workflows: check-pr, audit-prs, post-push-verify, fix-ci-failures.
+These workflows should emit the warning and skip CI status checks gracefully
+rather than failing silently.
+
 **Quality Principles**
 
 1. **Fail fast, fix fast.** Identify failures immediately after pushing. The longer a broken PR sits, the harder it is to fix.

--- a/docs/forge-abstraction.md
+++ b/docs/forge-abstraction.md
@@ -95,6 +95,40 @@ Some settings are UI-only and differ between forges:
 
 These settings cannot be abstracted by the forge wrapper -- they must be configured manually per repository on each forge.
 
+## Gitea Actions API for CI Status
+
+Gitea provides a REST API for Actions workflow runs at `/api/v1/repos/{owner}/{repo}/actions/runs`. This could substitute for `gh pr checks` on Gitea-hosted repos.
+
+### API Endpoint
+
+```text
+GET /api/v1/repos/{owner}/{repo}/actions/runs
+```
+
+Returns a list of workflow runs with `status` and `conclusion` fields. Filtering by branch or PR is possible via query parameters.
+
+### Feasibility Assessment
+
+**Viable but not yet implemented.** The API exists and returns the needed data, but:
+
+1. `tea` CLI does not expose Actions runs (as of tea v0.9). Raw `curl` calls against the Gitea API would be required.
+2. Mapping PR number to a specific workflow run requires correlating the PR's head branch with the run's branch — `gh pr checks` does this automatically.
+3. Authentication requires a Gitea API token (already configured if `tea login` was run).
+
+### Current Status
+
+The `devkit-pr-checks()` wrapper in `scripts/forge-wrappers.sh` returns exit code 1 with a warning on Gitea repos. A future enhancement could implement the API call:
+
+```bash
+# Potential implementation (not yet active):
+curl -s -H "Authorization: token $GITEA_TOKEN" \
+  "$GITEA_URL/api/v1/repos/$OWNER/$REPO/actions/runs?branch=$HEAD_BRANCH" \
+  | python3 -c "import json,sys; runs=json.load(sys.stdin)['workflow_runs']; \
+    print('pass' if all(r['conclusion']=='success' for r in runs) else 'fail')"
+```
+
+This is deferred until a Gitea-hosted project needs CI status checking in automation.
+
 ## Graceful Degradation
 
 When `tea` is not installed and a Gitea repo is detected:

--- a/scripts/forge-wrappers.sh
+++ b/scripts/forge-wrappers.sh
@@ -139,6 +139,20 @@ devkit-pr-list() {
 }
 
 # ---------------------------------------------------------------------------
+# devkit-pr-checks -- Check CI status on a pull request
+#   Returns exit code 1 on Gitea (not available via tea CLI).
+# ---------------------------------------------------------------------------
+devkit-pr-checks() {
+  case "$(devkit-forge-detect)" in
+    github) gh pr checks "$@" ;;
+    gitea)
+      echo "[WARN] CI status checking unavailable on Gitea. Verify CI manually before merging." >&2
+      return 1
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
 # devkit-pr-merge -- Merge a pull request
 #   First positional arg is PR number/URL. Extra flags passed through.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds forge detection warning to quality-control skill for Gitea repos
- New `devkit-pr-checks()` wrapper in `scripts/forge-wrappers.sh` — returns exit 1 with clear warning on Gitea
- Documents Gitea Actions API investigation in `docs/forge-abstraction.md` — viable but deferred

## Test plan

- [ ] `devkit-pr-checks` on a GitHub repo passes through to `gh pr checks`
- [ ] `devkit-pr-checks` on a Gitea repo emits warning and returns exit 1
- [ ] Markdown lint passes

Closes #215

Generated with [Claude Code](https://claude.com/claude-code)