### PR TITLE
feat(metrics): add effectiveness measurement skill and data model

### DIFF
--- a/.samverk/status.md
+++ b/.samverk/status.md
@@ -15,7 +15,7 @@ Active maintenance and execution. AI tooling methodology, Claude Code configurat
 ## What Is Running
 
 - Symlinked rules loaded by all Claude Code sessions via ~/.claude/
-- 21 skills, 7 agents, 11 rules files, 128 active patterns (AP: 67, KG: 61)
+- 22 skills, 7 agents, 11 rules files, 128 active patterns (AP: 67, KG: 61)
 - SessionStart hook for context injection
 - Credentials migrated to PowerShell SecretStore vault (HomeLabVault)
 
@@ -25,13 +25,14 @@ Active maintenance and execution. AI tooling methodology, Claude Code configurat
 
 ## Queued
 
-- Synapset deep migration -- evaluate replacing rules file reads with `search_memory` calls (semantic > keyword matching). Current: dual-store (rules files + Synapset)
+- Sync batch-ingested entries to Synapset pool (#333) -- closes coverage gap found during deep migration evaluation
 
 ## Recently Completed
 
 - **v2.4.0 release** -- autonomous autolearn routing (PR #322)
 - Autolearn batch ingest: 15 issues -> 14 KG + 3 AP + 1 WP entries (PR #329)
 - Rules compaction: KG 44k->35k (90->60), AP 38k->35k (77->67) (PR #331)
+- Synapset deep migration evaluated: full migration not viable, dual-store is the target architecture
 - Synapset integration verified working (3 pools, dual-store operational)
 - v2.3.0: Synapset backend, MCP research, cross-ref verification
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ devkit/
 ├── claude/              - Claude Code config (rules, skills, agents, hooks)
 │   ├── CLAUDE.md        - Global instructions (installed to ~/.claude/)
 │   ├── rules/           - Auto-loaded pattern files (11 files, 150 patterns)
-│   ├── skills/          - Invokable skills (21 skills with workflow files)
+│   ├── skills/          - Invokable skills (22 skills with workflow files)
 │   ├── agents/          - Agent templates (7 agents)
 │   └── hooks/           - SessionStart hook
 ├── devspace/            - Workspace shared configs (.editorconfig, VS Code)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Setup creates symlinks from `~/.claude/` to the DevKit clone (or copies files in
 | Component | Count | Location |
 |-----------|-------|----------|
 | Rules (auto-loaded every session) | 11 files | `claude/rules/` |
-| Skills (invoke with `/skill-name`) | 21 skills | `claude/skills/` |
+| Skills (invoke with `/skill-name`) | 22 skills | `claude/skills/` |
 | Agent templates | 7 agents | `claude/agents/` |
 | SessionStart hook | 1 | `claude/hooks/` |
 | Setup scripts (PowerShell + legacy bash) | 7+3 | `setup/` + `setup/legacy/` |
@@ -61,7 +61,7 @@ See [Settings Strategy](docs/settings-strategy.md) for the two-layer permission 
 
 | Directory | Purpose |
 |-----------|---------|
-| `claude/` | Global Claude Code config — CLAUDE.md, 11 rules files (150 patterns), 21 skills, 7 agent templates, hooks |
+| `claude/` | Global Claude Code config — CLAUDE.md, 11 rules files (150 patterns), 22 skills, 7 agent templates, hooks |
 | `devspace/` | Workspace shared configs — .editorconfig, .markdownlint.json, VS Code fragments |
 | `docs/` | Human-readable guides — architecture decisions, profile format spec |
 | `machine/` | Machine state snapshots — VS Code extensions, tool versions |
@@ -251,6 +251,7 @@ Claude.ai Chat uses a separate skill store - install via Settings > Skills in th
 |-------|---------|---------|
 | autolearn | Session learning capture and reflection | Code |
 | quality-control | CI verification and PR health checks | Code |
+| metrics | Effectiveness measurement and rework analysis | Code |
 | manage-github-issues | Issue generation, audit, and triage | Code |
 | requirements-generator | Requirements.md creation | Code/Chat |
 | setup-github-actions | CI/CD workflow generation | Code |

--- a/claude/skills/metrics/SKILL.md
+++ b/claude/skills/metrics/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: metrics
+description: DevKit effectiveness measurement dashboard and collection
+user_invocable: true
+---
+
+# Metrics
+
+Measure DevKit's impact on code quality and rework reduction across all managed projects.
+
+<essential_principles>
+
+- All metrics stored in SQLite MCP (`~/databases/claude.db`)
+- PR data sourced from GitHub API (immutable history)
+- Collection happens at natural boundaries, not continuously
+- Schema defined in `scripts/metrics-init.sql`
+
+</essential_principles>
+
+<routing>
+
+| Input | Workflow | Description |
+|-------|----------|-------------|
+| `dashboard`, (default) | workflows/dashboard.md | Show current metrics summary |
+| `collect` | workflows/collect.md | Run PR metrics collection from GitHub API |
+| `rework`, `rework-report` | workflows/rework-report.md | Rework rate analysis per project |
+| `trend` | workflows/trend.md | Compare metrics across time windows |
+
+</routing>

--- a/claude/skills/metrics/workflows/collect.md
+++ b/claude/skills/metrics/workflows/collect.md
@@ -1,0 +1,37 @@
+# Metrics Collection
+
+Trigger PR metrics collection from GitHub API for all DevKit-managed repos.
+
+## Steps
+
+### 1. Run Collection Script
+
+Execute the PR metrics collection script:
+
+```bash
+bash scripts/collect-pr-metrics.sh --days 30
+```
+
+If running in a context where `scripts/` is not the DevKit repo root, use the full path:
+
+```bash
+bash "$(git -C ~/.claude rev-parse --show-toplevel 2>/dev/null || echo d:/DevSpace/devkit)/scripts/collect-pr-metrics.sh" --days 30
+```
+
+### 2. Collect for Specific Repo (Optional)
+
+If the user specifies a repo:
+
+```bash
+bash scripts/collect-pr-metrics.sh --repo OWNER/REPO --days 30
+```
+
+### 3. Report Results
+
+After collection, show:
+
+- Number of repos scanned
+- Number of PRs collected
+- Any errors encountered
+
+Then suggest: "Run `/metrics dashboard` to view the results."

--- a/claude/skills/metrics/workflows/dashboard.md
+++ b/claude/skills/metrics/workflows/dashboard.md
@@ -1,0 +1,120 @@
+# Metrics Dashboard
+
+Display a summary of DevKit effectiveness metrics from SQLite.
+
+## Steps
+
+### 1. Ensure Schema Exists
+
+Run the schema initialization to ensure tables exist:
+
+```bash
+sqlite3 ~/databases/claude.db < scripts/metrics-init.sql
+```
+
+If `sqlite3` is unavailable, use the SQLite MCP tools to create tables from `scripts/metrics-init.sql`.
+
+### 2. Query PR Metrics (Last 30 Days)
+
+Use SQLite MCP `read_query` or `sqlite3` to run:
+
+```sql
+SELECT
+    repo,
+    COUNT(*) as prs,
+    ROUND(AVG(push_count), 1) as avg_pushes,
+    ROUND(100.0 * SUM(ci_first_pass) / COUNT(*), 0) as first_pass_pct,
+    SUM(fix_push_cycles) as total_fix_cycles
+FROM pr_metrics
+WHERE merged_at >= date('now', '-30 days')
+GROUP BY repo
+ORDER BY repo;
+```
+
+### 3. Query Conformance Scores (Latest Per Project)
+
+```sql
+SELECT repo, audit_date, score_pct, passed, failed
+FROM conformance_scores c1
+WHERE audit_date = (SELECT MAX(audit_date) FROM conformance_scores c2 WHERE c2.repo = c1.repo)
+ORDER BY repo;
+```
+
+### 4. Query Pattern Impact (Last 30 Days)
+
+```sql
+SELECT
+    entry_id,
+    entry_title,
+    COUNT(*) as total_events,
+    SUM(CASE WHEN event_type = 'applied' THEN 1 ELSE 0 END) as applied,
+    SUM(CASE WHEN event_type = 'prevented' THEN 1 ELSE 0 END) as prevented,
+    SUM(CASE WHEN event_type = 'caught' THEN 1 ELSE 0 END) as caught,
+    MAX(session_date) as last_used
+FROM pattern_events
+WHERE session_date >= date('now', '-30 days')
+GROUP BY entry_id
+ORDER BY total_events DESC
+LIMIT 20;
+```
+
+### 5. Query Skill Usage (Last 30 Days)
+
+```sql
+SELECT
+    skill_name,
+    COUNT(*) as invocations,
+    ROUND(100.0 * SUM(completed) / COUNT(*), 0) as completion_pct
+FROM skill_usage
+WHERE invoked_at >= date('now', '-30 days')
+GROUP BY skill_name
+ORDER BY invocations DESC;
+```
+
+### 6. Query Autolearn Pipeline (Last 30 Days)
+
+```sql
+SELECT
+    event_type,
+    COUNT(*) as count
+FROM autolearn_events
+WHERE event_date >= date('now', '-30 days')
+GROUP BY event_type
+ORDER BY CASE event_type
+    WHEN 'discovered' THEN 1
+    WHEN 'issue_created' THEN 2
+    WHEN 'ingested' THEN 3
+    WHEN 'applied' THEN 4
+    ELSE 5
+END;
+```
+
+### 7. Format and Display
+
+Present results in this format:
+
+```text
+## DevKit Effectiveness Dashboard
+
+### Rework Rate (last 30 days)
+| Project | PRs | Avg Pushes/PR | First-Pass CI % | Fix-Push Cycles |
+|---------|-----|---------------|-----------------|-----------------|
+
+### Conformance (latest audit)
+| Project | Score | Passed | Failed | Date |
+|---------|-------|--------|--------|------|
+
+### Pattern Impact (last 30 days)
+| Entry | Applied | Prevented | Caught | Last Used |
+|-------|---------|-----------|--------|-----------|
+
+### Skill Usage (last 30 days)
+| Skill | Invocations | Completion % |
+|-------|-------------|--------------|
+
+### Autolearn Pipeline (last 30 days)
+| Stage | Count |
+|-------|-------|
+```
+
+If any table has no data, show "(no data collected yet -- run `/metrics collect` first)" instead.

--- a/claude/skills/metrics/workflows/rework-report.md
+++ b/claude/skills/metrics/workflows/rework-report.md
@@ -1,0 +1,85 @@
+# Rework Report
+
+Detailed rework rate analysis per project, identifying patterns in CI failures and fix-push cycles.
+
+## Steps
+
+### 1. Ensure Data Exists
+
+Check if pr_metrics has data:
+
+```sql
+SELECT COUNT(*) FROM pr_metrics;
+```
+
+If zero, advise: "No PR data collected yet. Run `/metrics collect` first."
+
+### 2. Summary by Project
+
+```sql
+SELECT
+    repo,
+    COUNT(*) as total_prs,
+    ROUND(AVG(push_count), 1) as avg_pushes_per_pr,
+    ROUND(100.0 * SUM(ci_first_pass) / COUNT(*), 0) as first_pass_pct,
+    SUM(fix_push_cycles) as total_fix_cycles,
+    ROUND(AVG(CASE WHEN fix_push_cycles > 0 THEN fix_push_cycles END), 1) as avg_cycles_when_failing
+FROM pr_metrics
+WHERE merged_at >= date('now', '-30 days')
+GROUP BY repo
+ORDER BY first_pass_pct ASC;
+```
+
+### 3. Worst Offenders (PRs with Most Rework)
+
+```sql
+SELECT repo, pr_number, branch, push_count, fix_push_cycles, ci_first_pass
+FROM pr_metrics
+WHERE merged_at >= date('now', '-30 days')
+    AND fix_push_cycles > 0
+ORDER BY fix_push_cycles DESC
+LIMIT 10;
+```
+
+### 4. Trend Comparison (Last 30d vs Prior 30d)
+
+```sql
+SELECT
+    'Last 30 days' as period,
+    COUNT(*) as prs,
+    ROUND(AVG(push_count), 1) as avg_pushes,
+    ROUND(100.0 * SUM(ci_first_pass) / COUNT(*), 0) as first_pass_pct
+FROM pr_metrics
+WHERE merged_at >= date('now', '-30 days')
+UNION ALL
+SELECT
+    'Prior 30 days' as period,
+    COUNT(*) as prs,
+    ROUND(AVG(push_count), 1) as avg_pushes,
+    ROUND(100.0 * SUM(ci_first_pass) / COUNT(*), 0) as first_pass_pct
+FROM pr_metrics
+WHERE merged_at >= date('now', '-60 days')
+    AND merged_at < date('now', '-30 days');
+```
+
+### 5. Format Report
+
+Present as:
+
+```text
+## Rework Report
+
+### Summary by Project
+| Project | PRs | Avg Pushes | First-Pass % | Fix Cycles | Avg When Failing |
+|---------|-----|------------|--------------|------------|------------------|
+
+### Worst Offenders (Most Rework)
+| Project | PR # | Branch | Pushes | Fix Cycles |
+|---------|------|--------|--------|------------|
+
+### Trend (30d vs Prior 30d)
+| Period | PRs | Avg Pushes | First-Pass % | Direction |
+|--------|-----|------------|--------------|-----------|
+```
+
+Add directional indicators: first-pass % improving = good, degrading = flag for attention.

--- a/claude/skills/metrics/workflows/trend.md
+++ b/claude/skills/metrics/workflows/trend.md
@@ -1,0 +1,69 @@
+# Metrics Trend Analysis
+
+Compare DevKit effectiveness metrics across time windows to identify improvement or degradation.
+
+## Steps
+
+### 1. Query Rework Trend
+
+Compare last 30 days vs prior 30 days:
+
+```sql
+SELECT
+    CASE
+        WHEN merged_at >= date('now', '-30 days') THEN 'Last 30d'
+        ELSE 'Prior 30d'
+    END as period,
+    COUNT(*) as prs,
+    ROUND(AVG(push_count), 1) as avg_pushes,
+    ROUND(100.0 * SUM(ci_first_pass) / COUNT(*), 0) as first_pass_pct,
+    SUM(fix_push_cycles) as fix_cycles
+FROM pr_metrics
+WHERE merged_at >= date('now', '-60 days')
+GROUP BY period
+ORDER BY period DESC;
+```
+
+### 2. Query Conformance Trend
+
+Show score progression per project:
+
+```sql
+SELECT repo, audit_date, score_pct
+FROM conformance_scores
+WHERE audit_date >= date('now', '-90 days')
+ORDER BY repo, audit_date;
+```
+
+### 3. Query Pattern Application Trend
+
+```sql
+SELECT
+    strftime('%Y-%m', session_date) as month,
+    COUNT(*) as events,
+    COUNT(DISTINCT entry_id) as unique_patterns
+FROM pattern_events
+WHERE session_date >= date('now', '-90 days')
+GROUP BY month
+ORDER BY month;
+```
+
+### 4. Format Report
+
+```text
+## Trend Analysis
+
+### Rework Rate Trend
+| Period | PRs | Avg Pushes | First-Pass % | Fix Cycles | Direction |
+|--------|-----|------------|--------------|------------|-----------|
+
+### Conformance Score Trend
+| Project | 3 Months Ago | 2 Months Ago | Last Month | Direction |
+|---------|-------------|-------------|------------|-----------|
+
+### Pattern Application Trend
+| Month | Events | Unique Patterns | Direction |
+|-------|--------|-----------------|-----------|
+```
+
+Use directional indicators based on comparison to prior period.

--- a/docs/ADR-0017-effectiveness-measurement.md
+++ b/docs/ADR-0017-effectiveness-measurement.md
@@ -1,0 +1,60 @@
+# ADR-0017: DevKit Effectiveness Measurement
+
+## Status
+
+Accepted (2026-03-15)
+
+## Context
+
+DevKit has anecdotal evidence of impact on code quality ("zero rework sprint" AP#101, "all CI-green first pass" AP#127) but no objective, quantifiable measurement system. Without data, we cannot:
+
+- Prove DevKit reduces rework across projects
+- Identify which patterns deliver the most value
+- Track improvement or degradation over time
+- Make evidence-based decisions about rule priorities
+
+Samverk and Synapset both have production-grade monitoring (runtime metrics, failure tracking, tool call recording). DevKit needs an adapted approach since it is a configuration toolkit, not a running service.
+
+## Decision
+
+Implement a four-phase effectiveness measurement system using existing infrastructure.
+
+### Architecture
+
+Three storage tiers:
+
+1. **SQLite MCP** (`~/databases/claude.db`) for structured metrics (PR data, CI pass rates, conformance scores, skill usage)
+2. **Synapset MCP** (pool: `devkit-metrics`) for semantic search over session narratives
+3. **GitHub API** (via `gh`) as source of truth for CI/PR data
+
+Collection happens at natural boundaries (session start/end, autolearn runs, CI completions) rather than continuously. No new always-on processes.
+
+### Key Metrics
+
+| Metric | Source | Collection Method |
+|--------|--------|------------------|
+| Rework Rate (fix-push cycles per PR) | GitHub API | On-demand script |
+| CI First-Pass Rate | GitHub API | On-demand script |
+| Pattern Application | Autolearn skill | Session boundary |
+| Autolearn Velocity | GitHub Issues + Rules | Session boundary |
+| Skill Usage | Skill instrumentation | Per invocation |
+| Conformance Score | Conformance audit | Per audit run |
+
+### Why SQLite Over Synapset for Structured Metrics
+
+Synapset excels at semantic search over unstructured text. Metrics are structured, relational data requiring aggregation (AVG, SUM, GROUP BY) and time-series comparison. SQLite via MCP provides this naturally. Synapset remains the store for session narratives and pattern application context.
+
+## Alternatives Considered
+
+1. **Synapset-only**: Rejected. Vector similarity search is wrong tool for numeric aggregation.
+2. **GitHub API only (no persistence)**: Rejected. Rate limits and no historical trend capability.
+3. **File-based JSON snapshots**: Considered for Phase 4 as git-tracked history supplement.
+4. **External service (Grafana/Prometheus)**: Rejected. Over-engineered for a config toolkit.
+
+## Consequences
+
+- New `/metrics` skill with dashboard, collect, rework-report, trend workflows
+- Schema in `scripts/metrics-init.sql` -- tables created on first use
+- Collection script `scripts/collect-pr-metrics.sh` queries GitHub API
+- Phases 2-3 instrument existing skills (autolearn, conformance-audit) with recording steps
+- README skill count increases from 21 to 22

--- a/scripts/collect-pr-metrics.sh
+++ b/scripts/collect-pr-metrics.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Collect PR metrics from GitHub API for all DevKit-managed repos.
+# Populates pr_metrics table in ~/databases/claude.db via sqlite3.
+#
+# Usage: collect-pr-metrics.sh [--days N] [--repo OWNER/REPO]
+# Defaults: last 30 days, all repos in D:\DevSpace\
+
+DAYS=30
+TARGET_REPO=""
+DB="$HOME/databases/claude.db"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --days) DAYS="$2"; shift 2 ;;
+        --repo) TARGET_REPO="$2"; shift 2 ;;
+        --db)   DB="$2"; shift 2 ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+# Ensure database and schema exist
+mkdir -p "$(dirname "$DB")"
+sqlite3 "$DB" < "$SCRIPT_DIR/metrics-init.sql" 2>/dev/null || true
+
+# Discover repos or use specified one
+if [[ -n "$TARGET_REPO" ]]; then
+    REPOS=("$TARGET_REPO")
+else
+    REPOS=()
+    # Read repos from devkit config if available
+    CONFIG="$HOME/.devkit-config.json"
+    if [[ -f "$CONFIG" ]]; then
+        DEVSPACE=$(python3 -c "import json; print(json.load(open('$CONFIG')).get('devspacePath', 'D:/DevSpace'))" 2>/dev/null || echo "D:/DevSpace")
+    else
+        DEVSPACE="D:/DevSpace"
+    fi
+
+    # Find git repos with GitHub remotes
+    for dir in "$DEVSPACE"/*/; do
+        if [[ -d "$dir/.git" ]]; then
+            remote=$(git -C "$dir" remote get-url origin 2>/dev/null || true)
+            if [[ "$remote" == *"github.com"* ]]; then
+                # Extract OWNER/REPO from remote URL
+                repo=$(echo "$remote" | sed -E 's|.*github\.com[:/]([^/]+/[^/.]+)(\.git)?$|\1|')
+                if [[ -n "$repo" ]]; then
+                    REPOS+=("$repo")
+                fi
+            fi
+        fi
+    done
+fi
+
+if [[ ${#REPOS[@]} -eq 0 ]]; then
+    echo "No GitHub repos found." >&2
+    exit 1
+fi
+
+SINCE=$(date -u -d "$DAYS days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+        date -u -v-${DAYS}d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+        echo "2026-01-01T00:00:00Z")
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+echo "Collecting PR metrics since $SINCE for ${#REPOS[@]} repo(s)..."
+
+TOTAL_PRS=0
+TOTAL_INSERTED=0
+
+for repo in "${REPOS[@]}"; do
+    echo "  $repo..."
+
+    # Fetch merged PRs since SINCE
+    prs=$(gh api "repos/$repo/pulls?state=closed&sort=updated&direction=desc&per_page=100" \
+        --jq "[.[] | select(.merged_at != null and .merged_at >= \"$SINCE\") | {number, branch: .head.ref, created_at, merged_at}]" 2>/dev/null || echo "[]")
+
+    count=$(echo "$prs" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
+
+    if [[ "$count" == "0" ]]; then
+        echo "    No merged PRs in period."
+        continue
+    fi
+
+    TOTAL_PRS=$((TOTAL_PRS + count))
+
+    # Process each PR
+    echo "$prs" | python3 -c "
+import json, sys, subprocess, sqlite3, os
+
+prs = json.load(sys.stdin)
+repo = '$repo'
+db_path = '$DB'
+now = '$NOW'
+
+conn = sqlite3.connect(db_path)
+cur = conn.cursor()
+inserted = 0
+
+for pr in prs:
+    num = pr['number']
+    branch = pr['branch']
+
+    # Count CI workflow runs for this PR's branch
+    try:
+        result = subprocess.run(
+            ['gh', 'api', f'repos/{repo}/actions/runs?branch={branch}&per_page=100',
+             '--jq', '[.workflow_runs[] | {conclusion, created_at}]'],
+            capture_output=True, text=True, timeout=30, encoding='utf-8'
+        )
+        runs = json.loads(result.stdout) if result.returncode == 0 else []
+    except Exception:
+        runs = []
+
+    total_runs = len(runs)
+    green_runs = sum(1 for r in runs if r.get('conclusion') == 'success')
+
+    # First CI pass: did the earliest run succeed?
+    ci_first_pass = 0
+    if runs:
+        sorted_runs = sorted(runs, key=lambda r: r.get('created_at', ''))
+        if sorted_runs and sorted_runs[0].get('conclusion') == 'success':
+            ci_first_pass = 1
+
+    # Push count approximation: number of CI runs triggered
+    push_count = max(total_runs, 1)
+
+    # Fix-push cycles: pushes after first failure
+    fix_push_cycles = max(0, push_count - 1) if not ci_first_pass else 0
+
+    try:
+        cur.execute('''
+            INSERT OR REPLACE INTO pr_metrics
+            (repo, pr_number, branch, created_at, merged_at, push_count,
+             ci_first_pass, ci_total_runs, ci_green_runs, fix_push_cycles, collected_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ''', (repo, num, branch, pr.get('created_at'), pr.get('merged_at'),
+              push_count, ci_first_pass, total_runs, green_runs, fix_push_cycles, now))
+        inserted += 1
+    except Exception as e:
+        print(f'    Error inserting PR #{num}: {e}', file=sys.stderr)
+
+conn.commit()
+conn.close()
+print(f'    {inserted}/{len(prs)} PRs collected.')
+" 2>&1
+
+    result=$?
+    if [[ $result -eq 0 ]]; then
+        TOTAL_INSERTED=$((TOTAL_INSERTED + count))
+    fi
+done
+
+echo ""
+echo "Done. $TOTAL_PRS PRs processed across ${#REPOS[@]} repo(s)."
+echo "Database: $DB"

--- a/scripts/metrics-init.sql
+++ b/scripts/metrics-init.sql
@@ -1,0 +1,81 @@
+-- DevKit Effectiveness Metrics Schema
+-- Storage: ~/databases/claude.db (SQLite MCP)
+-- See: docs/ADR-0017-effectiveness-measurement.md
+
+-- PR-level metrics: one row per PR across all DevKit-managed projects
+CREATE TABLE IF NOT EXISTS pr_metrics (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo TEXT NOT NULL,
+    pr_number INTEGER NOT NULL,
+    branch TEXT,
+    created_at TEXT,
+    merged_at TEXT,
+    push_count INTEGER DEFAULT 1,
+    ci_first_pass INTEGER,
+    ci_total_runs INTEGER DEFAULT 1,
+    ci_green_runs INTEGER DEFAULT 0,
+    fix_push_cycles INTEGER DEFAULT 0,
+    labels TEXT,
+    collected_at TEXT NOT NULL,
+    UNIQUE(repo, pr_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pr_metrics_repo ON pr_metrics(repo);
+CREATE INDEX IF NOT EXISTS idx_pr_metrics_merged ON pr_metrics(merged_at);
+
+-- Conformance scores: one row per project per audit run
+CREATE TABLE IF NOT EXISTS conformance_scores (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo TEXT NOT NULL,
+    audit_date TEXT NOT NULL,
+    total_checks INTEGER,
+    passed INTEGER,
+    failed INTEGER,
+    skipped INTEGER,
+    score_pct REAL,
+    details TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_conformance_repo ON conformance_scores(repo);
+CREATE INDEX IF NOT EXISTS idx_conformance_date ON conformance_scores(audit_date);
+
+-- Pattern application events: when a KG/AP entry prevented or caught an issue
+CREATE TABLE IF NOT EXISTS pattern_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entry_id TEXT NOT NULL,
+    entry_title TEXT,
+    event_type TEXT NOT NULL,
+    project TEXT,
+    session_date TEXT NOT NULL,
+    description TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_pattern_entry ON pattern_events(entry_id);
+CREATE INDEX IF NOT EXISTS idx_pattern_date ON pattern_events(session_date);
+
+-- Skill usage tracking
+CREATE TABLE IF NOT EXISTS skill_usage (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    skill_name TEXT NOT NULL,
+    invoked_at TEXT NOT NULL,
+    project TEXT,
+    workflow_used TEXT,
+    completed INTEGER DEFAULT 1
+);
+
+CREATE INDEX IF NOT EXISTS idx_skill_name ON skill_usage(skill_name);
+CREATE INDEX IF NOT EXISTS idx_skill_date ON skill_usage(invoked_at);
+
+-- Autolearn velocity: pattern lifecycle tracking
+CREATE TABLE IF NOT EXISTS autolearn_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type TEXT NOT NULL,
+    entry_id TEXT,
+    source_project TEXT,
+    event_date TEXT NOT NULL,
+    issue_number INTEGER,
+    description TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_autolearn_type ON autolearn_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_autolearn_date ON autolearn_events(event_date);


### PR DESCRIPTION
## Summary

Phase 1 of DevKit effectiveness measurement -- the foundation for objectively measuring
DevKit's impact on code quality and rework reduction.

- **SQLite schema** (`scripts/metrics-init.sql`): 5 tables (pr_metrics, conformance_scores, pattern_events, skill_usage, autolearn_events) with 10 indexes
- **Collection script** (`scripts/collect-pr-metrics.sh`): Queries GitHub API for merged PRs, push counts, CI pass rates across all DevKit-managed repos
- **New `/metrics` skill**: dashboard, collect, rework-report, trend workflows
- **ADR-0017**: Documents architecture decision (SQLite + GitHub API + Synapset tiers)

### Key Metrics Enabled

| Metric | What It Measures |
|--------|-----------------|
| Rework Rate | Fix-push cycles per PR |
| CI First-Pass Rate | % of PRs where first CI run passes |
| Pattern Application | When a KG/AP entry prevents a mistake (Phase 2) |
| Skill Usage | Which skills invoked, how often (Phase 2) |
| Conformance Score | 19-point checklist trending (Phase 3) |

Closes #334

## Test plan

- [x] markdownlint: 0 errors (9 files)
- [x] SQL schema: 5 tables, 10 indexes
- [x] SKILL.md routing: all 4 workflow files exist
- [x] README/CLAUDE.md skill count updated (21 -> 22)
- [ ] CI passes (skill count validation, routing validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)