### PR TITLE
docs: update skill/rules counts and add scripts/ to structure docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,8 @@ bash setup/legacy/verify.sh
 devkit/
 ├── claude/              - Claude Code config (rules, skills, agents, hooks)
 │   ├── CLAUDE.md        - Global instructions (installed to ~/.claude/)
-│   ├── rules/           - Auto-loaded pattern files (8 files, 135+ patterns)
-│   ├── skills/          - Invokable skills (18 skills with workflow files)
+│   ├── rules/           - Auto-loaded pattern files (10 files, 153+ patterns)
+│   ├── skills/          - Invokable skills (21 skills with workflow files)
 │   ├── agents/          - Agent templates (7 agents)
 │   └── hooks/           - SessionStart hook
 ├── devspace/            - Workspace shared configs (.editorconfig, VS Code)
@@ -46,6 +46,7 @@ devkit/
 ├── mcp/                 - MCP server inventory and config templates
 ├── profiles/            - Kit 2 stack profiles (project type definitions)
 ├── project-templates/   - Kit 3 scaffolding templates
+├── scripts/             - Utility scripts (secret distribution, Copilot setup, forge wrappers)
 ├── setup/               - PowerShell stubs (*.ps1, lib/*.ps1)
 │   ├── lib/             - Shared PowerShell libraries
 │   └── legacy/          - Deprecated bash scripts

--- a/README.md
+++ b/README.md
@@ -61,13 +61,14 @@ See [Settings Strategy](docs/settings-strategy.md) for the two-layer permission 
 
 | Directory | Purpose |
 |-----------|---------|
-| `claude/` | Global Claude Code config — CLAUDE.md, 10 rules files (135+ patterns), 21 skills, 7 agent templates, hooks |
+| `claude/` | Global Claude Code config — CLAUDE.md, 10 rules files (153+ patterns), 21 skills, 7 agent templates, hooks |
 | `devspace/` | Workspace shared configs — .editorconfig, .markdownlint.json, VS Code fragments |
 | `docs/` | Human-readable guides — architecture decisions, profile format spec |
 | `machine/` | Machine state snapshots — VS Code extensions, tool versions |
 | `mcp/` | MCP server inventory, config templates (no secrets), Memory bootstrap guide |
 | `profiles/` | Kit 2 stack profiles — project type definitions (Go, React, IoT, etc.) |
 | `project-templates/` | Kit 3 scaffolding — workspace CLAUDE.md template, project starter files |
+| `scripts/` | Utility scripts — secret distribution (`Set-DevkitSecrets.ps1`), Copilot review setup, forge wrappers |
 | `setup/` | Setup scripts — PowerShell stubs (`*.ps1`, `lib/*.ps1`) and `legacy/` bash scripts |
 | `METHODOLOGY.md` | Development process — phases, gates, decision framework |
 


### PR DESCRIPTION
## Summary

- `CLAUDE.md`: rules 8→10 files, 135+→153+ patterns, skills 18→21; add `scripts/` to structure tree
- `README.md`: 135+→153+ patterns in What's Inside; add `scripts/` row to directory table

Drift found during housekeeping audit -- counts had not been updated since v2.1.0.

Verified counts: `ls claude/rules/*.md` = 10, `ls claude/skills/` = 21, `ls claude/agents/*.md` = 7, `grep -c '**Added:**'` AP=71 + KG=82 = 153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)