### PR TITLE
fix: remove false manual requirement (Actions PR Permission check)

### DIFF
--- a/claude/skills/conformance-audit/references/checklist.md
+++ b/claude/skills/conformance-audit/references/checklist.md
@@ -164,15 +164,14 @@ A project may match multiple stacks (e.g., Go backend + Node frontend). Apply ch
 - **Fail indicators**: Any file over 40k. Output: `rules/<filename> is Xk -- exceeds 40k limit, run /rules-compact`
 - **Fix reference**: Run `/rules-compact` skill to archive stale entries and consolidate duplicates
 
-### 18. Actions PR Permission
+### 18. Release PAT Configured
 
-- **What to check**: Repository has "Allow GitHub Actions to create and approve pull requests" enabled
+- **What to check**: `RELEASE_PLEASE_TOKEN` secret is set on the repository
 - **Stacks**: Only if release-please is configured (check 8 passes)
-- **Pass criteria**: This is a **manual UI-only check** -- it cannot be verified or set via the GitHub API or `gh` CLI
-- **Navigation path**: Repository Settings > Actions > General > Workflow permissions > check "Allow GitHub Actions to create and approve pull requests"
-- **Fail indicators**: Release Please workflow runs succeed but never open a PR. The workflow log shows `Resource not accessible by integration` or `HttpError: GitHub Actions is not permitted to create or approve pull requests`
-- **Fix reference**: Manual -- navigate to the exact path above and enable the checkbox. No API equivalent exists
-- **Note**: This setting is per-repository and defaults to **disabled** on new repos. It must be enabled before any workflow (release-please, retrigger-ci, release-gate) that creates or modifies PRs using `GITHUB_TOKEN`
+- **Pass criteria**: `gh secret list --repo OWNER/REPO` includes `RELEASE_PLEASE_TOKEN`
+- **Fail indicators**: Secret missing; release-please workflow fails with `HttpError: Resource not accessible by integration`
+- **Fix reference**: `scripts/Set-DevkitSecrets.ps1 -Repo OWNER/REPO` (reads from `~/.devkit-config.json` `.Secrets` block); or `new-project.ps1` section 2.7 sets it automatically on new projects
+- **Note**: The "Allow GitHub Actions to create and approve pull requests" UI setting is NOT required when using `RELEASE_PLEASE_TOKEN` (a PAT). That restriction only applies to `GITHUB_TOKEN`. `release-gate.yml` and `retrigger-ci.yml` use `GITHUB_TOKEN` only for editing existing PRs (labels, comments, close/reopen) -- not creating new ones. The UI setting is therefore irrelevant for this setup.
 
 ### 19. Periodic Documentation Audit
 

--- a/docs/onboarding-checklist.md
+++ b/docs/onboarding-checklist.md
@@ -116,62 +116,41 @@ git push -u origin chore/initial-ci
 
 Merge this PR after CI passes.
 
-## Phase 3: Manual GitHub UI Settings
+## Phase 3: Automated Repository Configuration
 
-These settings **cannot** be configured via API or CLI. Each must be set manually in the GitHub web UI.
+All repository configuration is applied via API or CLI — no browser steps required.
 
-### 3.1 Actions PR Permission (REQUIRED)
+### 3.1 Release PAT Secret (AUTOMATED by new-project.ps1)
 
-**Path**: Repository Settings > Actions > General > Workflow permissions
+`new-project.ps1` section 2.7 reads `RELEASE_PLEASE_TOKEN` from `~/.devkit-config.json` and sets it automatically. For existing repos, run:
 
-1. Select **"Read and write permissions"**
-2. Check **"Allow GitHub Actions to create and approve pull requests"**
-3. Click **Save**
-
-**Why**: Without this, `release-please`, `retrigger-ci`, and `release-gate` workflows fail with `Resource not accessible by integration` when they try to create or modify PRs using `GITHUB_TOKEN`. This setting defaults to **disabled** on new repositories.
-
-**Failure symptom**: Release Please workflow runs succeed but never open a PR. Workflow log shows `HttpError: GitHub Actions is not permitted to create or approve pull requests`.
-
-### 3.2 Copilot PR Review Ruleset (RECOMMENDED)
-
-**Path**: Repository Settings > Rules > Rulesets > New ruleset > New branch ruleset
-
-1. Name the ruleset **"Copilot PR Review"**
-2. Set enforcement status to **Active**
-3. Under "Target branches", add **Default branch**
-4. Under "Branch rules", enable **"Require a pull request before merging"**
-   - Set "Required approvals" to **0** (Copilot cannot approve, only comment)
-   - Check **"Require review from GitHub Copilot"**
-   - Check **"Review new pushes"**
-5. Under "Branch rules", enable **"Restrict merge methods"**
-   - Check **"Squash"** only
-6. Under "Bypass list", add your admin account
-7. Click **Create**
-
-Alternatively, create the ruleset via API then enable Copilot manually:
-
-```bash
-bash scripts/copilot-review-setup.sh setup OWNER/REPO
-# Then go to Settings > Rules > Rulesets > Copilot PR Review
-# and manually enable the Copilot review toggle (API cannot set this)
+```powershell
+pwsh scripts/Set-DevkitSecrets.ps1 -Repo OWNER/REPO
 ```
 
-**Why**: Copilot auto-review provides informational code review on every push. It is not a merge gate — CI is the only merge gate. See `docs/copilot-integration.md` for the full three-layer protection model.
+**Why**: `release-please.yml` uses this PAT (not `GITHUB_TOKEN`) to create release PRs. A PAT acts as a user token and is not subject to the "Allow GitHub Actions to create PRs" repository permission, which only restricts the built-in `GITHUB_TOKEN`. See KG#94.
 
-### 3.3 Auto-Merge (REQUIRED if using release-gate)
+### 3.2 Auto-Merge (AUTOMATED by new-project.ps1)
 
-**Path**: Repository Settings > General (scroll to "Pull Requests" section)
-
-1. Check **"Allow auto-merge"**
-2. Click **Save** (or update)
-
-Can also be set via API:
+`new-project.ps1` enables auto-merge via API during scaffolding. For existing repos:
 
 ```bash
 gh api repos/OWNER/REPO -X PATCH -f allow_auto_merge=true
 ```
 
-**Why**: The `release-gate.yml` workflow uses `gh pr merge --auto` to auto-merge release PRs after CI passes.
+**Gitea**: Set via API: `PATCH /api/v1/repos/{owner}/{repo}` with `allow_auto_merge: true`.
+
+**Why**: `release-gate.yml` uses `gh pr merge --auto` to merge release PRs after CI passes.
+
+### 3.3 Copilot PR Review Ruleset (OPTIONAL, GitHub-only, partially automated)
+
+Creates the ruleset via API. The Copilot review toggle within the ruleset requires a one-time UI action and cannot be set via API:
+
+```bash
+bash scripts/copilot-review-setup.sh setup OWNER/REPO
+```
+
+**Note**: This is informational only — Copilot cannot approve PRs (KG#99). CI is the merge gate. Skip this step on Gitea-hosted projects (no Copilot equivalent exists).
 
 ## Phase 4: Gitea Equivalents
 
@@ -195,7 +174,7 @@ After completing all steps, run the conformance audit:
 /conformance-audit
 ```
 
-Select the single-project check and provide the project path. All 18 checks should pass (or show as "skip" for non-applicable stack checks).
+Select the single-project check and provide the project path. All 19 checks should pass (or show as "skip" for non-applicable stack checks).
 
 ### Expected results for a fully onboarded project
 
@@ -218,7 +197,8 @@ Select the single-project check and provide the project path. All 18 checks shou
 | 15. Retrigger CI | Pass |
 | 16. Auto-Merge | Pass |
 | 17. Rules File Size | Skip (DevKit only) |
-| 18. Actions PR Permission | Pass (manual verification) |
+| 18. Release PAT Configured | Pass |
+| 19. Periodic Documentation Audit | Skip (DevKit only) |
 
 If any check fails, the audit output includes the fix reference (template path or command).
 
@@ -234,11 +214,8 @@ If any check fails, the audit output includes the fix reference (template path o
 
 ### Manual (human in browser)
 
-- Actions PR Permission (Settings > Actions > General)
-- Copilot review toggle in ruleset (Settings > Rules > Rulesets)
-- Auto-merge checkbox (Settings > General) — also settable via API
+- Copilot review toggle in ruleset (Settings > Rules > Rulesets) — optional, GitHub-only, informational only
 
 ### Cannot be automated
 
-- Actions PR Permission — no API exists
-- Copilot review toggle within rulesets — API creates the ruleset but cannot enable the Copilot toggle
+- Copilot review toggle within rulesets — API creates the ruleset but cannot enable the Copilot toggle (GitHub-only feature; not applicable on Gitea)


### PR DESCRIPTION
## Summary

Conformance check #18 "Actions PR Permission" was documented as a required manual browser step with no automation path. Analysis during Gitea migration planning (issue #247) confirmed it is **not required** for our setup.

**Why it was wrong:** The "Allow GitHub Actions to create and approve pull requests" restriction applies exclusively to `GITHUB_TOKEN` (the built-in Actions bot token). Our `release-please.yml` uses `RELEASE_PLEASE_TOKEN` — a Personal Access Token that acts as a user, not as the Actions bot. User tokens bypass this restriction regardless of the repository setting.

`release-gate.yml` and `retrigger-ci.yml` use `GITHUB_TOKEN` only to edit existing PRs (labels, comments, close/reopen state) — not to create new ones. No creation = restriction doesn't apply.

## Changes

- **conformance-audit/checklist.md**: Check #18 renamed to "Release PAT Configured" — verifiable and automatable via `gh secret list` and `Set-DevkitSecrets.ps1`
- **docs/onboarding-checklist.md**: Phase 3 rewritten from "Manual GitHub UI Settings" to "Automated Repository Configuration". All three previous manual steps are either removed (3.1 not needed), automated via API (3.2/3.3), or explicitly marked optional (Copilot ruleset toggle)

## Result

Zero required human-in-the-loop steps for per-project automation setup on GitHub. The only remaining manual item is the Copilot review toggle (optional, informational, GitHub-only, not applicable on Gitea).

Closes part of #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)