### PR TITLE
fix: use 4-backtick outer fence in handoff-template.md to fix markdown lint

### DIFF
--- a/devspace/templates/handoff-template.md
+++ b/devspace/templates/handoff-template.md
@@ -5,7 +5,7 @@ Handoffs transfer work from Claude Chat (planning/design) to Claude Code (execut
 
 ## Required Sections
 
-```markdown
+````markdown
 # Handoff: <Title>
 
 **Date:** YYYY-MM-DD
@@ -69,6 +69,7 @@ even for documentation-only changes, autolearn entries, or config files.
 ```
 <type>: <description>
 ```
+````
 
 ## Template Usage Notes
 


### PR DESCRIPTION
## Summary

The 3-backtick outer fence in `devspace/templates/handoff-template.md` was broken by the first inner ` ```bash ` block, exposing template content as raw markdown and triggering MD029/MD031/MD033/MD040 lint errors in CI for all PRs branched from the current main.

**Fix:** Upgrade outer fence from 3 to 4 backticks so inner 3-backtick fences are treated as literal code content.

This unblocks CI for all pending PRs (#261–#268).

## Test plan

- [ ] CI markdown lint passes
- [ ] Template renders correctly with nested code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)