### PR TITLE
feat(credentials): integrate HomeLabVault credential management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ CLAUDE.local.md
 
 # Machine-specific devkit config (written by bootstrap.ps1)
 .devkit-config.json
+.devkit-config.json.bak*
+
+# Credential backups from vault migration
+.credentials.bak-*
 
 # Machine state snapshots (hardware-specific, contain serial numbers)
 machine/SystemConfig*.txt

--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ cp claude/settings.template.json ~/.claude/settings.json
 ```bash
 # Copy and customize the desktop config
 cp mcp/claude-desktop.template.json "$HOME/.config/Claude/claude_desktop_config.json"
-# Edit the file and replace all <PLACEHOLDER> values with your tokens/paths
+# Edit the file: replace <PATH> placeholders with machine-specific paths
+# Secret tokens are read from environment variables (populated by HomeLabVault)
+# See docs/credentials.md for the full credential workflow
 ```
 
 See [mcp/servers.md](mcp/servers.md) for the full server inventory and install instructions.
@@ -217,7 +219,7 @@ With symlinks active, changes flow automatically:
 
 ## What's NOT in This Repo
 
-- **API keys and tokens** — Use placeholders in templates, fill in per machine
+- **API keys and tokens** — Stored in HomeLabVault, consumed via env vars ([docs/credentials.md](docs/credentials.md))
 - **MCP Memory data** — Accumulates organically; see `mcp/memory-seeds.md` for bootstrap
 - **Session state** — Debug logs, file history, task state (machine-specific, not portable)
 - **Project-specific CLAUDE.md** — Each project has its own; only the template is here

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,0 +1,147 @@
+# Credentials Management
+
+DevKit uses a centralized vault-based credential system. Secrets are stored once
+in an encrypted vault and made available to all shells and tools via persistent
+user-level environment variables.
+
+## Architecture
+
+```text
+PowerShell SecretStore Vault (HomeLabVault)
+    |
+    |  sync-secrets (PS7 profile helper)
+    v
+User-level Environment Variables (HKCU\Environment)
+    |
+    |  Inherited automatically
+    v
+All shells: PowerShell 5/7, CMD, Git Bash, WSL, Claude Code
+```
+
+## Environment Variables
+
+These user-level environment variables are set by the vault and available in
+every shell session:
+
+| Env Var | Vault Name | Purpose |
+|---------|------------|---------|
+| `ANTHROPIC_API_KEY` | `anthropic/api-key` | Anthropic Claude API key |
+| `OPENAI_API_KEY` | `openai/api-key` | OpenAI API key |
+| `GITHUB_TOKEN` | `github/pat-personal` | GitHub fine-grained PAT (repos, actions, gh CLI) |
+| `GITHUB_MCP_TOKEN` | `github/pat-mcp` | GitHub classic PAT (MCP servers, Docker MCP) |
+| `GITEA_TOKEN` | `gitea/pat-homelab` | Gitea PAT for gitea.herbhall.net |
+| `GITEA_DISPATCHER_TOKEN` | `gitea/pat-dispatcher` | Gitea dispatcher service token |
+| `CLOUDFLARE_API_TOKEN` | `cloudflare/api-token` | Cloudflare DNS API token |
+| `HOME_ASSISTANT_TOKEN` | `homeassistant/token` | Home Assistant long-lived access token |
+| `SAMVERK_AUTH_TOKEN` | `samverk/auth-token` | Samverk MCP bearer token |
+
+## Common Operations
+
+### Add a new secret
+
+```powershell
+# In PowerShell 7 (pwsh)
+nvs 'category/secret-name' 'secret-value'
+sync-secrets
+```
+
+This stores the secret in the vault and pushes it to a user-level environment
+variable. New shell sessions pick it up automatically; existing sessions need
+to restart or refresh their environment.
+
+### Rotate a secret
+
+```powershell
+# In PowerShell 7 (pwsh)
+nvs 'category/secret-name' 'new-secret-value'
+sync-secrets
+```
+
+Same as adding -- `nvs` overwrites the existing value, then `sync-secrets`
+updates the environment variable.
+
+### Read a secret
+
+```powershell
+# From the vault directly (PS7 only)
+gvs 'category/secret-name'
+
+# From any shell via env var
+echo $GITHUB_TOKEN        # bash
+echo $env:GITHUB_TOKEN    # PowerShell
+echo %GITHUB_TOKEN%       # CMD
+```
+
+### Distribute secrets to GitHub repos
+
+DevKit's `Set-DevkitSecrets.ps1` pushes secrets to GitHub/Gitea repos as
+Actions secrets. It reads from environment variables when the vault migration
+marker is present in `~/.devkit-config.json`:
+
+```powershell
+# All repos
+.\scripts\Set-DevkitSecrets.ps1
+
+# Single repo
+.\scripts\Set-DevkitSecrets.ps1 -Repo HerbHall/myproject
+```
+
+## How DevKit Scripts Consume Secrets
+
+Scripts follow a priority chain:
+
+1. **Vault migration detected** (`_note` field in `~/.devkit-config.json` `.Secrets`
+   block) -- read from user-level environment variables
+2. **Legacy `.Secrets` block** -- read directly from `~/.devkit-config.json`
+   (pre-migration machines)
+3. **Direct env var fallback** -- check environment variables as last resort
+
+This means scripts work on both migrated and unmigrated machines without changes.
+
+## Legacy Systems
+
+### ~/.devkit-config.json .Secrets block
+
+Before the vault migration, secrets were stored directly in this JSON file.
+After migration, the block contains only a `_note` field:
+
+```json
+{
+  "Secrets": {
+    "_note": "Secrets moved to PowerShell SecretStore vault (HomeLabVault)...",
+    "_migration_date": "2026-03-09"
+  }
+}
+```
+
+Scripts detect this marker and fall back to environment variables.
+
+### Windows Credential Manager (setup/lib/credentials.ps1)
+
+The `devkit/` prefixed entries in Windows Credential Manager (via `cmdkey`/P-Invoke)
+are superseded by the vault. The module is retained for backward compatibility but
+new secrets should use the vault.
+
+### Plaintext files (~/.credentials/)
+
+Removed during migration. Backups at `~/.credentials.bak-2026-03-09/`. Never
+store secrets in plaintext files.
+
+## Security Rules
+
+- **Never** store secrets in code, config files, or plaintext
+- **Never** commit `.devkit-config.json`, `.env`, or `*.local.json` (all gitignored)
+- **Always** use environment variables in scripts (not hardcoded values)
+- **Always** run `sync-secrets` after rotating a secret in the vault
+- Template files use `<PLACEHOLDER>` markers or `${ENV_VAR}` references, never real values
+
+## SSH Configuration
+
+Host aliases are configured in `~/.ssh/config` for common targets:
+
+```text
+ssh proxmox    ssh samverk    ssh unraid
+ssh gitea      ssh dns-proxy  ssh ollama    ssh ha
+```
+
+All use `id_ed25519` key with root user.

--- a/mcp/claude-desktop.template.json
+++ b/mcp/claude-desktop.template.json
@@ -1,5 +1,10 @@
 {
-  "_comment": "Copy to %APPDATA%/Claude/claude_desktop_config.json and replace <PLACEHOLDER> values",
+  "_comment": [
+    "Copy to %APPDATA%/Claude/claude_desktop_config.json",
+    "Secrets come from user-level environment variables (populated by HomeLabVault via sync-secrets).",
+    "Replace <PATH> placeholders with machine-specific paths.",
+    "See docs/credentials.md for the full credential workflow."
+  ],
   "mcpServers": {
     "sequential-thinking": {
       "command": "npx",
@@ -15,14 +20,16 @@
     },
     "sqlite": {
       "command": "npx",
-      "args": ["-y", "mcp-sqlite", "<PATH_TO_DATABASES>/claude.db"]
+      "args": ["-y", "mcp-sqlite", "<PATH_TO_DATABASES>/claude.db"],
+      "_comment": "Replace <PATH_TO_DATABASES> with your databases directory (e.g. ~/databases)"
     },
     "github": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-github"],
       "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "<GITHUB_PAT>"
-      }
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_MCP_TOKEN}"
+      },
+      "_comment": "Uses GITHUB_MCP_TOKEN env var (classic PAT for MCP servers)"
     },
     "gitlab": {
       "command": "npx",
@@ -30,7 +37,8 @@
       "env": {
         "GITLAB_PERSONAL_ACCESS_TOKEN": "<GITLAB_PAT>",
         "GITLAB_API_URL": "https://gitlab.com/api/v4"
-      }
+      },
+      "_comment": "GitLab PAT not yet in vault -- replace manually if needed"
     },
     "docker-local": {
       "command": "uvx",
@@ -41,15 +49,17 @@
       "args": ["mcp-server-docker"],
       "env": {
         "DOCKER_HOST": "ssh://<USER>@<UNRAID_HOST>"
-      }
+      },
+      "_comment": "Replace with SSH host alias from ~/.ssh/config (e.g. ssh://root@unraid)"
     },
     "hass-mcp": {
       "command": "uvx",
       "args": ["hass-mcp"],
       "env": {
         "HA_URL": "http://<HOME_ASSISTANT_HOST>:8123",
-        "HA_TOKEN": "<HA_LONG_LIVED_TOKEN>"
-      }
+        "HA_TOKEN": "${HOME_ASSISTANT_TOKEN}"
+      },
+      "_comment": "Uses HOME_ASSISTANT_TOKEN env var. Replace <HOME_ASSISTANT_HOST> with your HA hostname."
     },
     "MCP_DOCKER": {
       "command": "docker",
@@ -58,11 +68,13 @@
         "LOCALAPPDATA": "<LOCALAPPDATA_PATH>",
         "ProgramData": "<PROGRAMDATA_PATH>",
         "ProgramFiles": "<PROGRAMFILES_PATH>"
-      }
+      },
+      "_comment": "Windows system paths -- typically auto-detected. Only set if Docker MCP gateway needs explicit paths."
     },
     "filesystem-docker": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "-v", "<HOME_DIR>:/workspace", "mcp/filesystem", "/workspace"]
+      "args": ["run", "-i", "--rm", "-v", "<HOME_DIR>:/workspace", "mcp/filesystem", "/workspace"],
+      "_comment": "Replace <HOME_DIR> with your home directory path"
     },
     "playwright-docker": {
       "command": "docker",

--- a/scripts/Set-DevkitSecrets.ps1
+++ b/scripts/Set-DevkitSecrets.ps1
@@ -5,11 +5,13 @@
     Distributes secrets from ~/.devkit-config.json to GitHub repos.
 
 .DESCRIPTION
-    Reads the .Secrets block from ~/.devkit-config.json and pushes each
-    key/value pair as a GitHub Actions secret to one or all repos owned
-    by the configured GitHub user.
+    Distributes secrets to GitHub/Gitea repos as Actions secrets.
 
-    Replaces the one-off D:\DevSpace\scripts\Set-ReleasePleaseToken.ps1.
+    Secret sources (checked in order):
+    1. If ~/.devkit-config.json .Secrets block contains a _note field
+       (vault migration marker), reads from user-level environment
+       variables populated by the HomeLabVault via sync-secrets.
+    2. Otherwise reads directly from the .Secrets block (legacy path).
 
 .PARAMETER Repo
     Push secrets to a single repo (e.g. HerbHall/myproject).
@@ -67,19 +69,58 @@ if (-not $config.PSObject.Properties['Secrets']) {
 
 $secrets = $config.Secrets
 
-# Validate that .Secrets is a non-null object with at least one property
-if ($null -eq $secrets -or $secrets.PSObject.Properties.Count -eq 0) {
-    Write-Error "The .Secrets block in $configFile must be a non-null object with at least one property"
-    exit 1
-}
-$secretNames = @($secrets.PSObject.Properties.Name)
+# ---------------------------------------------------------------------------
+# If the Secrets block has been migrated to the vault (contains _note field),
+# fall back to reading secrets from environment variables instead.
+# ---------------------------------------------------------------------------
+$useEnvVars = $false
+if ($null -ne $secrets -and $secrets.PSObject.Properties['_note']) {
+    Write-Host 'Secrets block migrated to vault -- reading from environment variables'
+    $useEnvVars = $true
 
-if ($secretNames.Count -eq 0) {
-    Write-Warning 'No secrets defined in .Secrets block -- nothing to do'
-    exit 0
-}
+    # Map: GitHub Actions secret name -> environment variable name
+    $envMapping = @{
+        'RELEASE_PLEASE_TOKEN'   = 'GITHUB_TOKEN'
+        'GITHUB_MCP_TOKEN'       = 'GITHUB_MCP_TOKEN'
+        'HOME_ASSISTANT_TOKEN'   = 'HOME_ASSISTANT_TOKEN'
+        'CLOUDFLARE_API_TOKEN'   = 'CLOUDFLARE_API_TOKEN'
+        'GITEA_ACCESS_TOKEN'     = 'GITEA_TOKEN'
+        'SAMVERK_AUTH_TOKEN'     = 'SAMVERK_AUTH_TOKEN'
+        'ANTHROPIC_API_KEY'      = 'ANTHROPIC_API_KEY'
+        'GITEA_DISPATCHER_TOKEN' = 'GITEA_DISPATCHER_TOKEN'
+    }
 
-Write-Host "Secrets to distribute: $($secretNames -join ', ')"
+    # Build a secrets hashtable from env vars
+    $resolvedSecrets = @{}
+    foreach ($pair in $envMapping.GetEnumerator()) {
+        $val = [System.Environment]::GetEnvironmentVariable($pair.Value, 'User')
+        if (-not [string]::IsNullOrWhiteSpace($val)) {
+            $resolvedSecrets[$pair.Key] = $val
+        }
+    }
+
+    if ($resolvedSecrets.Count -eq 0) {
+        Write-Error "No secrets found in environment variables. Run sync-secrets in PowerShell 7 to push vault to env vars."
+        exit 1
+    }
+
+    $secretNames = @($resolvedSecrets.Keys)
+    Write-Host "Secrets to distribute (from env): $($secretNames -join ', ')"
+} else {
+    # Legacy path: read directly from .Secrets block in config file
+    if ($null -eq $secrets -or $secrets.PSObject.Properties.Count -eq 0) {
+        Write-Error "The .Secrets block in $configFile must be a non-null object with at least one property"
+        exit 1
+    }
+    $secretNames = @($secrets.PSObject.Properties.Name)
+
+    if ($secretNames.Count -eq 0) {
+        Write-Warning 'No secrets defined in .Secrets block -- nothing to do'
+        exit 0
+    }
+
+    Write-Host "Secrets to distribute: $($secretNames -join ', ')"
+}
 
 # ---------------------------------------------------------------------------
 # Resolve target repos
@@ -150,7 +191,7 @@ foreach ($targetRepo in $repos) {
     Write-Host "`n  $targetRepo"
 
     foreach ($secretName in $secretNames) {
-        $secretValue = $secrets.$secretName
+        $secretValue = if ($useEnvVars) { $resolvedSecrets[$secretName] } else { $secrets.$secretName }
 
         if ([string]::IsNullOrWhiteSpace($secretValue)) {
             Write-Warning "    $secretName -- empty value, skipping"

--- a/setup/lib/credentials.ps1
+++ b/setup/lib/credentials.ps1
@@ -1,5 +1,14 @@
 # setup/lib/credentials.ps1 -- Windows Credential Manager integration
 #
+# STATUS: SUPERSEDED (2026-03-09)
+#   The primary secret store is now PowerShell SecretStore vault (HomeLabVault).
+#   Secrets are pushed to user-level environment variables via sync-secrets.
+#   See docs/credentials.md for the current architecture.
+#
+#   This module is retained for backward compatibility. Existing devkit/
+#   entries in Windows Credential Manager still work. New secrets should
+#   be stored in the vault instead.
+#
 # Provides: Set-DevkitCredential, Get-DevkitCredential, Test-DevkitCredential,
 #           Remove-DevkitCredential, Invoke-CredentialCollection
 # Stores API tokens and secrets in Windows Credential Manager via cmdkey.

--- a/setup/new-project.ps1
+++ b/setup/new-project.ps1
@@ -958,13 +958,22 @@ logger:
         if (Test-Path $configFile) {
             try {
                 $config = Get-Content $configFile -Raw | ConvertFrom-Json
-                if ($config.PSObject.Properties['Secrets'] -and
-                    $config.Secrets.PSObject.Properties['RELEASE_PLEASE_TOKEN']) {
-                    $rpt = $config.Secrets.RELEASE_PLEASE_TOKEN
+                if ($config.PSObject.Properties['Secrets']) {
+                    if ($config.Secrets.PSObject.Properties['_note']) {
+                        # Vault migration: read from env var instead
+                        $rpt = [System.Environment]::GetEnvironmentVariable('GITHUB_TOKEN', 'User')
+                    } elseif ($config.Secrets.PSObject.Properties['RELEASE_PLEASE_TOKEN']) {
+                        $rpt = $config.Secrets.RELEASE_PLEASE_TOKEN
+                    }
                 }
             } catch {
                 # Ignore parse errors
             }
+        }
+
+        # Final fallback: try env var directly (covers machines without config file)
+        if ([string]::IsNullOrWhiteSpace($rpt)) {
+            $rpt = [System.Environment]::GetEnvironmentVariable('GITHUB_TOKEN', 'User')
         }
 
         if (-not [string]::IsNullOrWhiteSpace($rpt)) {
@@ -981,9 +990,9 @@ logger:
                 Write-Warn "Run manually: gh secret set RELEASE_PLEASE_TOKEN --repo $githubUser/$projectName"
             }
         } else {
-            Write-Warn 'RELEASE_PLEASE_TOKEN not found in ~/.devkit-config.json -- skipping'
+            Write-Warn 'RELEASE_PLEASE_TOKEN not found -- skipping'
             Write-Warn "Run manually: gh secret set RELEASE_PLEASE_TOKEN --repo $githubUser/$projectName"
-            Write-Warn 'To automate: add .Secrets.RELEASE_PLEASE_TOKEN to ~/.devkit-config.json'
+            Write-Warn 'To automate: run sync-secrets in PS7 to push vault secrets to env vars'
         }
     }
 


### PR DESCRIPTION
## Summary

- Scripts detect vault migration (`_note` marker in `.Secrets` block) and fall back to user-level environment variables populated by HomeLabVault
- `Set-DevkitSecrets.ps1`: env var mapping for 8 secrets with legacy path preserved
- `new-project.ps1`: vault-aware `RELEASE_PLEASE_TOKEN` with env var fallback chain
- `claude-desktop.template.json`: replaced hardcoded `<PLACEHOLDER>` tokens with `${ENV_VAR}` references and inline docs
- `credentials.ps1`: marked SUPERSEDED, kept functional for backward compat
- `docs/credentials.md`: new documentation covering vault architecture, common operations, and security rules
- `.gitignore`: added backup file patterns from vault migration

## Test plan

- [x] JSON template validates (`python -c "import json; json.load(...)"`)
- [x] Both PS1 scripts parse without errors (AST parser check)
- [x] `docs/credentials.md` passes markdownlint (0 errors)
- [x] `README.md` passes markdownlint (0 errors)
- [ ] CI markdown lint passes
- [ ] CI skill routing validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)