### PR TITLE
chore(rules): session review -- 3 gotchas, 1 pattern added

### DIFF
--- a/claude/rules/autolearn-patterns.md
+++ b/claude/rules/autolearn-patterns.md
@@ -1,7 +1,7 @@
 ---
 description: Learned patterns from past sessions. Read when encountering similar situations.
 tier: 2
-entry_count: 73
+entry_count: 74
 last_updated: "2026-03-09"
 ---
 
@@ -791,3 +791,22 @@ The env var (layer 1) covers the outer process stdout/stderr. The reconfigure ca
 keeps it safe on Python < 3.7. `subprocess.run` (layer 3) opens a new stream and
 ignores PYTHONIOENCODING, so it needs its own `encoding=` argument.
 **See also:** AP#11 (jq-replacement context where this pattern was first documented)
+
+## 123. PSScriptAnalyzer Brownfield Onboarding — Audit Before First CI Run
+
+**Added:** 2026-03-09 | **Source:** DevKit | **Status:** active
+
+**Category:** ci-config
+**Context:** Adding PSScriptAnalyzer CI to an existing repo with many PowerShell scripts surfaces pre-existing violations iteratively across multiple CI cycles (each 2-minute windows-latest run reveals a different set of failures). On DevKit: first run surfaced PSReviewUnusedParameter/PSUseSingularNouns, second run surfaced PSUseUsingScopeModifierInNewRunspaces/PSAvoidUsingPlainTextForPassword, third run surfaced PSUseBOMForUnicodeEncodedFile.
+**Fix:** Before pushing CI integration, run PSScriptAnalyzer locally against all scripts and resolve or exclude ALL violations in a single pass:
+
+```powershell
+$files = Get-ChildItem -Path setup,scripts -Recurse -Filter '*.ps1'
+$results = $files | ForEach-Object {
+    Invoke-ScriptAnalyzer -Path $_.FullName -Severity Warning,Error
+}
+$results | Format-Table -AutoSize
+```
+
+Create `PSScriptAnalyzerSettings.psd1` with justified exclusions before the first CI run. Common brownfield exclusions for DevKit-style repos: `PSAvoidUsingWriteHost`, `PSUseShouldProcessForStateChangingFunctions`, `PSReviewUnusedParameter` (ParameterSetName dispatch), `PSUseSingularNouns` (internal helpers), `PSAvoidAssignmentToAutomaticVariable` (loop vars named `$profile`), `PSUseUsingScopeModifierInNewRunspaces` (Start-Job with ArgumentList), `PSAvoidUsingPlainTextForPassword` ([object[]]$Credentials false positive), `PSUseBOMForUnicodeEncodedFile` (cross-platform git strips BOM).
+**See also:** KG#112 (Invoke-ScriptAnalyzer -Include invalid parameter), AP#84 (mandatory lint step language)

--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -1,7 +1,7 @@
 ---
 description: Known gotchas and platform-specific issues. Read when debugging unexpected behavior.
 tier: 2
-entry_count: 89
+entry_count: 92
 last_updated: "2026-03-09"
 ---
 
@@ -847,3 +847,45 @@ body = body.replace("\r\n", "\n")
 ```
 
 **See also:** KG#62 (CRLF breaks bash grep in CI); KG#101 (Edit tool CRLF matching failure -- same root cause, different surface)
+
+## 110. GitHub Actions New CI Job Uses Base Branch Workflow, Not PR Branch
+
+**Added:** 2026-03-09 | **Source:** DevKit | **Status:** active
+
+**Platform:** GitHub Actions
+**Issue:** When a PR introduces a new CI job for the first time, GitHub Actions runs the workflow from the BASE branch (usually `main`), not the PR branch. The new job doesn't exist on `main` yet, so it is silently absent from the CI run. The PR passes CI (the new job never runs), then ALL subsequent PRs fail because the job now exists on `main` and is broken.
+**Fix:** Before merging a PR that adds a new CI job, verify the job ran in the CI check list. If the new job name is absent from the check list, the workflow was evaluated from `main`. To test the new job, merge a trivially correct version first, then fix issues in follow-up PRs.
+**See also:** KG#66 (golangci-lint-action v7 schema enforcement -- same CI surprise pattern)
+
+## 111. markdownlint 3-Backtick Outer Fence Broken by Inner Backtick Blocks
+
+**Added:** 2026-03-09 | **Source:** DevKit | **Status:** active
+
+**Platform:** All (markdownlint-cli2)
+**Issue:** A fenced code block using ` ```language ` as the outer fence is terminated by the first inner ` ``` ` block it contains. Everything after the inner block is treated as regular markdown, triggering MD029, MD031, MD033, MD040, and other rules on content that was supposed to be inside the fence.
+**Fix:** When a code block's content contains triple-backtick fences (e.g., a markdown template or documentation showing code examples), use a 4-backtick outer fence:
+
+`````markdown
+````markdown
+...content with inner ```bash blocks...
+````
+`````
+
+Verify locally with `npx markdownlint-cli2 "path/to/file.md"` before pushing.
+
+## 112. Invoke-ScriptAnalyzer Has No -Include Parameter
+
+**Added:** 2026-03-09 | **Source:** DevKit | **Status:** active
+
+**Platform:** PowerShell / PSScriptAnalyzer
+**Issue:** `Invoke-ScriptAnalyzer -Path . -Include '*.ps1'` throws "A parameter cannot be found that matches parameter name 'Include'". The `-Include` parameter does not exist on `Invoke-ScriptAnalyzer`. Copilot and LLMs commonly generate this invalid syntax.
+**Fix:** Use `Get-ChildItem` to collect files, then pipe each to `Invoke-ScriptAnalyzer`:
+
+```powershell
+$files = Get-ChildItem -Path . -Recurse -Filter '*.ps1'
+$results = $files | ForEach-Object {
+    Invoke-ScriptAnalyzer -Path $_.FullName -Severity Warning,Error
+}
+```
+
+To scan only specific subdirectories, scope `Get-ChildItem -Path setup,scripts`.


### PR DESCRIPTION
## Summary

Session review for 2026-03-09 DevKit session (PSScriptAnalyzer CI integration sprint).

- **KG#110**: GitHub Actions new CI job uses base branch workflow, not PR branch — the root cause of why PR #267 (broken PSScriptAnalyzer job) passed CI and then broke all subsequent PRs
- **KG#111**: markdownlint 3-backtick outer fence broken by inner backtick blocks — root cause of lint failures in `devspace/templates/handoff-template.md`
- **KG#112**: `Invoke-ScriptAnalyzer` has no `-Include` parameter — Copilot generated invalid syntax; fixed in PR #271
- **AP#123**: PSScriptAnalyzer brownfield onboarding — audit all PS1 files locally before pushing CI to avoid iterative 2-minute CI cycles

All 4 findings also stored in MCP Memory knowledge graph.

## Validation

- `entry_count` updated: known-gotchas.md 89→92, autolearn-patterns.md 73→74
- `last_updated` confirmed: 2026-03-09 (already current)
- All findings passed validation: no dangerous patterns, no core principle conflicts