### PR TITLE
fix: collect-pr-metrics.sh Python fallback for MSYS

### DIFF
--- a/scripts/collect-pr-metrics.sh
+++ b/scripts/collect-pr-metrics.sh
@@ -23,7 +23,18 @@ done
 
 # Ensure database and schema exist
 mkdir -p "$(dirname "$DB")"
-sqlite3 "$DB" < "$SCRIPT_DIR/metrics-init.sql" 2>/dev/null || true
+# Try sqlite3 first, fall back to Python for MSYS/Windows compatibility
+if command -v sqlite3 >/dev/null 2>&1; then
+    sqlite3 "$DB" < "$SCRIPT_DIR/metrics-init.sql" 2>/dev/null || true
+else
+    python3 -c "
+import sqlite3
+conn = sqlite3.connect('$DB')
+with open('$SCRIPT_DIR/metrics-init.sql') as f:
+    conn.executescript(f.read())
+conn.close()
+" 2>/dev/null || true
+fi
 
 # Discover repos or use specified one
 if [[ -n "$TARGET_REPO" ]]; then


### PR DESCRIPTION
## Summary

Add Python sqlite3 fallback for schema initialization when `sqlite3` CLI is unavailable (MSYS/Windows). Discovered during baseline metrics collection.

## Test plan

- [x] Verified: script runs successfully with Python fallback on MSYS
- [x] 428 PRs collected across 10 repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)