### PR TITLE
docs(audit): fix stale README counts and verification gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,15 +230,15 @@ With symlinks active, changes flow automatically:
 | File | Entries | Purpose |
 |------|---------|---------|
 | `agent-team-coordination.md` | - | Multi-agent team coordination rules and anti-patterns |
-| `autolearn-patterns.md` | 76 | Learned patterns: lint fixes, CI config, architecture, testing |
+| `autolearn-patterns.md` | 71 | Learned patterns: lint fixes, CI config, architecture, testing |
 | `compaction-recovery.md` | - | Context compaction recovery rules and loop detection |
 | `core-principles.md` | 10 | Immutable core principles (Tier 0) |
 | `error-policy.md` | - | Zero-tolerance error policy and fix-forward workflow (Tier 1) |
-| `known-gotchas.md` | 60 | Platform issues: Windows, GitHub, Go, React, Docker |
+| `known-gotchas.md` | 82 | Platform issues: Windows, GitHub, Go, React, Docker |
 | `markdown-style.md` | - | Markdownlint conventions |
 | `review-policy.md` | - | Independent review policy: mandatory triggers and scope |
 | `subagent-ci-checklist.md` | - | Pre-commit CI validation checklists |
-| `workflow-preferences.md` | 11 | Established conventions: git, commits, testing |
+| `workflow-preferences.md` | 16 | Established conventions: git, commits, testing |
 
 ### Skills (invoke with /skill-name)
 

--- a/setup/legacy/verify.sh
+++ b/setup/legacy/verify.sh
@@ -52,7 +52,7 @@ done
 
 echo ""
 echo "Verifying individual skills..."
-for skill in autolearn code-review devkit-sync docker-containerization go-development manage-github-issues plan-review powershell-windows quality-control react-frontend-development requirements-generator security-review server-management setup-github-actions systematic-debugging webapp-testing windows-development bash-linux; do
+for skill in autolearn bash-linux code-review conformance-audit devkit-sync docker-containerization go-development manage-github-issues plan-review powershell-windows quality-control react-frontend-development requirements-generator rules-compact security-review server-management setup-github-actions skill-audit systematic-debugging webapp-testing windows-development; do
     check "$CLAUDE_HOME/skills/$skill/SKILL.md" "$skill skill"
 done
 

--- a/setup/verify.ps1
+++ b/setup/verify.ps1
@@ -37,6 +37,7 @@ Write-Section 'Verification: Core Tools'
 $tools = @(
     @{ Name = 'git';     Check = 'git' },
     @{ Name = 'gh';      Check = 'gh' },
+    @{ Name = 'node';    Check = 'node' },
     @{ Name = 'go';      Check = 'go' },
     @{ Name = 'docker';  Check = 'docker' },
     @{ Name = 'code';    Check = 'code' },


### PR DESCRIPTION
## Summary

Findings from a comprehensive audit of docs-vs-reality.

- **README.md**: Rules file entry counts were stale — updated to match actual `entry_count` frontmatter values (autolearn-patterns 76→71, known-gotchas 60→82, workflow-preferences 11→16)
- **verify.sh**: Three skills added since the legacy script was last updated were missing from the skill check loop (`conformance-audit`, `rules-compact`, `skill-audit`); list is now alphabetized
- **verify.ps1**: `node` was absent from core tools despite being a required dependency for Claude Code CLI

## Test plan

- [ ] CI passes (markdownlint, skill routing, rule metadata)
- [ ] README entry counts now match `grep entry_count claude/rules/*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)