### PR TITLE
feat(skills): add Go goroutine deadlock analysis to systematic-debugging

### DIFF
--- a/claude/skills/systematic-debugging/SKILL.md
+++ b/claude/skills/systematic-debugging/SKILL.md
@@ -110,3 +110,73 @@ journalctl -u myservice -n 100 --no-pager
 - **Assuming** — "It must be X" without proof
 - **Not reproducing first** — Fixing blindly
 - **Stopping at symptoms** — Not finding root cause
+
+## Go: Goroutine Deadlock Analysis
+
+When `go test` times out with a goroutine dump, use this structured approach.
+
+### Step 1: Identify the lock holder
+
+Find the goroutine that HOLDS the mutex (it won't say "Mutex.Lock" — it will be
+blocked elsewhere while owning it):
+
+```text
+goroutine N [chan send]:          ← blocked on channel while holding mutex
+goroutine N [chan receive]:       ← blocked waiting for data
+goroutine N [sync.WaitGroup.Wait]:  ← waiting for workers to finish
+```
+
+### Step 2: Identify all waiters
+
+Look for `[sync.Mutex.Lock]` goroutines — these are blocked trying to acquire the mutex.
+Note which functions they're in and at what line numbers.
+
+### Step 3: Struct field offset calculation
+
+If goroutine dump line numbers don't match current source (stale binary suspect),
+use the struct pointer and mutex address to verify which mutex is being contended:
+
+```text
+Pool at 0x...e480, mutex at 0x...e4e0
+Offset = 0xe4e0 - 0xe480 = 0x60 = 96 bytes
+
+Count field sizes from struct definition:
+  registry   *T    = 8 bytes  (offset 0)
+  tracker    iface = 16 bytes (offset 8)
+  store      iface = 16 bytes (offset 24)
+  costs      *T    = 8 bytes  (offset 40)
+  workers    int   = 8 bytes  (offset 48)
+  tasks      chan  = 8 bytes  (offset 56)
+  wg    WaitGroup  = 12 bytes (offset 64, padded to 16 → offset 80... check alignment)
+  ...
+  mu    sync.Mutex = 8 bytes  (offset 96 = 0x60) ✓ MATCH
+```
+
+If the offset matches the current struct layout, the **struct is unchanged** but
+line numbers differ — confirms a stale binary with code added/removed above the mutex.
+
+### Step 4: Stale binary check
+
+If line numbers don't match current source:
+
+```bash
+# Check when the file was last committed vs when the test binary was compiled
+git log --format="%H %ai %s" -- internal/pkg/file.go
+
+# If the file was committed AFTER the test was launched, binary is stale.
+# Verify by running fresh:
+go test -count=1 -timeout 30s ./internal/pkg/...
+# If it passes → current code is already fixed, old binary had the bug.
+```
+
+### Step 5: Deadlock cycle checklist
+
+```text
+Classic pool deadlock cycle:
+□ Submit() holds mu → blocked on buffered channel send (buffer full)
+□ Workers need to drain channel → workers also need mu
+□ Shutdown() needs mu → also blocked
+
+Root cause: a field read by workers was protected by mu.
+Fix: switch to atomic.Pointer / atomic.Value for worker-hot-path fields.
+```


### PR DESCRIPTION
## Summary

- Adds a structured 5-step Go deadlock analysis section to the `systematic-debugging` skill
- Covers goroutine dump reading, struct offset math, stale binary detection, and the classic pool deadlock cycle pattern
- Closes #273 (Go pool deadlock — Submit-holds-mutex + worker-needs-mutex + atomic.Pointer fix)
- Closes #272 (Go background task binary compiles at launch time — stale line numbers)

## Test plan

- [ ] Markdown lint passes
- [ ] Skill routing validation passes (no routing changes)
- [ ] Skill count check passes (no new skills added)