### PR TITLE
fix(docs): update stale pattern counts in README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ bash setup/legacy/verify.sh
 devkit/
 ├── claude/              - Claude Code config (rules, skills, agents, hooks)
 │   ├── CLAUDE.md        - Global instructions (installed to ~/.claude/)
-│   ├── rules/           - Auto-loaded pattern files (10 files, 153+ patterns)
+│   ├── rules/           - Auto-loaded pattern files (10 files, 170+ patterns)
 │   ├── skills/          - Invokable skills (21 skills with workflow files)
 │   ├── agents/          - Agent templates (7 agents)
 │   └── hooks/           - SessionStart hook

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Setup creates symlinks from `~/.claude/` to the DevKit clone (or copies files in
 | Skills (invoke with `/skill-name`) | 21 skills | `claude/skills/` |
 | Agent templates | 7 agents | `claude/agents/` |
 | SessionStart hook | 1 | `claude/hooks/` |
-| Setup + verification scripts | 3 | `setup/legacy/` |
+| Setup scripts (PowerShell + legacy bash) | 7+3 | `setup/` + `setup/legacy/` |
 
 ### Templates (customize per user/machine)
 
@@ -61,7 +61,7 @@ See [Settings Strategy](docs/settings-strategy.md) for the two-layer permission 
 
 | Directory | Purpose |
 |-----------|---------|
-| `claude/` | Global Claude Code config — CLAUDE.md, 10 rules files (153+ patterns), 21 skills, 7 agent templates, hooks |
+| `claude/` | Global Claude Code config — CLAUDE.md, 10 rules files (170+ patterns), 21 skills, 7 agent templates, hooks |
 | `devspace/` | Workspace shared configs — .editorconfig, .markdownlint.json, VS Code fragments |
 | `docs/` | Human-readable guides — architecture decisions, profile format spec |
 | `machine/` | Machine state snapshots — VS Code extensions, tool versions |
@@ -232,11 +232,11 @@ With symlinks active, changes flow automatically:
 | File | Entries | Purpose |
 |------|---------|---------|
 | `agent-team-coordination.md` | - | Multi-agent team coordination rules and anti-patterns |
-| `autolearn-patterns.md` | 71 | Learned patterns: lint fixes, CI config, architecture, testing |
+| `autolearn-patterns.md` | 75 | Learned patterns: lint fixes, CI config, architecture, testing |
 | `compaction-recovery.md` | - | Context compaction recovery rules and loop detection |
 | `core-principles.md` | 10 | Immutable core principles (Tier 0) |
 | `error-policy.md` | - | Zero-tolerance error policy and fix-forward workflow (Tier 1) |
-| `known-gotchas.md` | 82 | Platform issues: Windows, GitHub, Go, React, Docker |
+| `known-gotchas.md` | 95 | Platform issues: Windows, GitHub, Go, React, Docker |
 | `markdown-style.md` | - | Markdownlint conventions |
 | `review-policy.md` | - | Independent review policy: mandatory triggers and scope |
 | `subagent-ci-checklist.md` | - | Pre-commit CI validation checklists |


### PR DESCRIPTION
## Summary

- Update autolearn-patterns.md count: 71 -> 75
- Update known-gotchas.md count: 82 -> 95
- Update total pattern count: 153+ -> 170+
- Clarify setup scripts row to include PowerShell scripts (7+3)

Found via docs-vs-reality audit.

## Test plan

- [ ] CI passes (markdown lint, template validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)