### PR TITLE
fix: apply Copilot follow-up fixes (PRs #235 and #236)

### DIFF
--- a/scripts/Set-DevkitSecrets.ps1
+++ b/scripts/Set-DevkitSecrets.ps1
@@ -108,10 +108,17 @@ if ($PSCmdlet.ParameterSetName -eq 'Single') {
 
     # Use gh api with pagination to fetch all repositories for the user.
     # full_name has the "owner/name" format equivalent to nameWithOwner.
-    $repoOutput = & gh api "users/$githubUser/repos" --paginate --jq '.[].full_name' 2>&1 | Out-String
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "gh api failed while fetching repos: $repoOutput"
-        exit 1
+    # Isolate stderr so error messages don't mix with repo names in $repoOutput.
+    $tmpErr = [System.IO.Path]::GetTempFileName()
+    try {
+        $repoOutput = & gh api "users/$githubUser/repos" --paginate --jq '.[].full_name' 2>$tmpErr | Out-String
+        if ($LASTEXITCODE -ne 0) {
+            $stderrMsg = Get-Content $tmpErr -Raw -ErrorAction SilentlyContinue
+            Write-Error "gh api failed while fetching repos: $stderrMsg"
+            exit 1
+        }
+    } finally {
+        Remove-Item $tmpErr -ErrorAction SilentlyContinue
     }
 
     # Split the output into individual repo names, trimming empty lines.

--- a/setup/new-project.ps1
+++ b/setup/new-project.ps1
@@ -736,11 +736,11 @@ logger:
             $null = & git add -A 2>&1
             $null = & git commit -m "chore: initial project scaffolding" 2>&1
 
-            $ghOutput = & gh repo create "$githubUser/$projectName" `
+            $null = & gh repo create "$githubUser/$projectName" `
                 --private `
                 --source . `
                 --remote origin `
-                --push 2>&1 | Out-String
+                --push 2>&1
             $ghExit = $LASTEXITCODE
 
             Pop-Location
@@ -859,7 +859,7 @@ logger:
             }
         }
 
-        if ($rpt) {
+        if (-not [string]::IsNullOrWhiteSpace($rpt)) {
             try {
                 $rptResult = ($rpt | & gh secret set RELEASE_PLEASE_TOKEN --repo "$githubUser/$projectName" 2>&1)
                 if ($LASTEXITCODE -eq 0) {


### PR DESCRIPTION
## Summary

- **new-project.ps1**: Change `$ghOutput =` to `$null =` for the `gh repo create` call (and drop `Out-String` since output is discarded). Fixes `PSUseDeclaredVarsMoreThanAssignments` PSScriptAnalyzer warning — the variable was captured but never read.
- **Set-DevkitSecrets.ps1**: Isolate stderr via a temp file so `gh api` error messages don't mix with repo names in `$repoOutput`. This prevents gh error text from appearing as a fake repo name and causing a misleading failure message.

These fixes correspond to Copilot sub-PRs #235 and #236, which targeted the already-squash-merged `feat/issue-233-release-please-token` branch and therefore did not land on main.

Closes #235
Closes #236

## Test plan

- [ ] `new-project.ps1`: PSScriptAnalyzer should no longer warn on `$ghOutput` at line 739
- [ ] `Set-DevkitSecrets.ps1`: stderr from `gh api` failure now correctly surfaced without polluting repo list

🤖 Generated with [Claude Code](https://claude.com/claude-code)