### PR TITLE
chore(autolearn): session review 2026-03-08

### DIFF
--- a/claude/rules/autolearn-patterns.md
+++ b/claude/rules/autolearn-patterns.md
@@ -1,7 +1,7 @@
 ---
 description: Learned patterns from past sessions. Read when encountering similar situations.
 tier: 2
-entry_count: 71
+entry_count: 72
 last_updated: "2026-03-08"
 ---
 
@@ -748,3 +748,12 @@ On resume: `git status`, `git diff --stat`, `go build ./...`, then commit. Subag
 **Category:** scaffolding-pattern
 **Context:** New repos need long-lived PATs (e.g., `RELEASE_PLEASE_TOKEN`) set as GitHub Actions secrets. Prompting users each time is fragile; env vars don't survive across sessions.
 **Fix:** Store PATs in `~/.devkit-config.json` under `.Secrets`. New-project.ps1 reads and sets them automatically (section 2.7). Use `scripts/Set-DevkitSecrets.ps1` to backfill existing repos (`-Repo HerbHall/foo` for one, no args for all). File is local-only, never committed. See KG#94 for why `GITHUB_TOKEN` is insufficient for release-please.
+
+## 121. Periodic Project Audit via Explore Subagent
+
+**Added:** 2026-03-08 | **Source:** DevKit | **Status:** active
+
+**Category:** process-pattern
+**Context:** Documentation, skill lists, CI coverage, and setup scripts drift from reality over time without automated validation. Stale counts, missing checklist blocks, and undocumented CI gaps accumulate invisibly.
+**Fix:** Run a structured Explore subagent audit periodically. The prompt should cover 10 dimensions: (1) docs-vs-reality count claims, (2) skill routing table completeness, (3) agent template coverage, (4) rules file metadata accuracy, (5) CI job gap analysis, (6) setup script completeness, (7) project template freshness, (8) hook coverage, (9) sync manifest integrity, (10) cross-reference completeness. Results from one DevKit audit: found stale README counts, 3 missing skills in verify.sh, absent `node` check, missing RUST-CI/DOTNET-CI checklists, no PSScriptAnalyzer in CI -- all actionable in the same session.
+**See also:** AP#47 (check existing assets before scoping issues), AP#83 (sprint scope reduction via exploration), AP#85 (roadmap drift)

--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -1,7 +1,7 @@
 ---
 description: Known gotchas and platform-specific issues. Read when debugging unexpected behavior.
 tier: 2
-entry_count: 82
+entry_count: 85
 last_updated: "2026-03-08"
 ---
 
@@ -736,3 +736,45 @@ All parallel agents write to the same working directory. Changes mix as unstaged
 **Workaround:** Remove the `status:needs-human` label manually. The issue is valid; proceed normally.
 **Fix needed:** Dispatcher should treat `invalid_frontmatter` as a soft warning, not a hard escalation. Options: (1) skip frontmatter requirement for issues created by Copilot or external agents, (2) route to a fallback classify path using title/label heuristics, (3) only escalate if frontmatter is present but malformed. See Samverk issue #180.
 **See also:** KG#99 (Copilot review is informational -- same "Copilot-as-actor" surface area)
+
+## 103. Copilot Sub-PRs Target Feature Branch, Not Main
+
+**Added:** 2026-03-08 | **Source:** DevKit | **Status:** active
+
+**Platform:** GitHub (Copilot coding agent)
+**Issue:** Copilot's auto-generated sub-PRs (follow-up fix suggestions) target the feature branch that triggered the review, not `main`. When that feature branch is squash-merged and closed, the Copilot sub-PRs still point to the now-dead branch. Merging them (even with `--admin`) lands commits on the dead branch, not `main`. Changes are silently lost.
+**Symptom:** `gh pr merge <copilot-pr> --admin` succeeds but the fixes never appear on `main`.
+**Fix:** Before merging any Copilot sub-PR, check its target: `gh pr view <number> --json baseRefName,state`. If `baseRefName` is not `main` and the original PR is already merged, apply the fixes manually on a new branch from `main`.
+**See also:** KG#99 (Copilot review is informational -- same Copilot-as-actor surface area)
+
+## 104. PowerShell Unused Variable Triggers PSScriptAnalyzer Warning
+
+**Added:** 2026-03-08 | **Source:** DevKit | **Status:** active
+
+**Platform:** PowerShell (PSScriptAnalyzer)
+**Issue:** `PSUseDeclaredVarsMoreThanAssignments` fires when command output is captured into a variable that is never read: `$output = & command 2>&1 | Out-String`. If `$output` is only assigned and never referenced, the analyser warns. Caught by local PostToolUse hook; NOT caught by DevKit CI (issue #243 tracks adding PS lint to CI).
+**Fix:** Use `$null = & command 2>&1` to explicitly discard output. Drop `Out-String` — allocation is wasted if the result isn't used.
+
+## 105. PowerShell 2>&1 Mixes Stderr Into Parsed Output
+
+**Added:** 2026-03-08 | **Source:** DevKit | **Status:** active
+
+**Platform:** PowerShell (all)
+**Issue:** `& command 2>&1 | Out-String` merges stderr into the stdout string. When the output is parsed line-by-line for data (e.g. repo names from `gh api`), any error message from the command appears as a fake data record. Splitting on newlines produces garbage entries.
+**Fix:** Redirect stderr to a temp file to isolate it:
+
+```powershell
+$tmpErr = [System.IO.Path]::GetTempFileName()
+try {
+    $out = & command 2>$tmpErr | Out-String
+    if ($LASTEXITCODE -ne 0) {
+        $err = Get-Content $tmpErr -Raw -ErrorAction SilentlyContinue
+        Write-Error "command failed: $err"
+        exit 1
+    }
+} finally {
+    Remove-Item $tmpErr -ErrorAction SilentlyContinue
+}
+```
+
+**See also:** AP#76 (temp-file pattern for MSYS→PowerShell), KG#104 (unused var warning from the same code path)


### PR DESCRIPTION
## Summary

Autolearn session review entries from the 2026-03-08 session.

### New entries

**Known Gotchas:**

- **KG#103**: Copilot sub-PRs target the feature branch that triggered review, not `main`. Squash-merging the feature branch leaves Copilot's follow-up PRs pointing to a dead branch — merging them with `--admin` silently lands changes on the dead branch.
- **KG#104**: PSScriptAnalyzer `PSUseDeclaredVarsMoreThanAssignments` fires when command output is captured into a variable that's never read. Fix: `$null = & command 2>&1`.
- **KG#105**: PowerShell `2>&1 | Out-String` mixes stderr into stdout. When parsing output as data, error messages appear as fake records. Fix: redirect stderr to temp file.

**Learned Patterns:**

- **AP#121**: Periodic project audit via Explore subagent — structured 10-dimension prompt catches doc drift, missing CI checks, stale skill lists, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)