### PR TITLE
chore: formalize DevKit as Samverk-managed project

### DIFF
--- a/.samverk/project.yaml
+++ b/.samverk/project.yaml
@@ -1,0 +1,28 @@
+# Samverk Project Configuration — DevKit
+schema_version: "1.0.0"
+project:
+  name: devkit
+  description: "AI development methodology and Claude Code configuration toolkit"
+  forge: github
+  repo: HerbHall/devkit
+  url: https://github.com/HerbHall/devkit
+  license: MIT
+  stack: powershell
+  phase: execution
+  created: "2025-12-01"
+
+lifecycle:
+  current_phase: execution
+  phases_completed:
+    - intake
+    - research
+    - requirements
+    - scaffold
+  notes: "DevKit predates Samverk and was formalized retroactively. Phases 1-5 were completed organically before Samverk lifecycle management existed."
+
+autonomy:
+  tier_overrides:
+    # DevKit rules files are auto-loaded by all sessions —
+    # changes have broad impact, so raise the tier.
+    rules_file_edit: 3
+    skill_modification: 2

--- a/.samverk/status.md
+++ b/.samverk/status.md
@@ -1,39 +1,44 @@
 ---
-phase: active-maintenance
-updated: 2026-03-08T01:00:00Z
-updated_by: claude-code
+phase: execution
+updated: 2026-03-09T15:00:00Z
+updated_by: claude-chat
+managed_by: samverk
 ---
 
-# DevKit -- Current State
+# DevKit — Current State
 
 ## Phase
 
-Active maintenance: AI tooling methodology, Claude Code configuration toolkit.
-Latest: verify.ps1 implemented, skill-audit added, Gitea CI fallback.
+Active maintenance and execution. AI tooling methodology, Claude Code configuration toolkit.
+**Now formally managed by Samverk** (formalized 2026-03-09, retroactive lifecycle phases 1-5).
 
 ## What Is Running
 
 - Symlinked rules loaded by all Claude Code sessions via ~/.claude/
 - 21 skills, 7 agents, 8 rules files, 135+ patterns
 - SessionStart hook for context injection
+- Credentials migrated to PowerShell SecretStore vault (HomeLabVault)
 
 ## In Flight
 
-- No active work
+- Synapset integration research (OpenBrain-inspired vector memory for autolearn)
+- Credential management integration (Set-DevkitSecrets.ps1 patched for vault)
 
 ## Queued
 
-- No open issues -- backlog driven by cross-project conformance needs
+- Update MCP template for vault-based credential references
+- Review setup/lib/credentials.ps1 compatibility with vault
+- docs/credentials.md for new vault workflow
+- Synapset consumer integration (autolearn → vector memory)
 
-## Last Session Summary
+## Related Projects
 
-Implemented verify.ps1 (Kit 4), added KG#101 (Edit tool CRLF),
-KG#102 (dispatcher false-positive), skill-audit conformance tool,
-and Gitea CI graceful fallback for quality-control.
+- **Synapset** (gitea:samverk-admin/synapset) — Vector memory MCP server, DevKit is primary consumer
+- **Samverk** (github:HerbHall/samverk) — Project lifecycle manager
 
 ## Start Here (Cold Start Protocol)
 
 1. Read this file
-2. Samverk MCP not yet configured for this project -- skip step 2
+2. Check .samverk/project.yaml for lifecycle context
 3. Read open issues if relevant to the task
-4. Proceed -- do not ask the user to explain project state
+4. Proceed — do not ask the user to explain project state


### PR DESCRIPTION
Adds Samverk project overlay to DevKit.

## Changes
- .samverk/project.yaml — lifecycle configuration, forge/repo metadata, autonomy tier overrides
- .samverk/status.md — updated with Samverk management context, related projects, credential migration status

## Context
DevKit is now formally managed by Samverk. Lifecycle phases 1-5 were completed organically before Samverk existed; this formalizes that retroactively.

Tier overrides raise rules_file_edit to Tier 3 (broad impact across all sessions) and skill_modification to Tier 2.