### PR TITLE
feat(metrics): conformance score persistence and autolearn velocity

### DIFF
--- a/claude/skills/autolearn/workflows/session-review.md
+++ b/claude/skills/autolearn/workflows/session-review.md
@@ -133,6 +133,19 @@ write_query(database: "claude.db", query: "CREATE TABLE IF NOT EXISTS pattern_ev
 
 If SQLite MCP is unavailable, skip -- pattern recording is best-effort.
 
+### 5c. Record Autolearn Velocity
+
+For each learning stored in this session, record its lifecycle stage using SQLite MCP. This tracks the pipeline: discovered -> issue_created -> ingested -> applied.
+
+```text
+write_query(database: "claude.db", query: "CREATE TABLE IF NOT EXISTS autolearn_events (id INTEGER PRIMARY KEY AUTOINCREMENT, event_type TEXT NOT NULL, entry_id TEXT, source_project TEXT, event_date TEXT NOT NULL, issue_number INTEGER, description TEXT); INSERT INTO autolearn_events (event_type, entry_id, source_project, event_date, description) VALUES ('<discovered|issue_created|ingested|applied>', '<AP#N or KG#N>', '<project>', datetime('now'), '<brief note>');"
+)
+```
+
+Event types: `discovered` (new pattern found), `issue_created` (DevKit issue filed), `ingested` (added to rules files), `applied` (pattern used to prevent/catch an issue).
+
+If SQLite MCP is unavailable, skip -- velocity tracking is best-effort.
+
 ### 6. Create Relations
 
 Link learnings to their context:

--- a/claude/skills/conformance-audit/workflows/full-audit.md
+++ b/claude/skills/conformance-audit/workflows/full-audit.md
@@ -179,6 +179,16 @@ For each project:
 - Score = pass / (pass + fail) as a percentage
 - Round to the nearest whole number
 
+### 6b. Persist Scores
+
+If SQLite MCP tools are available, record each project's score:
+
+```text
+write_query(database: "claude.db", query: "CREATE TABLE IF NOT EXISTS conformance_scores (id INTEGER PRIMARY KEY AUTOINCREMENT, repo TEXT NOT NULL, audit_date TEXT NOT NULL, total_checks INTEGER, passed INTEGER, failed INTEGER, skipped INTEGER, score_pct REAL, details TEXT); INSERT INTO conformance_scores (repo, audit_date, total_checks, passed, failed, skipped, score_pct) VALUES ('<repo>', datetime('now'), <total>, <passed>, <failed>, <skipped>, <score_pct>);")
+```
+
+If SQLite MCP is unavailable, skip -- score persistence is best-effort.
+
 ### 7. Identify Cross-Project Patterns
 
 After all projects are audited, identify checks that fail across multiple projects:

--- a/claude/skills/conformance-audit/workflows/single-project.md
+++ b/claude/skills/conformance-audit/workflows/single-project.md
@@ -328,3 +328,13 @@ Manual: 18
 
 Run `/conformance-audit fix` to auto-fix applicable gaps.
 ```
+
+### 8. Persist Score
+
+If SQLite MCP tools (`write_query`) are available, record the conformance score for trend tracking:
+
+```text
+write_query(database: "claude.db", query: "CREATE TABLE IF NOT EXISTS conformance_scores (id INTEGER PRIMARY KEY AUTOINCREMENT, repo TEXT NOT NULL, audit_date TEXT NOT NULL, total_checks INTEGER, passed INTEGER, failed INTEGER, skipped INTEGER, score_pct REAL, details TEXT); INSERT INTO conformance_scores (repo, audit_date, total_checks, passed, failed, skipped, score_pct) VALUES ('<repo>', datetime('now'), <total>, <passed>, <failed>, <skipped>, <score_pct>);")
+```
+
+If SQLite MCP is unavailable, skip -- score persistence is best-effort.


### PR DESCRIPTION
## Summary

Phase 3 of DevKit effectiveness measurement.

- **Conformance audit**: Add score persistence to SQLite after single-project (step 8) and full-audit (step 6b) workflows
- **Autolearn velocity**: Add lifecycle event recording (step 5c) to session-review workflow tracking discovered -> issue_created -> ingested -> applied pipeline

All recording is best-effort with SQLite MCP -- silent skip when unavailable.

Closes #336

## Test plan

- [x] markdownlint: 0 errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)