### PR TITLE
chore(rules): compact rules files under 35k

### DIFF
--- a/claude/rules/archive/autolearn-patterns.md
+++ b/claude/rules/archive/autolearn-patterns.md
@@ -403,3 +403,91 @@ if err != nil {
 **Category:** platform-workaround
 **Context:** `jq` unavailable on Windows MSYS. Python's `json` + `urllib.request` modules provide equivalent functionality.
 **Fix:** Use inline Python for JSON operations. Combine with Windows Python path detection (KG#8). UTF-8 I/O fix now documented in AP#122.
+
+## Archived 2026-03-15: Rules compaction (governance + React + Windows consolidation)
+
+### Superseded entry
+
+## 27. golangci-lint bodyclose with websocket.Dial (removed from active 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** superseded-by-KG17
+
+Previously retained as stub in active file. Fully removed. See KG#17 for the consolidated entry.
+
+### Consolidation victims: DevKit governance pipeline (merged into AP#18)
+
+## 92. DevKit Scaffolding Must Include Executable Templates
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** consolidated-into-AP18
+
+**Category:** process-pattern
+**Context:** Profiles describing WHAT but no HOW scaffolding leads to manual CI infrastructure creation and preventable failures.
+**Fix:** Include ready-to-copy templates: pre-push hook, golangci-lint config, Makefile, CI workflow.
+
+## 93. Advisory Rules Without Enforcement Are Ignored Under Pressure
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** consolidated-into-AP18
+
+**Category:** process-pattern
+**Context:** Advisory-only rules are skipped under time pressure. Agents repeat known mistakes.
+**Fix:** Enforcement tiers: Tier 0 immutable, Tier 1 governed, Tier 2 learned with periodic review. Pre-commit verification must be mandatory ("must" not "should").
+
+## 94. Autolearn Must Validate Before Writing Rules
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** consolidated-into-AP18
+
+**Category:** process-pattern
+**Context:** Unvalidated learnings become permanent rules cascading to all projects. A workaround could weaken guardrails.
+**Fix:** Five-stage pipeline: evidence check, core principle alignment, best practices review, conflict check, risk classification. Dangerous patterns ("skip", "bypass", "suppress") always trigger human review.
+
+## 95. Fix-Forward Replaces Pre-Existing Error Classification
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** consolidated-into-AP18
+
+**Category:** process-pattern
+**Context:** "Pre-existing" classification had no follow-through. Errors noted and ignored indefinitely.
+**Fix:** Fix-forward: (1) fix inline <5 min, (2) can't fix? file GitHub issue, (3) systemic? update DevKit gap. Never acceptable: "noted as pre-existing, moving on."
+
+## 108. Phased Research-Gate Workflow for New Projects
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** consolidated-into-AP18
+
+**Category:** process-pattern
+**Context:** Flat issue backlogs lead to underresearched designs and no validation checkpoints.
+**Fix:** Structure as: Research issues -> Implementation issues -> Gate issue (checklist). Forces thinking before coding at every stage.
+
+### Consolidation victims: React Compiler and MUI patterns (merged into AP#111)
+
+## 112. useRef Guard to Prevent useEffect Re-Trigger Loops
+
+**Added:** 2026-03-02 | **Source:** RunNotes | **Status:** consolidated-into-AP111
+
+**Category:** frontend-pattern
+**Context:** useEffect detecting stale data triggers state updates, which re-trigger the same effect infinitely.
+**Fix:** Use `useRef(false)` flag. Set `true` after first run. Reset only on intentional user actions (e.g., manual refresh).
+
+## 114. React Callback Ref for MUI Popper Anchors (React Compiler Compliance)
+
+**Added:** 2026-03-02 | **Source:** Runbooks | **Status:** consolidated-into-AP111
+
+**Category:** frontend-pattern
+**Context:** MUI Popper needs `anchorEl` during render. `useRef` + `ref.current` triggers React Compiler's refs rule.
+**Fix:** Use callback ref with `useState`: `const [anchorEl, setAnchorEl] = useState(null)` then `<Button ref={setAnchorEl}>`. See also KG#6.
+
+### Consolidation victims: Windows shell interop (merged into AP#73)
+
+## 75. Start-Job Timeout for Commands That Might Hang
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** consolidated-into-AP73
+
+**Category:** platform-workaround
+**Context:** Windows Store Python aliases hang forever. `command -v` resolves them as valid but `& py --version` blocks.
+**Fix:** Wrap in `Start-Job` + `Wait-Job -Timeout 5`. Stop and remove job if timeout. 5s catches hangs while allowing slow tools.
+
+## 76. PowerShell Temp File for Complex Commands from MSYS Bash
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** consolidated-into-AP73
+
+**Category:** platform-workaround
+**Context:** Inline PowerShell from MSYS bash breaks with `$env:PATH`, special chars. `cmd.exe /c` swallows output.
+**Fix:** Write temp `.ps1` file using single-quoted heredoc (`'PSEOF'`), execute with `powershell.exe -NoProfile -File /tmp/cmd.ps1 2>&1`.

--- a/claude/rules/archive/known-gotchas.md
+++ b/claude/rules/archive/known-gotchas.md
@@ -408,3 +408,217 @@ gh issue create --milestone takes title, not number. Merged into KG#107 (gh CLI 
 ## KG#109 (archived 2026-03-14, consolidated into KG#62)
 
 GitHub REST API returns CRLF in issue body text fields. Merged into KG#62 (Windows CRLF Breaks Tool String Matching).
+
+## Archived 2026-03-15: Rules compaction (batch ingest + consolidation)
+
+### Low-value or unreferenced entries
+
+## KG#2 (archived 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** archived-2026-03-15
+
+**Platform:** GitHub
+**Fix:** `gh pr merge --admin` bypasses protection when you're the only maintainer.
+
+## KG#5 (archived 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** archived-2026-03-15
+
+**Platform:** Go (all)
+**Issue:** Changing `for _, v := range slice` to `for i := range slice` -- easy to miss `v` references deeper in the loop body.
+**Fix:** Search the entire loop body for the old variable name. Replace ALL occurrences with `slice[i]`.
+
+## KG#11 (archived 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** archived-2026-03-15
+
+**Platform:** All (curl, fetch)
+**Issue:** GitHub REST API requires a `User-Agent` header. Requests without it return empty or 403.
+**Fix:** Always include `User-Agent: <app-name>` in GitHub API requests.
+
+## KG#14 (archived 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** archived-2026-03-15
+
+**Platform:** Go (all)
+**Issue:** `if obj.Field == nil || obj.Field.Sub == 0` with logging that accesses `obj.Field.X` panics when `obj.Field` is nil.
+**Fix:** Split into two separate `if` blocks -- check nil first, then check the field.
+
+## KG#15 (archived 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** archived-2026-03-15
+
+**Platform:** Git (all)
+**Issue:** After squash-merge, `git branch --merged main` won't list the branch (different hashes).
+**Fix:** Use `git branch -D` (force delete). Verify safety with `git remote prune origin` first.
+
+## KG#16 (archived 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** archived-2026-03-15
+
+**Platform:** GitHub
+**Issue:** `Closes #1, #2, #3` only auto-closes #1. GitHub requires the keyword before each number.
+**Fix:** Use `Closes #1, Closes #2, Closes #3` or one per line.
+
+## KG#37 (archived 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** archived-2026-03-15
+
+**Platform:** Windows (VS Code)
+**Issue:** `rm -rf` fails on directories VS Code has open as workspace roots. File watcher holds handles.
+**Fix:** Remove contents first, then reload VS Code with updated workspace config. Or close VS Code first.
+
+## KG#38 (archived 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** archived-2026-03-15
+
+**Platform:** Playwright (all)
+**Issue:** `getByLabel('Password')` matches both the input and companion toggle button.
+**Fix:** Use `page.locator('#password')` to target by ID instead.
+
+## KG#47 (archived 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** archived-2026-03-15
+
+**Platform:** PowerShell 7+
+**Issue:** `[Mandatory] [string[]]` validates each element. Empty strings `''` fail validation.
+**Fix:** Add `[AllowEmptyString()]` alongside `[Mandatory]`.
+
+## KG#48 (archived 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** archived-2026-03-15
+
+**Platform:** Windows (Hyper-V)
+**Issue:** Returns `$false` when Hyper-V is already active (hypervisor claimed VT-x).
+**Fix:** Use Hyper-V state as fallback: `if ($virtCheck.Met -or $hyperVMet) { # confirmed }`.
+
+## KG#49 (archived 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** archived-2026-03-15
+
+**Platform:** PowerShell (all)
+**Issue:** `Get-ChildItem` skips dotfiles (hidden on Windows). Filter `credentials*` won't match `.credentials*`.
+**Fix:** Use `-Force` flag AND add separate `.credentials*` filter.
+
+## KG#54 (archived 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** archived-2026-03-15
+
+**Platform:** PowerShell 7+ / GitHub
+
+### param() must be first executable statement
+
+**Issue:** `Set-StrictMode` before `param()` causes confusing error.
+**Fix:** Only comments and `#Requires` before `param()`.
+
+### Branch protection requires pre-existing CI check names
+
+**Issue:** `required_status_checks.contexts` must reference jobs that have already run.
+**Fix:** Merge CI workflow first, verify job names in Actions tab, then apply protection.
+
+## KG#56 (archived 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** archived-2026-03-15
+
+**Platform:** Claude Code (Windows)
+**Issue:** Subagent adds deps to `package.json` but can't run `pnpm install`. CI fails with `ERR_PNPM_OUTDATED_LOCKFILE`.
+**Fix:** Run `pnpm install` after merging subagent changes to update lockfile.
+
+## KG#72 (archived 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** archived-2026-03-15
+
+**Platform:** React / ESLint
+**Issue:** This rule does NOT support `// eslint-disable-next-line`. Adding it produces "Unused directive".
+**Fix:** Config-level override only: `"react-hooks/set-state-in-effect": "warn"` in `eslint.config.js`.
+
+## KG#73 (archived 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** archived-2026-03-15
+
+**Platform:** npm / React
+**Issue:** ESLint 10.x breaks `eslint-plugin-react-hooks` which requires `eslint@^9`.
+**Fix:** Pin: `npm install --save-dev eslint@^9 @eslint/js@^9`.
+
+## KG#79 (archived 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** archived-2026-03-15
+
+**Platform:** GitHub
+**Issue:** Repo secrets are under Settings > Secrets and variables > Actions (expandable submenu).
+**Fix:** Use CLI: `gh secret set SECRETNAME`. `gh secret list` to verify.
+
+## KG#80 (archived 2026-03-15)
+
+**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** archived-2026-03-15
+
+**Platform:** PowerShell 7+
+**Issue:** Under StrictMode, accessing nonexistent property on PSCustomObject throws -- even in conditionals.
+**Fix:** Use `$obj.PSObject.Properties.Match('prop').Count -gt 0`. Does NOT affect hashtables.
+
+## KG#86 (archived 2026-03-15)
+
+**Added:** 2026-03-02 | **Source:** DevKit | **Status:** archived-2026-03-15
+
+**Platform:** Bash (all, especially CI)
+**Issue:** `grep -c` outputs "0" AND exits code 1. `$(grep -c ... || echo "0")` captures "0\n0", breaking arithmetic.
+**Fix:** Use `|| true` instead of `|| echo "0"`.
+
+## KG#100 (archived 2026-03-15)
+
+**Added:** 2026-03-07 | **Source:** DevKit | **Status:** archived-2026-03-15
+
+**Platform:** Claude Code (all)
+**Issue:** After completing a multi-step task, CC displays a pasted large input block as text rather than executing it. Context saturation at task boundaries.
+**Fix:** Kill session and open fresh. Do NOT attempt multiple `?` prompts -- if it fails twice, session is unrecoverable.
+**Prevention:** Keep handoff prompts under 40 lines. Run `/rules-compact` if rules files approach 40k.
+
+## KG#139 (archived 2026-03-15)
+
+**Added:** 2026-03-15 | **Source:** Synapset | **Status:** archived-2026-03-15
+
+**Platform:** Go (all)
+**Issue:** WASM-based SQLite driver has single linear memory space. Concurrent goroutine access causes `panic: wasm error: out of bounds memory access`.
+**Fix:** Use `sync.Mutex` or `*sql.DB` with `SetMaxOpenConns(1)`. Alternative: switch to CGO-based driver (`mattn/go-sqlite3`) which supports SQLite threading modes.
+
+### Consolidation victims (2026-03-15)
+
+## KG#7 (archived 2026-03-15, consolidated into KG#6)
+
+React Compiler Lint: Recursive useCallback Self-Reference. Merged into KG#6 (React Compiler Lint: Refs During Render).
+
+## KG#13 (archived 2026-03-15, consolidated into KG#12)
+
+Swagger Drift After Any Handler/Model Change. Merged into KG#12 (Swagger Cross-Platform Drift).
+
+## KG#66 (archived 2026-03-15, consolidated into KG#65)
+
+golangci-lint-action v7 Runs config verify (Schema Enforcement). Merged into KG#65 (golangci-lint v2 Config and Schema).
+
+## KG#67 (archived 2026-03-15, consolidated into KG#111)
+
+Agent-Generated Markdown Tables: Pipes in Cells and Missing Columns. Merged into KG#111 (Markdown Editing Gotchas).
+
+## KG#112 (archived 2026-03-15, consolidated into KG#104)
+
+Invoke-ScriptAnalyzer Has No -Include Parameter. Merged into KG#104 (PowerShell Tool and Variable Gotchas).
+
+## KG#113 (archived 2026-03-15, consolidated into KG#104)
+
+PowerShell $args Is an Automatic Variable. Merged into KG#104 (PowerShell Tool and Variable Gotchas).
+
+## KG#124 (archived 2026-03-15, consolidated into KG#123)
+
+Gitea PR Merge After Rebase Needs Pause. Merged into KG#123 (Gitea API and Actions Gotchas).
+
+## KG#130 (archived 2026-03-15, consolidated into KG#25)
+
+git worktree Operations Can Flip core.bare=true. Merged into KG#25 (Parallel Background Agents Share Working Tree).
+
+## KG#137 (archived 2026-03-15, consolidated into KG#127)
+
+sqlite-vec vec0 Virtual Tables Do Not Support UPDATE. Merged into KG#127 (sqlite-vec Virtual Table Gotchas).
+
+## KG#138 (archived 2026-03-15, consolidated into KG#123)
+
+Gitea Reserves GITEA_ Prefix for Actions Secret Names. Merged into KG#123 (Gitea API and Actions Gotchas).

--- a/claude/rules/autolearn-patterns.md
+++ b/claude/rules/autolearn-patterns.md
@@ -1,7 +1,7 @@
 ---
 description: Learned patterns from past sessions. Read when encountering similar situations.
 tier: 2
-entry_count: 77
+entry_count: 67
 last_updated: "2026-03-15"
 ---
 
@@ -88,13 +88,36 @@ go-licenses check ./... 2>&1 | grep -E "GPL|AGPL|LGPL|SSPL" && exit 1 || echo "N
 **Context:** Swagger cross-platform drift (enum definitions, x-enum-descriptions, go mod download for CI).
 **Fix:** See KG#12 for full consolidated reference. Key fix: add `swaggertype:"integer"` to `time.Duration` fields, run `go mod download` before `swag init` in CI.
 
-## 18. Documentation Drift Audit After PR Bursts
+## 18. DevKit Governance and Validation Pipeline (Consolidated Reference)
 
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+**Added:** 2026-02-17 | **Source:** Multiple | **Status:** active
+**Consolidates:** AP#92, AP#93, AP#94, AP#95, AP#108 (archived)
 
 **Category:** process-pattern
-**Context:** After merging many PRs in a burst, roadmap checklists, README claims, and architecture docs drift from reality.
-**Fix:** Audit: (1) list merged PRs since last doc update, (2) cross-reference with roadmap, (3) check README claims against actual capabilities, (4) fix aspirational language.
+
+### Documentation drift audit
+
+After PR bursts, audit: list merged PRs since last doc update, cross-reference with roadmap, check README claims against actual capabilities, fix aspirational language.
+
+### Executable templates in scaffolding
+
+Profiles describing WHAT but no HOW leads to manual CI creation. Include ready-to-copy templates: pre-push hook, golangci-lint config, Makefile, CI workflow.
+
+### Enforcement over advisory rules
+
+Advisory-only rules are skipped under pressure. Use enforcement tiers (Tier 0 immutable, Tier 1 governed, Tier 2 learned). Pre-commit verification must be mandatory ("must" not "should").
+
+### Autolearn validation pipeline
+
+Five-stage pipeline before writing rules: evidence check, core principle alignment, best practices review, conflict check, risk classification. Dangerous patterns ("skip", "bypass", "suppress") always trigger human review.
+
+### Fix-forward replaces pre-existing classification
+
+Fix-forward: (1) fix inline <5 min, (2) can't fix? file GitHub issue, (3) systemic? update DevKit gap. Never acceptable: "noted as pre-existing, moving on."
+
+### Research-gate workflow for new projects
+
+Structure as: Research issues -> Implementation issues -> Gate issue (checklist). Forces thinking before coding at every stage.
 
 ## 19. golangci-lint Rules (Consolidated Reference)
 
@@ -158,12 +181,6 @@ copy(oldKEK, km.kek)
 **Category:** correction
 **Context:** `func handler(w http.ResponseWriter, _ *http.Request)` causes "undefined: r" when you later add `r.Context()`.
 **Fix:** Always name handler parameters, even if currently unused. Compiler allows named-but-unused params.
-
-## 27. golangci-lint bodyclose with websocket.Dial
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** superseded-by-KG17
-
-Archived to `claude/rules/archive/autolearn-patterns.md`. See KG#17 for the consolidated entry.
 
 ## 28. Go 1.22+ ServeMux Ambiguous Route Pattern Panic
 
@@ -262,17 +279,11 @@ Check CI on ALL PRs first. Merge green sequentially (rebase between each). Close
 
 **Category:** workflow-pattern
 
-### Self-recovery from shared working tree
+Legacy stash/pop approach for parallel agents. Superseded by AP#127 (worktree isolation) for new work. Retained for reference when worktrees unavailable.
 
-Agents detect leaked files via `git status`, clean with `git checkout -- <leaked>`. Prompts must specify target branch, exact files, and `git checkout <branch>` as first step.
-
-### Agent disruption of parallel work (commit/checkout/same-file)
-
-`git checkout <branch>` discards other agents' unstaged tracked-file changes. When 2+ agents modify same file, read combined diff first, then stash/pop to sort into correct branches. Two approaches: restrict agents from committing (safer) or re-apply from output summary (faster).
-
-### Subagent recovery after session break
-
-On resume: `git status`, `git diff --stat`, `go build ./...`, then commit. Subagent work persists in working tree even if main context was interrupted.
+- **Self-recovery from shared working tree**: Agents detect leaked files via `git status`, clean with `git checkout -- <leaked>`.
+- **Agent disruption of parallel work**: `git checkout <branch>` discards other agents' unstaged changes. Restrict agents from committing (safer) or re-apply from output summary (faster).
+- **Subagent recovery after session break**: On resume: `git status`, `git diff --stat`, `go build ./...`, then commit.
 
 ## 50. VS Code Auto-Open File on Workspace Start
 
@@ -338,13 +349,24 @@ On resume: `git status`, `git diff --stat`, `go build ./...`, then commit. Subag
 **Context:** Ensuring every new project gets CLAUDE.md requires multiple safety nets.
 **Fix:** Three layers: (1) `git init.templateDir` auto-copies starter, (2) shell helper for intentional workflow, (3) SessionStart hook detects missing CLAUDE.md.
 
-## 73. Three-Stream Redirect for VS Code CLI in PowerShell Scripts
+## 73. Windows Shell Interop Workarounds (Consolidated Reference)
 
 **Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
+**Consolidates:** AP#75, AP#76 (archived)
 
 **Category:** platform-workaround
-**Context:** `code --list-extensions` in PowerShell opens `code-stdin-*` tabs. Redirecting only stdout/stderr is NOT sufficient.
-**Fix:** Redirect ALL THREE streams. `-RedirectStandardInput` to empty temp file feeds EOF immediately, preventing VS Code from reading parent stdin.
+
+### Three-stream redirect for VS Code CLI
+
+`code --list-extensions` in PowerShell opens `code-stdin-*` tabs. Redirect ALL THREE streams -- `-RedirectStandardInput` to empty temp file feeds EOF immediately, preventing VS Code from reading parent stdin.
+
+### Start-Job timeout for hanging commands
+
+Windows Store Python aliases hang forever. `command -v` resolves them as valid but `& py --version` blocks. Wrap in `Start-Job` + `Wait-Job -Timeout 5`. Stop and remove job if timeout.
+
+### PowerShell temp file from MSYS bash
+
+Inline PowerShell from MSYS bash breaks with `$env:PATH`, special chars. Write temp `.ps1` file using single-quoted heredoc (`'PSEOF'`), execute with `powershell.exe -NoProfile -File /tmp/cmd.ps1 2>&1`.
 
 ## 74. Iterative Bootstrap Debugging on New Machines
 
@@ -353,22 +375,6 @@ On resume: `git status`, `git diff --stat`, `go build ./...`, then commit. Subag
 **Category:** workflow-pattern
 **Context:** First-time bootstrap surfaces cascading issues. Each phase may expose issues invisible until prior phases complete.
 **Fix:** Run end-to-end, capture full output, fix ALL failures in single pass. Multiple failures may share root cause (e.g., PATH staleness).
-
-## 75. Start-Job Timeout for Commands That Might Hang
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Category:** platform-workaround
-**Context:** Windows Store Python aliases hang forever. `command -v` resolves them as valid but `& py --version` blocks.
-**Fix:** Wrap in `Start-Job` + `Wait-Job -Timeout 5`. Stop and remove job if timeout. 5s catches hangs while allowing slow tools.
-
-## 76. PowerShell Temp File for Complex Commands from MSYS Bash
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Category:** platform-workaround
-**Context:** Inline PowerShell from MSYS bash breaks with `$env:PATH`, special chars. `cmd.exe /c` swallows output.
-**Fix:** Write temp `.ps1` file using single-quoted heredoc (`'PSEOF'`), execute with `powershell.exe -NoProfile -File /tmp/cmd.ps1 2>&1`.
 
 ## 77. Small Wave Without Subagent for Focused Changes
 
@@ -476,7 +482,7 @@ On resume: `git status`, `git diff --stat`, `go build ./...`, then commit. Subag
 - **formatters**: v2 moved `gofmt`/`goimports` from `linters:` to `formatters: enable:` top-level key.
 - **gosimple**: merged into `staticcheck` in v2. Remove from linters list.
 
-**See also:** KG#65 (silent config failure), KG#66 (v7 action schema enforcement).
+**See also:** KG#65 (config requirements + v7 schema enforcement).
 
 ## 91. go run for Pinned Tool Versions
 
@@ -485,38 +491,6 @@ On resume: `git status`, `git diff --stat`, `go build ./...`, then commit. Subag
 **Category:** workflow-pattern
 **Context:** `go install ...@latest` creates version drift, PATH issues on Windows MSYS, and risks surprise breakage.
 **Fix:** Use `go run github.com/.../tool@vX.Y.Z` in Makefiles and hooks. Exact version, no install, no PATH issues.
-
-## 92. DevKit Scaffolding Must Include Executable Templates
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Category:** process-pattern
-**Context:** Profiles describing WHAT but no HOW scaffolding leads to manual CI infrastructure creation and preventable failures.
-**Fix:** Include ready-to-copy templates: pre-push hook, golangci-lint config, Makefile, CI workflow.
-
-## 93. Advisory Rules Without Enforcement Are Ignored Under Pressure
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Category:** process-pattern
-**Context:** Advisory-only rules are skipped under time pressure. Agents repeat known mistakes.
-**Fix:** Enforcement tiers: Tier 0 immutable, Tier 1 governed, Tier 2 learned with periodic review. Pre-commit verification must be mandatory ("must" not "should").
-
-## 94. Autolearn Must Validate Before Writing Rules
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Category:** process-pattern
-**Context:** Unvalidated learnings become permanent rules cascading to all projects. A workaround could weaken guardrails.
-**Fix:** Five-stage pipeline: evidence check, core principle alignment, best practices review, conflict check, risk classification. Dangerous patterns ("skip", "bypass", "suppress") always trigger human review.
-
-## 95. Fix-Forward Replaces Pre-Existing Error Classification
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Category:** process-pattern
-**Context:** "Pre-existing" classification had no follow-through. Errors noted and ignored indefinitely.
-**Fix:** Fix-forward: (1) fix inline <5 min, (2) can't fix? file GitHub issue, (3) systemic? update DevKit gap. Never acceptable: "noted as pre-existing, moving on."
 
 ## 96. Interactive Q&A Then Background Agent for Human-Dependent Issues
 
@@ -558,14 +532,6 @@ On resume: `git status`, `git diff --stat`, `go build ./...`, then commit. Subag
 **Context:** "Self-check" phrasing in CI checklist treated as advisory. Agents skip golangci-lint.
 **Fix:** "Step 4, NOT optional, fix ALL" language. Agent compliance depends on enforcement language, not just rule presence.
 
-## 108. Phased Research-Gate Workflow for New Projects
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Category:** process-pattern
-**Context:** Flat issue backlogs lead to underresearched designs and no validation checkpoints.
-**Fix:** Structure as: Research issues -> Implementation issues -> Gate issue (checklist). Forces thinking before coding at every stage.
-
 ## 110. Docker Desktop Extension Marketplace Submission Checklist
 
 **Added:** 2026-03-02 | **Source:** Runbooks, RunNotes | **Status:** active
@@ -575,29 +541,24 @@ On resume: `git status`, `git diff --stat`, `go build ./...`, then commit. Subag
 **Fix:** Checklist: (1) Dockerfile labels (screenshots JSON, changelog HTML, additional-urls), (2) .hadolint.yaml ignores DL3048/DL3045, (3) multi-arch (amd64+arm64), (4) `docker extension validate`, (5) submit via docker/extensions-submissions.
 **See also:** KG#77
 
-## 111. MUI Tooltip Requires Span Wrapper for Disabled Buttons
+## 111. React Compiler and MUI Interaction Patterns (Consolidated Reference)
 
-**Added:** 2026-03-02 | **Source:** RunNotes | **Status:** active
-
-**Category:** frontend-pattern
-**Context:** MUI `<Tooltip>` on disabled `<IconButton>` never shows -- disabled elements don't fire mouse events.
-**Fix:** Wrap disabled button in `<span>`. Applies to any disabled interactive element inside Tooltip.
-
-## 112. useRef Guard to Prevent useEffect Re-Trigger Loops
-
-**Added:** 2026-03-02 | **Source:** RunNotes | **Status:** active
+**Added:** 2026-03-02 | **Source:** Multiple | **Status:** active
+**Consolidates:** AP#112, AP#114 (archived)
 
 **Category:** frontend-pattern
-**Context:** useEffect detecting stale data triggers state updates, which re-trigger the same effect infinitely.
-**Fix:** Use `useRef(false)` flag. Set `true` after first run. Reset only on intentional user actions (e.g., manual refresh).
 
-## 114. React Callback Ref for MUI Popper Anchors (React Compiler Compliance)
+### MUI Tooltip on disabled elements
 
-**Added:** 2026-03-02 | **Source:** Runbooks | **Status:** active
+MUI `<Tooltip>` on disabled `<IconButton>` never shows -- disabled elements don't fire mouse events. Wrap disabled button in `<span>`. Applies to any disabled interactive element inside Tooltip.
 
-**Category:** frontend-pattern
-**Context:** MUI Popper needs `anchorEl` during render. `useRef` + `ref.current` triggers React Compiler's refs rule.
-**Fix:** Use callback ref with `useState`: `const [anchorEl, setAnchorEl] = useState(null)` then `<Button ref={setAnchorEl}>`. See also KG#6.
+### useRef guard for useEffect loops
+
+useEffect detecting stale data triggers state updates, which re-trigger the same effect infinitely. Use `useRef(false)` flag. Set `true` after first run. Reset only on intentional user actions.
+
+### Callback ref for Popper anchors
+
+MUI Popper needs `anchorEl` during render. `useRef` + `ref.current` triggers React Compiler's refs rule. Use callback ref with `useState`: `const [anchorEl, setAnchorEl] = useState(null)` then `<Button ref={setAnchorEl}>`. See also KG#6.
 
 ## 117. Cross-Project Compliance Audit via Parallel Independent-Repo Agents
 
@@ -636,9 +597,9 @@ On resume: `git status`, `git diff --stat`, `go build ./...`, then commit. Subag
 **Added:** 2026-03-08 | **Source:** DevKit | **Status:** active
 
 **Category:** process-pattern
-**Context:** Documentation, skill lists, CI coverage, and setup scripts drift from reality over time without automated validation.
-**Fix:** Run a structured Explore subagent audit periodically covering 10 dimensions: docs-vs-reality counts, skill routing completeness, agent template coverage, rules file metadata accuracy, CI job gaps, setup script completeness, project template freshness, hook coverage, sync manifest integrity, cross-reference completeness.
-**See also:** AP#47 (check existing assets before scoping issues), AP#83 (sprint scope reduction via exploration), AP#85 (roadmap drift)
+**Context:** Documentation, skill lists, CI coverage, and setup scripts drift from reality without automated validation.
+**Fix:** Run structured Explore subagent audit periodically covering 10 dimensions: docs accuracy, skill routing, agent templates, rules metadata, CI jobs, setup scripts, project templates, hooks, sync manifest, cross-references.
+**See also:** AP#47, AP#83, AP#85
 
 ## 122. Python UTF-8 I/O on Windows for Unicode-Heavy Scripts
 
@@ -646,31 +607,17 @@ On resume: `git status`, `git diff --stat`, `go build ./...`, then commit. Subag
 **Consolidates:** AP#11, AP#109 (archived)
 
 **Category:** platform-workaround
-**Context:** Python on Windows defaults to cp1252 encoding. Any script that processes
-Unicode content (GitHub issue bodies, em-dashes, smart quotes, etc.) crashes
-with `UnicodeEncodeError`. This applies to any Python script, including jq replacements
-(use Python `json` + `urllib.request` instead of `jq` on Windows MSYS).
-For regex-heavy scripts, write a standalone `.py` file and call from a thin bash wrapper.
-**Fix:** Apply a three-layer fix -- all three layers are required:
-
-1. In the calling bash script: `export PYTHONIOENCODING=utf-8`
-2. At the top of the Python script:
-   `if hasattr(sys.stdout, "reconfigure"): sys.stdout.reconfigure(encoding="utf-8")`
-3. In every `subprocess.run` call: pass `encoding="utf-8"` explicitly
-
-The env var (layer 1) covers the outer process stdout/stderr. The reconfigure call
-(layer 2) is the preferred way to switch an already-open stream; the `hasattr` guard
-keeps it safe on Python < 3.7. `subprocess.run` (layer 3) opens a new stream and
-ignores PYTHONIOENCODING, so it needs its own `encoding=` argument.
+**Context:** Python on Windows defaults to cp1252 encoding. Scripts processing Unicode (em-dashes, smart quotes) crash with `UnicodeEncodeError`. Use Python `json` + `urllib.request` instead of `jq` on Windows MSYS. For regex-heavy scripts, write standalone `.py` file called from bash wrapper.
+**Fix:** Three-layer fix (all required): (1) bash: `export PYTHONIOENCODING=utf-8`, (2) Python top: `if hasattr(sys.stdout, "reconfigure"): sys.stdout.reconfigure(encoding="utf-8")`, (3) every `subprocess.run`: pass `encoding="utf-8"`. Each layer covers a different stream surface.
 
 ## 123. PSScriptAnalyzer Brownfield Onboarding -- Audit Before First CI Run
 
 **Added:** 2026-03-09 | **Source:** DevKit | **Status:** active
 
 **Category:** ci-config
-**Context:** Adding PSScriptAnalyzer CI to an existing repo surfaces pre-existing violations iteratively across multiple CI cycles. Each run reveals different failures.
-**Fix:** Run PSScriptAnalyzer locally against all scripts and resolve or exclude ALL violations in a single pass before pushing CI integration. Create `PSScriptAnalyzerSettings.psd1` with justified exclusions. Common brownfield exclusions: PSAvoidUsingWriteHost, PSUseShouldProcessForStateChangingFunctions, PSReviewUnusedParameter, PSUseSingularNouns, PSAvoidAssignmentToAutomaticVariable, PSUseUsingScopeModifierInNewRunspaces, PSAvoidUsingPlainTextForPassword, PSUseBOMForUnicodeEncodedFile.
-**See also:** KG#112 (Invoke-ScriptAnalyzer -Include invalid parameter), AP#84 (mandatory lint step language)
+**Context:** Adding PSScriptAnalyzer CI to an existing repo surfaces pre-existing violations iteratively.
+**Fix:** Run PSScriptAnalyzer locally against ALL scripts, resolve or exclude violations in a single pass before pushing CI. Create `PSScriptAnalyzerSettings.psd1` with justified exclusions.
+**See also:** KG#104 (PowerShell tool gotchas), AP#84
 
 ## 124. Pre-Sprint Human-Label Audit for Mislabeled Issues
 

--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -1,7 +1,7 @@
 ---
 description: Known gotchas and platform-specific issues. Read when debugging unexpected behavior.
 tier: 2
-entry_count: 90
+entry_count: 60
 last_updated: "2026-03-15"
 ---
 
@@ -16,21 +16,6 @@ Platform-specific issues, tool quirks, and surprising behaviors discovered throu
 **Platform:** Windows (MSYS_NT)
 **Issue:** MSYS bash auto-translates Unix-style paths to Windows paths. Paths starting with `/c/` become `C:\`.
 **Fix:** Use `MSYS_NO_PATHCONV=1` prefix or double-slash `//` to prevent translation.
-
-## 2. GitHub Branch Protection Requires --admin for Merge
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** GitHub
-**Fix:** `gh pr merge --admin` bypasses protection when you're the only maintainer.
-
-## 5. Incomplete Range Variable Replacement in Loop Refactoring
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** Go (all)
-**Issue:** Changing `for _, v := range slice` to `for i := range slice` -- easy to miss `v` references deeper in the loop body.
-**Fix:** Search the entire loop body for the old variable name. Replace ALL occurrences with `slice[i]`.
 
 ## 6. React Compiler Lint: Refs During Render (Consolidated Reference)
 
@@ -48,11 +33,8 @@ Platform-specific issues, tool quirks, and surprising behaviors discovered throu
 **Issue:** MUI `Popper`/`Popover` needs `anchorEl` during render. Using `useRef` + `ref.current` triggers the refs rule.
 **Fix:** Use callback ref with `useState`: `const [anchorEl, setAnchorEl] = useState(null)` then `<Button ref={setAnchorEl}>`.
 
-## 7. React Compiler Lint: Recursive useCallback Self-Reference
+### Recursive useCallback self-reference
 
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** React 19+ / ESLint react-hooks/immutability rule
 **Issue:** Recursive `useCallback` (e.g., `connect()` calling itself in `onclose`) triggers "Cannot access variable before it is declared".
 **Fix:** Store in a ref: `const connectRef = useRef<() => void>()` and call `connectRef.current?.()` for recursion.
 
@@ -63,14 +45,6 @@ Platform-specific issues, tool quirks, and surprising behaviors discovered throu
 **Platform:** Windows (MSYS_NT)
 **Issue:** `python3`/`python`/`py` resolve to Windows Store alias stubs. `command -v` reports them as found.
 **Fix:** Check with `"$p" --version` (not `command -v`). Include explicit Windows paths in the search loop.
-
-## 11. GitHub API Returns Empty Without User-Agent Header
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** All (curl, fetch)
-**Issue:** GitHub REST API requires a `User-Agent` header. Requests without it return empty or 403.
-**Fix:** Always include `User-Agent: <app-name>` in GitHub API requests.
 
 ## 12. Swagger Cross-Platform Drift (Consolidated Reference)
 
@@ -94,37 +68,10 @@ Platform-specific issues, tool quirks, and surprising behaviors discovered throu
 **Issue:** Perl regex stripping `x-enum-descriptions` can join adjacent lines.
 **Fix:** Verify YAML integrity after stripping. Consider using yq instead.
 
-## 13. Swagger Drift After Any Handler/Model Change
+### Any handler/model change requires swag init
 
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** Go (swaggo/swag)
 **Issue:** ANY change to Go types in swagger-annotated handlers requires regenerating the swagger spec.
 **Fix:** Always run `swag init` (or `make swagger`) after modifying handlers/structs. Commit regenerated files alongside Go changes.
-
-## 14. Go Nil Guard: Split Chained Nil Checks Into Separate Blocks
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** Go (all)
-**Issue:** `if obj.Field == nil || obj.Field.Sub == 0` with logging that accesses `obj.Field.X` panics when `obj.Field` is nil.
-**Fix:** Split into two separate `if` blocks -- check nil first, then check the field.
-
-## 15. Squash-Merged Branches Don't Appear in `git branch --merged`
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** Git (all)
-**Issue:** After squash-merge, `git branch --merged main` won't list the branch (different hashes).
-**Fix:** Use `git branch -D` (force delete). Verify safety with `git remote prune origin` first.
-
-## 16. GitHub `Closes #N` Comma Syntax Only Closes First Issue
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** GitHub
-**Issue:** `Closes #1, #2, #3` only auto-closes #1. GitHub requires the keyword before each number.
-**Fix:** Use `Closes #1, Closes #2, Closes #3` or one per line.
 
 ## 17. websocket.Dial Response Body Must Be Closed
 
@@ -176,7 +123,8 @@ Platform-specific issues, tool quirks, and surprising behaviors discovered throu
 
 All parallel agents write to the same working directory. Sort into branches via stage/stash/pop after agents complete.
 
-**Key scenarios:** (1) `git checkout` destroys other agents' unstaged tracked files. (2) `go build` compiles untracked files from other agents -- stash before pushing. (3) Stash during running agents is unsafe -- commit one agent's files first.
+**Key scenarios:** (1) `git checkout` destroys other agents' unstaged tracked files. (2) `go build` compiles untracked files from other agents -- stash before pushing. (3) Stash during running agents is unsafe -- commit one agent's files first. (4) Multiple `git worktree add`/`remove` operations (especially with parallel CC sessions) can flip `core.bare = true` in `.git/config` -- fix with `git config core.bare false`; detect with `git worktree list` showing `(bare)`.
+**See also:** AP#127
 
 ## 26. Sequential Same-File PR Merge Requires Rebase Between Each
 
@@ -218,46 +166,6 @@ All parallel agents write to the same working directory. Sort into branches via 
 **Issue:** `go test -race` fails without CGO. Race detector is implemented in C.
 **Fix:** Run `go test` locally without `-race`. Rely on CI Linux runners for race detection.
 
-## 37. VS Code Locks Workspace Root Directories
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** Windows (VS Code)
-**Issue:** `rm -rf` fails on directories VS Code has open as workspace roots. File watcher holds handles.
-**Fix:** Remove contents first, then reload VS Code with updated workspace config. Or close VS Code first.
-
-## 38. Playwright getByLabel Resolves Multiple Elements with Toggle Buttons
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** Playwright (all)
-**Issue:** `getByLabel('Password')` matches both the input and companion toggle button.
-**Fix:** Use `page.locator('#password')` to target by ID instead.
-
-## 47. PowerShell [Mandatory] Validates Each Element in String Arrays
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** PowerShell 7+
-**Issue:** `[Mandatory] [string[]]` validates each element. Empty strings `''` fail validation.
-**Fix:** Add `[AllowEmptyString()]` alongside `[Mandatory]`.
-
-## 48. Win32_Processor.VirtualizationFirmwareEnabled False When Hypervisor Running
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** Windows (Hyper-V)
-**Issue:** Returns `$false` when Hyper-V is already active (hypervisor claimed VT-x).
-**Fix:** Use Hyper-V state as fallback: `if ($virtCheck.Met -or $hyperVMet) { # confirmed }`.
-
-## 49. PowerShell Get-ChildItem Misses Dotfiles Without -Force
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** PowerShell (all)
-**Issue:** `Get-ChildItem` skips dotfiles (hidden on Windows). Filter `credentials*` won't match `.credentials*`.
-**Fix:** Use `-Force` flag AND add separate `.credentials*` filter.
-
 ## 50. Winget Installation Gotchas (Consolidated Reference)
 
 **Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
@@ -273,30 +181,6 @@ All parallel agents write to the same working directory. Sort into branches via 
 
 **Issue:** Winget-installed tools update registry PATH but current session has old PATH.
 **Fix:** Refresh: `$env:PATH = [Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' + [Environment]::GetEnvironmentVariable('PATH', 'User')`.
-
-## 54. PowerShell param() and CI Ordering (Consolidated Reference)
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** PowerShell 7+ / GitHub
-
-### param() must be first executable statement
-
-**Issue:** `Set-StrictMode` before `param()` causes confusing error.
-**Fix:** Only comments and `#Requires` before `param()`.
-
-### Branch protection requires pre-existing CI check names
-
-**Issue:** `required_status_checks.contexts` must reference jobs that have already run.
-**Fix:** Merge CI workflow first, verify job names in Actions tab, then apply protection.
-
-## 56. Subagent pnpm-lock.yaml Drift When Node.js Unavailable
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** Claude Code (Windows)
-**Issue:** Subagent adds deps to `package.json` but can't run `pnpm install`. CI fails with `ERR_PNPM_OUTDATED_LOCKFILE`.
-**Fix:** Run `pnpm install` after merging subagent changes to update lockfile.
 
 ## 61. Claude Code Settings Scope and Gitignore (Consolidated Reference)
 
@@ -328,45 +212,21 @@ Windows CRLF (`\r\n`) causes silent failures across multiple tools. Three known 
 
 **Universal fix:** Normalize `\r\n` to `\n` before any string processing on Windows.
 
-## 65. golangci-lint v2 Config Requirements
+## 65. golangci-lint v2 Config and Schema (Consolidated Reference)
 
 **Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
 
-**Platform:** Go (all)
+**Platform:** Go (all) / GitHub Actions
+
+### version field required
+
 **Issue:** v1 configs lack `version: "2"` field. v2 exits with "unsupported version" error. Build/test pass fine.
 **Fix:** Add `version: "2"` as first field. Update module path to `.../v2/cmd/golangci-lint`. Use devkit template `project-templates/golangci.yml`.
 
-## 66. golangci-lint-action v7 Runs config verify (Schema Enforcement)
+### Action v7 enforces strict schema
 
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** GitHub Actions
 **Issue:** v7 enforces strict JSON schema. v2.1 config keys fail with v2.10 schema. `linters-settings:` moved under `linters: settings:`. `issues: exclude-rules:` moved to `linters: exclusions: rules:`.
 **Fix:** Migrate config to v2.10 schema. Use `@v7` (not `@v6`) for golangci-lint v2. Default binary mode (not `goinstall`).
-
-## 67. Agent-Generated Markdown Tables: Pipes in Cells and Missing Columns
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** All (markdownlint)
-**Issue:** Agent markdown tables have MD056 errors: pipes in code spans parsed as separators, or missing columns.
-**Fix:** Run `npx markdownlint-cli2` on agent `.md` files. Use `&#124;` for pipes in cells. Verify column counts.
-
-## 72. ESLint react-hooks/set-state-in-effect Cannot Be Inline-Disabled
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** React / ESLint
-**Issue:** This rule does NOT support `// eslint-disable-next-line`. Adding it produces "Unused directive".
-**Fix:** Config-level override only: `"react-hooks/set-state-in-effect": "warn"` in `eslint.config.js`.
-
-## 73. ESLint 10 Breaks react-hooks Plugin Peer Dependency
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** npm / React
-**Issue:** ESLint 10.x breaks `eslint-plugin-react-hooks` which requires `eslint@^9`.
-**Fix:** Pin: `npm install --save-dev eslint@^9 @eslint/js@^9`.
 
 ## 74. gh repo edit Lacks --disable-* Flags
 
@@ -390,30 +250,6 @@ Windows CRLF (`\r\n`) causes silent failures across multiple tools. Three known 
 - **Multi-arch:** Must build `linux/amd64` + `linux/arm64` via `docker buildx`.
 - **MUI v5:** `@docker/docker-mui-theme` pins v5. Use `InputProps` not `slotProps.input`.
 - **Update after rebuild:** Use `docker extension install` (not `update`) -- tracks by digest.
-
-## 79. GitHub Secrets UI Is Buried Under Expandable Sidebar
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** GitHub
-**Issue:** Repo secrets are under Settings > Secrets and variables > Actions (expandable submenu).
-**Fix:** Use CLI: `gh secret set SECRETNAME`. `gh secret list` to verify.
-
-## 80. PowerShell StrictMode Throws on Nonexistent Property Access
-
-**Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
-
-**Platform:** PowerShell 7+
-**Issue:** Under StrictMode, accessing nonexistent property on PSCustomObject throws -- even in conditionals.
-**Fix:** Use `$obj.PSObject.Properties.Match('prop').Count -gt 0`. Does NOT affect hashtables.
-
-## 86. grep -c With || echo "0" Doubles Output on No Match
-
-**Added:** 2026-03-02 | **Source:** DevKit | **Status:** active
-
-**Platform:** Bash (all, especially CI)
-**Issue:** `grep -c` outputs "0" AND exits code 1. `$(grep -c ... || echo "0")` captures "0\n0", breaking arithmetic.
-**Fix:** Use `|| true` instead of `|| echo "0"`.
 
 ## 87. Vitest Cannot Resolve Browser-Only npm Package Exports
 
@@ -516,16 +352,7 @@ Windows CRLF (`\r\n`) causes silent failures across multiple tools. Three known 
 **Issue:** Copilot sub-PRs target the feature branch, not `main`. After squash-merge, merging these lands commits on a dead branch.
 **Fix:** Check target first: `gh pr view <number> --json baseRefName,state`. If base is not `main`, apply fixes manually on a new branch.
 
-## 100. Large Input Block Ignored at Task Transition (Variant B Stall)
-
-**Added:** 2026-03-07 | **Source:** DevKit | **Status:** active
-
-**Platform:** Claude Code (all)
-**Issue:** After completing a multi-step task, CC displays a pasted large input block as text rather than executing it. Context saturation at task boundaries.
-**Fix:** Kill session and open fresh. Do NOT attempt multiple `?` prompts -- if it fails twice, session is unrecoverable.
-**Prevention:** Keep handoff prompts under 40 lines. Run `/rules-compact` if rules files approach 40k.
-
-## 104. PowerShell Output Capture Gotchas (Consolidated Reference)
+## 104. PowerShell Tool and Variable Gotchas (Consolidated Reference)
 
 **Added:** 2026-03-08 | **Source:** DevKit | **Status:** active
 
@@ -540,6 +367,16 @@ Windows CRLF (`\r\n`) causes silent failures across multiple tools. Three known 
 
 **Issue:** `& command 2>&1 | Out-String` merges stderr into stdout. Parsing line-by-line produces garbage entries.
 **Fix:** Redirect stderr to a temp file: `$out = & command 2>$tmpErr | Out-String`. Check `$LASTEXITCODE` and read `$tmpErr` on failure.
+
+### Invoke-ScriptAnalyzer has no -Include parameter
+
+**Issue:** `-Include` parameter does not exist. Copilot and LLMs commonly generate this invalid syntax.
+**Fix:** Use `Get-ChildItem -Recurse -Filter '*.ps1'` to collect files, then pipe each to `Invoke-ScriptAnalyzer`.
+
+### $args is an automatic variable
+
+**Issue:** Using `$args` as a local variable triggers `PSAvoidAssignmentToAutomaticVariable`.
+**Fix:** Rename to `$cmdArgs`, `$labelArgs`, `$cliArgs`, or any non-reserved name. Other automatic variables: `$error`, `$input`, `$matches`, `$myinvocation`, `$psboundparameters`, `$pscmdlet`, `$psscriptroot`.
 
 ## 107. gh CLI Parameter Gotchas (Consolidated Reference)
 
@@ -586,30 +423,18 @@ Windows CRLF (`\r\n`) causes silent failures across multiple tools. Three known 
 **Issue:** Inserting mid-list without renumbering subsequent items triggers MD029.
 **Fix:** Update every item number from insertion point to end in a single edit.
 
-## 112. Invoke-ScriptAnalyzer Has No -Include Parameter
+### Pipes in table cells parsed as column separators
 
-**Added:** 2026-03-09 | **Source:** DevKit | **Status:** active
-
-**Platform:** PowerShell / PSScriptAnalyzer
-**Issue:** `-Include` parameter does not exist. Copilot and LLMs commonly generate this invalid syntax.
-**Fix:** Use `Get-ChildItem -Recurse -Filter '*.ps1'` to collect files, then pipe each to `Invoke-ScriptAnalyzer`.
-
-## 113. PowerShell $args Is an Automatic Variable
-
-**Added:** 2026-03-09 | **Source:** DevKit | **Status:** active
-
-**Platform:** PowerShell (all)
-**Issue:** `$args` is a PowerShell automatic variable containing the unbound parameters for the current function or script. Using it as a local variable name (e.g., `$args = @('label', 'create', ...)`) triggers `PSAvoidAssignmentToAutomaticVariable`. PSScriptAnalyzer flags it as an error.
-**Fix:** Rename to `$cmdArgs`, `$labelArgs`, `$cliArgs`, or any non-reserved name. Full list of automatic variables: `$args`, `$error`, `$input`, `$matches`, `$myinvocation`, `$ofs`, `$profile`, `$psboundparameters`, `$pscmdlet`, `$psscriptroot`, etc.
-**See also:** KG#104 (PSUseDeclaredVarsMoreThanAssignments -- related PSScriptAnalyzer surface)
+**Issue:** Agent markdown tables have MD056 errors: pipes in code spans parsed as separators, or missing columns.
+**Fix:** Run `npx markdownlint-cli2` on agent `.md` files. Use `&#124;` for pipes in cells. Verify column counts.
 
 ## 114. Set-StrictMode in Dot-Sourced PS Lib Pollutes Caller Scope
 
 **Added:** 2026-03-09 | **Source:** DevKit | **Status:** active
 
 **Platform:** PowerShell (all)
-**Issue:** `Set-StrictMode -Version Latest` at the top level of a dot-sourced `.ps1` lib file (`. "$PSScriptRoot\lib\foo.ps1"`) propagates to the calling script's scope and all subsequently dot-sourced files. This silently tightens rules in callers that didn't opt in and can cause unexpected runtime errors.
-**Fix:** Do NOT put `Set-StrictMode` in dot-sourced library files. Set it only in the entry-point script (`setup.ps1`, `new-project.ps1`, etc.) that owns its own execution context.
+**Issue:** `Set-StrictMode -Version Latest` at the top level of a dot-sourced `.ps1` lib file propagates to the calling script's scope and all subsequently dot-sourced files.
+**Fix:** Do NOT put `Set-StrictMode` in dot-sourced library files. Set it only in the entry-point script that owns its own execution context.
 
 ## 115. TypeScript API Interface Phantom Field Drift from Go Backend
 
@@ -678,21 +503,26 @@ Windows CRLF (`\r\n`) causes silent failures across multiple tools. Three known 
 **Issue:** Account API tokens fail on `/memberships` (error 10001) and `/user/tokens/verify` (error 9109). Wrangler calls `/memberships` on startup and fails with "Unable to authenticate request."
 **Fix:** Set `CLOUDFLARE_ACCOUNT_ID` env var alongside Account API token. Wrangler skips memberships lookup when account ID is explicit. User API tokens work without this workaround.
 
-## 123. Gitea API Token from Git Credential Manager
+## 123. Gitea API and Actions Gotchas (Consolidated Reference)
 
 **Added:** 2026-03-14 | **Source:** Synapset | **Status:** active
 
 **Platform:** Gitea / Git (all)
+
+### API token from Git Credential Manager
+
 **Issue:** When `tea` CLI is unavailable, need Gitea token for API calls.
 **Fix:** Extract from git credential manager: `git credential fill <<< 'protocol=https\nhost=gitea.example.com' | grep password`. Use with `Authorization: token` header. Gitea REST API is largely GitHub-compatible.
 
-## 124. Gitea PR Merge After Rebase Needs Pause
+### PR merge after rebase needs pause
 
-**Added:** 2026-03-14 | **Source:** Synapset | **Status:** active
-
-**Platform:** Gitea
 **Issue:** After force-pushing a rebased branch, Gitea's merge API may reject immediately with "not mergeable" while it recalculates merge status.
 **Fix:** Add a brief pause (2-3 seconds) between force-push and merge API call. Check mergeable status before merging.
+
+### GITEA_ prefix reserved for secret names
+
+**Issue:** Creating a secret starting with `GITEA_` via API returns `{"message":"invalid secret name"}`. Undocumented.
+**Fix:** Use a different prefix (e.g., `CI_GITEA_TOKEN` instead of `GITEA_TOKEN`). Workflows referencing `secrets.GITEA_TOKEN` silently get empty values.
 
 ## 125. go:embed Cache Misses Embedded File Changes
 
@@ -711,13 +541,21 @@ Windows CRLF (`\r\n`) causes silent failures across multiple tools. Three known 
 **Issue:** Funnel returns "Forbidden: invalid Host header" when accessed from a device within the same tailnet. Intra-tailnet traffic bypasses Funnel's public ingress path via WireGuard. External clients work fine.
 **Fix:** Use Cloudflare Tunnel instead of Tailscale Funnel for universal access (both internal and external clients).
 
-## 127. sqlite-vec vec0 Dimension Must Match Embedding Provider
+## 127. sqlite-vec Virtual Table Gotchas (Consolidated Reference)
 
 **Added:** 2026-03-14 | **Source:** Synapset | **Status:** active
 
 **Platform:** SQLite / sqlite-vec
+
+### Dimension must match embedding provider
+
 **Issue:** vec0 virtual table dimension (`float[N]`) is fixed at CREATE time. Hardcoding 1536 (OpenAI) but using Ollama (768) at runtime causes "Dimension mismatch" on insert.
 **Fix:** Pass dims from embedding provider at DB init time. Don't use const schema strings for vec0 -- make dimension configurable.
+
+### No UPDATE support
+
+**Issue:** `vec0` virtual tables do NOT support SQL UPDATE. Attempting to update an embedding in-place fails silently or errors.
+**Fix:** DELETE old row then INSERT new one. Wrap batch re-embedding in a transaction.
 
 ## 128. Claude Code User-Scope MCP Config Location Is ~/.claude.json
 
@@ -734,15 +572,6 @@ Windows CRLF (`\r\n`) causes silent failures across multiple tools. Three known 
 **Platform:** Claude Code (Linux)
 **Issue:** `claude --dangerously-skip-permissions` exits with error when running as root/sudo. Blocks headless agent use in systemd services running as root.
 **Fix:** Run Claude Code as a non-root service user. Create a dedicated user with shell access.
-
-## 130. git worktree Operations Can Flip core.bare=true
-
-**Added:** 2026-03-15 | **Source:** Samverk | **Status:** active
-
-**Platform:** Git (all)
-**Issue:** Multiple `git worktree add`/`remove` operations (especially with parallel CC sessions) can flip `core.bare = true` in the main repo's `.git/config`. All normal git operations fail.
-**Fix:** `git -C <repo> config core.bare false`. Detection: `git worktree list` shows main as `(bare)`.
-**See also:** KG#25, AP#127
 
 ## 131. git init Defaults to master on CI Runners
 
@@ -792,31 +621,6 @@ Windows CRLF (`\r\n`) causes silent failures across multiple tools. Three known 
 **Issue:** SPA catch-all route (`/ -> spaHandler`) intercepts paths not explicitly registered for all HTTP methods. Registering only `POST /mcp` causes GET/DELETE to fall through to SPA, returning HTML instead of JSON.
 **Fix:** Register without method prefix: `mux.Handle("/mcp", handler)` when the handler routes methods internally.
 **See also:** KG#28 (Go 1.22+ route pattern panic)
-
-## 137. sqlite-vec vec0 Virtual Tables Do Not Support UPDATE
-
-**Added:** 2026-03-15 | **Source:** Synapset | **Status:** active
-
-**Platform:** SQLite / sqlite-vec
-**Issue:** `vec0` virtual tables do NOT support SQL UPDATE. Attempting to update an embedding in-place fails silently or errors.
-**Fix:** DELETE old row then INSERT new one. Wrap batch re-embedding in a transaction.
-**See also:** KG#127 (vec0 dimension mismatch)
-
-## 138. Gitea Reserves GITEA_ Prefix for Actions Secret Names
-
-**Added:** 2026-03-15 | **Source:** Synapset | **Status:** active
-
-**Platform:** Gitea Actions
-**Issue:** Creating a secret starting with `GITEA_` via API returns `{"message":"invalid secret name"}`. Undocumented.
-**Fix:** Use a different prefix (e.g., `CI_GITEA_TOKEN` instead of `GITEA_TOKEN`). Workflows referencing `secrets.GITEA_TOKEN` silently get empty values.
-
-## 139. ncruces/go-sqlite3 WASM Driver Is Not Goroutine-Safe
-
-**Added:** 2026-03-15 | **Source:** Synapset | **Status:** active
-
-**Platform:** Go (all)
-**Issue:** WASM-based SQLite driver has single linear memory space. Concurrent goroutine access causes `panic: wasm error: out of bounds memory access`.
-**Fix:** Use `sync.Mutex` or `*sql.DB` with `SetMaxOpenConns(1)`. Alternative: switch to CGO-based driver (`mattn/go-sqlite3`) which supports SQLite threading modes.
 
 ## 140. nologin Shell Masks Real Errors for Service Users
 


### PR DESCRIPTION
## Summary

Rules files compaction to stay under the 35k performance threshold.

**known-gotchas.md: 44k -> 35k (21% reduction)**
- 20 entries archived (niche, unreferenced: KG#2,5,11,14,15,16,37,38,47,48,49,54,56,72,73,79,80,86,100,139)
- 8 consolidations (10 entries absorbed): KG#7->6, KG#13->12, KG#66->65, KG#67->111, KG#123+124+138, KG#127+137, KG#130->25, KG#104+112+113
- Result: 90 -> 60 entries

**autolearn-patterns.md: 38k -> 35k (8% reduction)**
- 1 entry archived (AP#27, superseded)
- 4 consolidations (9 entries absorbed): AP#18+92+93+94+95+108, AP#111+112+114, AP#73+75+76, AP#48 trimmed
- Result: 77 -> 67 entries

**Cross-reference fixes:** KG#66->KG#65, KG#112->KG#104

## Test plan

- [x] Both files under 35k (KG: 34,637, AP: 34,934)
- [x] markdownlint: 0 errors on all 4 files
- [x] All archived entries preserved in claude/rules/archive/
- [x] Cross-reference verification (Step 8) completed
- [x] Frontmatter counts updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)