### PR TITLE
chore(mcp): add ollama-local entry to MCP template

### DIFF
--- a/mcp/claude-desktop.template.json
+++ b/mcp/claude-desktop.template.json
@@ -79,6 +79,14 @@
     "playwright-docker": {
       "command": "docker",
       "args": ["run", "-i", "--rm", "mcp/playwright"]
+    },
+    "ollama-local": {
+      "command": "npx",
+      "args": ["-y", "ollama-mcp-server"],
+      "env": {
+        "OLLAMA_HOST": "http://localhost:11435"
+      },
+      "_comment": "Local Ollama instance. Default port is 11434; use 11435 if running alongside another instance."
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `ollama-local` MCP server entry (ollama-mcp-server on localhost:11435)

## Test plan

- [x] JSON validates successfully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)