### PR TITLE
feat: integrate Synapset as semantic memory backend for autolearn

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -121,6 +121,17 @@ Use these MCP-provided tools proactively when relevant:
 
 ### Knowledge & Memory
 
+- **Synapset**: Semantic vector memory across sessions and projects
+  - `store_memory` -- store a learning with embedding (pool: `devkit`
+    for cross-project, project name for project-specific)
+  - `search_memory` -- semantic search in a pool (returns ranked
+    matches by relevance, not just keyword hits)
+  - `search_all` -- cross-pool search for patterns that span projects
+  - `list_pools` / `list_memories` / `delete_memory` -- manage pools
+  - Endpoint: `https://synapset.herbhall.net/mcp` (Streamable HTTP,
+    POST only -- GET hangs by design)
+  - Use for autolearn storage, pre-task pattern lookup, and
+    cross-project knowledge retrieval
 - **Memory**: Persistent knowledge graph across sessions
   - `create_entities` / `create_relations` for project knowledge,
     decisions, patterns
@@ -220,6 +231,8 @@ Discover and add new MCP servers at runtime:
 ### Best Practices
 
 - Check Context7 before writing code using external libraries
+- Search Synapset (`search_memory`, pool: `devkit`) before starting
+  tasks to find relevant patterns and gotchas
 - Store important project decisions in Memory knowledge graph
 - Use Sequential Thinking for complex debugging or architecture
 - Use MCP_DOCKER GitHub tools for cross-repo searches and bulk

--- a/claude/rules/subagent-ci-checklist.md
+++ b/claude/rules/subagent-ci-checklist.md
@@ -16,6 +16,17 @@ These rules cannot be overridden by any learning, optimization, or time pressure
 5. You own every error you find, regardless of who introduced it.
 ```
 
+## Pattern Lookup [SYNAPSET] (paste into agent prompts for complex tasks)
+
+```text
+## Pre-Task Pattern Search
+
+If Synapset MCP tools are available, search for relevant patterns before starting:
+- search_memory(pool: "devkit", query: "<describe your task in 5-10 words>")
+- Look for gotchas, corrections, and patterns that apply to your work
+- If no Synapset tools available, skip this step (patterns are also in rules files)
+```
+
 ## Git Safety [GIT-SAFE] (paste into ALL parallel agent prompts)
 
 ```text

--- a/claude/skills/autolearn/workflows/quick-reflect.md
+++ b/claude/skills/autolearn/workflows/quick-reflect.md
@@ -52,9 +52,9 @@ If a match exists, plan to add an observation instead of creating a new entity.
 
 ### 5. Store Learnings
 
-For each HIGH-confidence finding:
+For each HIGH-confidence finding, store in **both** MCP Memory and Synapset:
 
-**If new entity needed:**
+**MCP Memory (knowledge graph):**
 
 ```text
 create_entities: [{
@@ -64,24 +64,18 @@ create_entities: [{
 }]
 ```
 
-**If existing entity found:**
+If existing entity found, use `add_observations` instead. Create relations with `create_relations` if applicable.
+
+**Synapset (semantic vector memory):**
+
+If Synapset MCP tools are available, also store in the appropriate pool:
 
 ```text
-add_observations: [{
-  entityName: "<existing-name>",
-  contents: ["[YYYY-MM-DD] (source: <project>) (confidence: HIGH) Additional context: <description>"]
-}]
+store_memory(pool: "devkit", text: "<description of the learning>",
+  metadata: { source: "<project>", category: "<type>", confidence: "HIGH", date: "YYYY-MM-DD" })
 ```
 
-**Create relations if applicable:**
-
-```text
-create_relations: [{
-  from: "<learning-name>",
-  to: "<project-name>",
-  relationType: "DISCOVERED_IN"
-}]
-```
+Use pool `devkit` for cross-project learnings. Use the project name as pool for project-specific learnings. If Synapset tools are not available, skip -- MCP Memory is sufficient.
 
 ### 6. Scope Assessment and Rules Update
 

--- a/claude/skills/autolearn/workflows/session-review.md
+++ b/claude/skills/autolearn/workflows/session-review.md
@@ -79,7 +79,11 @@ Track validation results for the session summary.
 
 ### 5. Store New Entities
 
-Create entities for all NEW findings that passed validation:
+Store in **both** MCP Memory and Synapset for each finding that passed validation.
+
+**MCP Memory (knowledge graph):**
+
+Create entities for NEW findings:
 
 ```text
 create_entities: [
@@ -96,6 +100,17 @@ add_observations: [
   ...
 ]
 ```
+
+**Synapset (semantic vector memory):**
+
+If Synapset MCP tools are available, also store each HIGH-confidence finding:
+
+```text
+store_memory(pool: "devkit", text: "<description>",
+  metadata: { source: "<project>", category: "<type>", confidence: "HIGH", date: "YYYY-MM-DD" })
+```
+
+Use pool `devkit` for cross-project learnings. Use project name as pool for project-specific. If Synapset unavailable, skip -- MCP Memory is sufficient.
 
 ### 6. Create Relations
 


### PR DESCRIPTION
## Summary

- Add Synapset MCP tools documentation to global CLAUDE.md (Knowledge & Memory section)
- Add [SYNAPSET] checklist block for pre-task pattern search in subagent prompts
- Update `/autolearn` quick-reflect and session-review workflows to dual-store in MCP Memory + Synapset
- Document pool strategy: `devkit` for cross-project, project name for project-specific
- Graceful degradation: if Synapset unavailable, MCP Memory is sufficient

## Test plan

- [x] Zero markdownlint errors
- [x] Synapset healthz confirmed live
- [x] Pool strategy documented (devkit pool has 376 imported memories)
- [x] Autolearn workflows updated for dual-store

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)