### PR TITLE
fix(setup): remove Set-StrictMode from dot-sourced credentials.ps1

### DIFF
--- a/setup/lib/credentials.ps1
+++ b/setup/lib/credentials.ps1
@@ -16,7 +16,8 @@
 
 #Requires -Version 7.0
 
-Set-StrictMode -Version Latest
+# NOTE: Do NOT add Set-StrictMode here -- this file is dot-sourced by callers
+# and StrictMode propagates to their scope (see KG#114).
 
 # ---------------------------------------------------------------------------
 # P/Invoke type for reading Generic credentials from Windows Credential Manager


### PR DESCRIPTION
## Summary

- Remove `Set-StrictMode` from `setup/lib/credentials.ps1` — this file is dot-sourced, so StrictMode propagates to callers (KG#114)
- Delete untracked `devspace/templates/handoff-OpenBrain.md` (project renamed to Synapset)

## Context

Jobs 2-4 from the credentials integration work were already completed in a prior session:
- `docs/credentials.md` — already exists with full vault architecture docs
- `mcp/claude-desktop.template.json` — already uses `${ENV_VAR}` references
- `setup/lib/credentials.ps1` — already has SUPERSEDED header; this PR fixes remaining KG#114 violation

## Test plan

- [ ] CI passes (PowerShell lint, markdown lint)
- [x] `credentials.ps1` no longer sets StrictMode for callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)