### PR TITLE
feat(conformance-audit): add check #19 -- periodic documentation audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Claude.ai Chat uses a separate skill store - install via Settings > Skills in th
 | code-review | Independent code review gate before commits | Code |
 | plan-review | Independent plan review gate before implementation | Code |
 | devkit-sync | Multi-machine DevKit sync: status, push, pull, init, diff, verify, promote, update | Code |
-| conformance-audit | 18-point project conformance checklist against DevKit standards | Code |
+| conformance-audit | 19-point project conformance checklist against DevKit standards | Code |
 | rules-compact | Compact oversized rules files: archive stale, deduplicate, consolidate | Code |
 | skill-audit | Audit skill quality: wait states, routing, references, frontmatter, rules metadata | Code |
 

--- a/claude/skills/conformance-audit/SKILL.md
+++ b/claude/skills/conformance-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conformance-audit
-description: Cross-project conformance auditing against DevKit standards (18-point checklist). Full audits, single-project checks, and auto-fix of common gaps.
+description: Cross-project conformance auditing against DevKit standards (19-point checklist). Full audits, single-project checks, and auto-fix of common gaps.
 user_invocable: true
 ---
 
@@ -10,7 +10,7 @@ Cross-project conformance auditing against DevKit standards. Run a 17-point chec
 
 <essential_principles>
 
-**The 18-point checklist is the single source of truth for conformance.** All audit workflows reference `references/checklist.md` for check definitions, pass criteria, and fix references. Do not invent checks outside this list.
+**The 19-point checklist is the single source of truth for conformance.** All audit workflows reference `references/checklist.md` for check definitions, pass criteria, and fix references. Do not invent checks outside this list.
 
 **Stack detection determines which checks apply.** Go projects need `.golangci.yml`, Rust needs clippy in CI, Node needs `eslint.config.js`, etc. Checks that do not apply to the detected stack are reported as "skip", not "fail".
 
@@ -23,7 +23,7 @@ Cross-project conformance auditing against DevKit standards. Run a 17-point chec
 <intake>
 **conformance-audit triggered.** What kind of conformance audit do you need?
 
-1. **Full audit** -- Run 18-point conformance check across all projects
+1. **Full audit** -- Run 19-point conformance check across all projects
 2. **Single project** -- Audit one specific project
 3. **Fix gaps** -- Auto-fix common conformance gaps for a project
 

--- a/claude/skills/conformance-audit/references/checklist.md
+++ b/claude/skills/conformance-audit/references/checklist.md
@@ -1,6 +1,6 @@
 # Conformance Checklist
 
-18-point checklist for DevKit project conformance. Each check includes what to look for, which stacks need it, how to determine pass/fail, and which DevKit template provides the fix.
+19-point checklist for DevKit project conformance. Each check includes what to look for, which stacks need it, how to determine pass/fail, and which DevKit template provides the fix.
 
 ## Stack Detection
 
@@ -173,6 +173,15 @@ A project may match multiple stacks (e.g., Go backend + Node frontend). Apply ch
 - **Fail indicators**: Release Please workflow runs succeed but never open a PR. The workflow log shows `Resource not accessible by integration` or `HttpError: GitHub Actions is not permitted to create or approve pull requests`
 - **Fix reference**: Manual -- navigate to the exact path above and enable the checkbox. No API equivalent exists
 - **Note**: This setting is per-repository and defaults to **disabled** on new repos. It must be enabled before any workflow (release-please, retrigger-ci, release-gate) that creates or modifies PRs using `GITHUB_TOKEN`
+
+### 19. Periodic Documentation Audit
+
+- **What to check**: Documentation claims (skill counts, entry counts, feature lists) match actual on-disk state
+- **Stacks**: DevKit only (skip for non-DevKit projects)
+- **Pass criteria**: This is a **manual periodic check** — run an Explore subagent audit covering: (1) README count claims vs frontmatter, (2) skill names in verify.sh vs actual skills, (3) verify.ps1 tool list vs documented dependencies, (4) CI coverage gaps (missing lint jobs for active stacks)
+- **Frequency**: Run after any sprint that adds skills, rules entries, or CI changes
+- **Fail indicators**: README entry counts diverge from frontmatter `entry_count`; verify.sh lists fewer skills than `claude/skills/` contains; verify.ps1 missing tools referenced in CLAUDE.md
+- **Fix reference**: AP#121 (structured 10-dimension audit prompt); run from main context with Explore subagent
 
 ## Scoring
 

--- a/claude/skills/conformance-audit/workflows/full-audit.md
+++ b/claude/skills/conformance-audit/workflows/full-audit.md
@@ -1,6 +1,6 @@
 # Conformance Audit: Full Audit
 
-Run the 18-point conformance checklist across all projects in the DevSpace workspace.
+Run the 19-point conformance checklist across all projects in the DevSpace workspace.
 
 ## Steps
 

--- a/claude/skills/conformance-audit/workflows/single-project.md
+++ b/claude/skills/conformance-audit/workflows/single-project.md
@@ -1,6 +1,6 @@
 # Conformance Audit: Single Project
 
-Run the 18-point conformance checklist against one specific project.
+Run the 19-point conformance checklist against one specific project.
 
 ## Steps
 
@@ -54,11 +54,11 @@ If the stack is `unknown`, note that stack-specific checks (5, 12) will be skipp
 
 ### 4. Read Checklist
 
-Load the 18-point checklist from `references/checklist.md` in the conformance-audit skill directory. Use it as the authoritative source for what to check, pass criteria, and fix references.
+Load the 19-point checklist from `references/checklist.md` in the conformance-audit skill directory. Use it as the authoritative source for what to check, pass criteria, and fix references.
 
 ### 5. Run Each Check
 
-Execute all 18 checks. For each one, report the result with detail:
+Execute all 19 checks. For each one, report the result with detail:
 
 **Check 1 -- CLAUDE.md**
 


### PR DESCRIPTION
## Summary

Adds a 19th check to the conformance audit checklist for DevKit projects, and updates all "18-point" references accordingly.

**Check #19: Periodic Documentation Audit** (DevKit-only, manual/periodic)

Covers: README count claims vs frontmatter, skill names in verify.sh vs actual skills, verify.ps1 tool list vs documented dependencies, CI coverage gaps.

Motivated by the 2026-03-08 audit session (AP#121) that found 5 actionable gaps — all fixed in same session. Without this check in the conformance checklist, there's no reminder to run the audit after sprints that add skills or rules entries.

Closes the skill improvement opportunity identified in the autolearn session review.

**Files changed:**
- `references/checklist.md`: Added check #19, updated "18-point" header to "19-point"
- `SKILL.md`: Updated count references
- `workflows/full-audit.md`: Updated count reference
- `workflows/single-project.md`: Updated count references (×2)
- `README.md`: Updated description string

## Test plan

- [ ] CI passes (markdown lint, skill routing, skill counts)
- [ ] `grep "19-point" claude/skills/conformance-audit/SKILL.md` returns a match
- [ ] No remaining "18-point" references in conformance-audit directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)