### PR TITLE
feat(autolearn): sync batch-ingested entries to Synapset

### DIFF
--- a/claude/skills/autolearn/workflows/quick-reflect.md
+++ b/claude/skills/autolearn/workflows/quick-reflect.md
@@ -77,6 +77,16 @@ store_memory(pool: "devkit", text: "<description of the learning>",
 
 Use pool `devkit` for cross-project learnings. Use the project name as pool for project-specific learnings. If Synapset tools are not available, skip -- MCP Memory is sufficient.
 
+**Batch ingest sync:** When adding entries to Tier 2 rules files (AP/KG) during this session -- whether from session learnings or issue ingestion -- also store each new entry in Synapset:
+
+```text
+store_memory(pool: "devkit", content: "<full entry text including title, context, and fix>",
+  category: "<pattern|gotcha|correction>", source: "<project>",
+  tags: "<entry_id>,<category>", summary: "<entry title>")
+```
+
+This ensures the Synapset corpus stays in sync with rules files. Without this step, batch-ingested entries are invisible to semantic search.
+
 ### 6. Scope Assessment and Rules Update
 
 Determine where this session is running to decide how to handle rules:

--- a/claude/skills/autolearn/workflows/session-review.md
+++ b/claude/skills/autolearn/workflows/session-review.md
@@ -112,6 +112,16 @@ store_memory(pool: "devkit", text: "<description>",
 
 Use pool `devkit` for cross-project learnings. Use project name as pool for project-specific. If Synapset unavailable, skip -- MCP Memory is sufficient.
 
+**Batch ingest sync:** When adding entries to Tier 2 rules files (AP/KG) during this session -- whether from session learnings or issue ingestion -- also store each new entry in Synapset:
+
+```text
+store_memory(pool: "devkit", content: "<full entry text including title, context, and fix>",
+  category: "<pattern|gotcha|correction>", source: "<project>",
+  tags: "<entry_id>,<category>", summary: "<entry title>")
+```
+
+This ensures the Synapset corpus stays in sync with rules files. Without this step, batch-ingested entries are invisible to semantic search.
+
 ### 6. Create Relations
 
 Link learnings to their context:

--- a/claude/skills/rules-compact/SKILL.md
+++ b/claude/skills/rules-compact/SKILL.md
@@ -63,6 +63,8 @@ For each stale entry:
 1. Copy the full entry text to `claude/rules/archive/<filename>`
 2. Add under a dated header: `## Archived YYYY-MM-DD: Rules compaction`
 3. Remove the entry from the active file
+4. If Synapset MCP is available, store the archived entry for long-tail search:
+   `store_memory(pool: "devkit", content: "<archived entry>", category: "general", tags: "archived,<entry_id>", summary: "<title> (archived)")`
 
 ## Step 4: Deduplicate
 


### PR DESCRIPTION
## Summary

- Add Synapset `store_memory` calls to autolearn workflows (quick-reflect + session-review) for entries added to rules files during ingestion
- Add Synapset archival step to rules-compact workflow (step 3.4)
- Closes coverage gap: batch-ingested entries now sync to Synapset for semantic search

Closes #333

## Test plan

- [x] markdownlint: 0 errors
- [x] Workflow step numbering intact
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)