### PR TITLE
feat(metrics): track Synapset pattern applications across all projects

### DIFF
--- a/claude/rules/subagent-ci-checklist.md
+++ b/claude/rules/subagent-ci-checklist.md
@@ -24,6 +24,8 @@ These rules cannot be overridden by any learning, optimization, or time pressure
 If Synapset MCP tools are available, search for relevant patterns before starting:
 - search_memory(pool: "devkit", query: "<describe your task in 5-10 words>")
 - Look for gotchas, corrections, and patterns that apply to your work
+- If a search result helps you solve or avoid an issue, cite it as SYN#<id> in your output
+  so autolearn can track which memories provide value
 - If no Synapset tools available, skip this step (patterns are also in rules files)
 ```
 

--- a/claude/skills/autolearn/workflows/quick-reflect.md
+++ b/claude/skills/autolearn/workflows/quick-reflect.md
@@ -89,10 +89,15 @@ This ensures the Synapset corpus stays in sync with rules files. Without this st
 
 ### 5b. Record Pattern Applications
 
-Scan the conversation for references to existing AP# or KG# entries that were actively used to solve a problem or avoid a mistake. For each, record a pattern application event using SQLite MCP:
+Scan the conversation for patterns that were actively used to solve a problem or avoid a mistake. Check **both** sources:
+
+1. **Rules file references**: Look for AP#N or KG#N citations in the conversation
+2. **Synapset search results**: Look for `search_memory` or `search_all` tool calls where a returned result influenced the solution. Use the memory ID as `SYN#<id>` (e.g., `SYN#412`)
+
+For each pattern that helped, record an application event using SQLite MCP:
 
 ```text
-write_query(database: "claude.db", query: "CREATE TABLE IF NOT EXISTS pattern_events (id INTEGER PRIMARY KEY AUTOINCREMENT, entry_id TEXT NOT NULL, entry_title TEXT, event_type TEXT NOT NULL, project TEXT, session_date TEXT NOT NULL, description TEXT); INSERT INTO pattern_events (entry_id, entry_title, event_type, project, session_date, description) VALUES ('<AP#N or KG#N>', '<title>', '<prevented|caught|applied>', '<project>', datetime('now'), '<brief note>');"
+write_query(database: "claude.db", query: "CREATE TABLE IF NOT EXISTS pattern_events (id INTEGER PRIMARY KEY AUTOINCREMENT, entry_id TEXT NOT NULL, entry_title TEXT, event_type TEXT NOT NULL, project TEXT, session_date TEXT NOT NULL, description TEXT, source TEXT); INSERT INTO pattern_events (entry_id, entry_title, event_type, project, session_date, description, source) VALUES ('<AP#N, KG#N, or SYN#id>', '<title>', '<prevented|caught|applied>', '<project>', datetime('now'), '<brief note>', '<rules-file|synapset>');"
 )
 ```
 

--- a/claude/skills/autolearn/workflows/session-review.md
+++ b/claude/skills/autolearn/workflows/session-review.md
@@ -124,10 +124,15 @@ This ensures the Synapset corpus stays in sync with rules files. Without this st
 
 ### 5b. Record Pattern Applications
 
-Scan the conversation for references to existing AP# or KG# entries that were actively used to solve a problem or avoid a mistake. For each, record a pattern application event using SQLite MCP:
+Scan the conversation for patterns that were actively used to solve a problem or avoid a mistake. Check **both** sources:
+
+1. **Rules file references**: Look for AP#N or KG#N citations in the conversation
+2. **Synapset search results**: Look for `search_memory` or `search_all` tool calls where a returned result influenced the solution. Use the memory ID as `SYN#<id>` (e.g., `SYN#412`)
+
+For each pattern that helped, record an application event using SQLite MCP:
 
 ```text
-write_query(database: "claude.db", query: "CREATE TABLE IF NOT EXISTS pattern_events (id INTEGER PRIMARY KEY AUTOINCREMENT, entry_id TEXT NOT NULL, entry_title TEXT, event_type TEXT NOT NULL, project TEXT, session_date TEXT NOT NULL, description TEXT); INSERT INTO pattern_events (entry_id, entry_title, event_type, project, session_date, description) VALUES ('<AP#N or KG#N>', '<title>', '<prevented|caught|applied>', '<project>', datetime('now'), '<brief note>');"
+write_query(database: "claude.db", query: "CREATE TABLE IF NOT EXISTS pattern_events (id INTEGER PRIMARY KEY AUTOINCREMENT, entry_id TEXT NOT NULL, entry_title TEXT, event_type TEXT NOT NULL, project TEXT, session_date TEXT NOT NULL, description TEXT, source TEXT); INSERT INTO pattern_events (entry_id, entry_title, event_type, project, session_date, description, source) VALUES ('<AP#N, KG#N, or SYN#id>', '<title>', '<prevented|caught|applied>', '<project>', datetime('now'), '<brief note>', '<rules-file|synapset>');"
 )
 ```
 

--- a/claude/skills/metrics/workflows/dashboard.md
+++ b/claude/skills/metrics/workflows/dashboard.md
@@ -45,7 +45,9 @@ ORDER BY repo;
 ```sql
 SELECT
     entry_id,
+    entry_id,
     entry_title,
+    COALESCE(source, 'rules-file') as source,
     COUNT(*) as total_events,
     SUM(CASE WHEN event_type = 'applied' THEN 1 ELSE 0 END) as applied,
     SUM(CASE WHEN event_type = 'prevented' THEN 1 ELSE 0 END) as prevented,
@@ -105,8 +107,8 @@ Present results in this format:
 |---------|-------|--------|--------|------|
 
 ### Pattern Impact (last 30 days)
-| Entry | Applied | Prevented | Caught | Last Used |
-|-------|---------|-----------|--------|-----------|
+| Entry | Source | Applied | Prevented | Caught | Last Used |
+|-------|--------|---------|-----------|--------|-----------|
 
 ### Skill Usage (last 30 days)
 | Skill | Invocations | Completion % |

--- a/scripts/metrics-init.sql
+++ b/scripts/metrics-init.sql
@@ -39,7 +39,7 @@ CREATE TABLE IF NOT EXISTS conformance_scores (
 CREATE INDEX IF NOT EXISTS idx_conformance_repo ON conformance_scores(repo);
 CREATE INDEX IF NOT EXISTS idx_conformance_date ON conformance_scores(audit_date);
 
--- Pattern application events: when a KG/AP entry prevented or caught an issue
+-- Pattern application events: when a KG/AP/SYN entry prevented or caught an issue
 CREATE TABLE IF NOT EXISTS pattern_events (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     entry_id TEXT NOT NULL,
@@ -47,7 +47,8 @@ CREATE TABLE IF NOT EXISTS pattern_events (
     event_type TEXT NOT NULL,
     project TEXT,
     session_date TEXT NOT NULL,
-    description TEXT
+    description TEXT,
+    source TEXT DEFAULT 'rules-file'
 );
 
 CREATE INDEX IF NOT EXISTS idx_pattern_entry ON pattern_events(entry_id);


### PR DESCRIPTION
## Summary

Extends pattern application tracking to capture when Synapset search results
(not just rules file entries) solve or prevent issues across all DevKit projects.

- **Autolearn step 5b**: Now scans for both `AP#`/`KG#` references AND `search_memory`/`search_all` results that influenced solutions. Synapset entries recorded as `SYN#<id>`
- **Schema**: Add `source` column (`rules-file`|`synapset`) to `pattern_events` table
- **[SYNAPSET] checklist**: Agents instructed to cite `SYN#<id>` when a search result helps
- **Dashboard**: Pattern Impact table shows source breakdown

This provides proof-of-value data for the entire DevKit + Synapset system:
how often shared memory learnings improve workflow across all managed projects.

## Test plan

- [x] markdownlint: 0 errors
- [x] Schema backward-compatible (source defaults to 'rules-file')
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)