### PR TITLE
fix(docs): correct pattern counts and skill list drift

### DIFF
--- a/.samverk/status.md
+++ b/.samverk/status.md
@@ -15,7 +15,7 @@ Active maintenance and execution. AI tooling methodology, Claude Code configurat
 ## What Is Running
 
 - Symlinked rules loaded by all Claude Code sessions via ~/.claude/
-- 22 skills, 7 agents, 11 rules files, 128 active patterns (AP: 67, KG: 61)
+- 22 skills, 7 agents, 11 rules files, 130 active patterns (AP: 67, KG: 63)
 - SessionStart hook for context injection
 - Credentials migrated to PowerShell SecretStore vault (HomeLabVault)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ bash setup/legacy/verify.sh
 devkit/
 ├── claude/              - Claude Code config (rules, skills, agents, hooks)
 │   ├── CLAUDE.md        - Global instructions (installed to ~/.claude/)
-│   ├── rules/           - Auto-loaded pattern files (11 files, 150 patterns)
+│   ├── rules/           - Auto-loaded pattern files (11 files, 130 patterns)
 │   ├── skills/          - Invokable skills (22 skills with workflow files)
 │   ├── agents/          - Agent templates (7 agents)
 │   └── hooks/           - SessionStart hook

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See [Settings Strategy](docs/settings-strategy.md) for the two-layer permission 
 
 | Directory | Purpose |
 |-----------|---------|
-| `claude/` | Global Claude Code config — CLAUDE.md, 11 rules files (150 patterns), 22 skills, 7 agent templates, hooks |
+| `claude/` | Global Claude Code config — CLAUDE.md, 11 rules files (130 patterns), 22 skills, 7 agent templates, hooks |
 | `devspace/` | Workspace shared configs — .editorconfig, .markdownlint.json, VS Code fragments |
 | `docs/` | Human-readable guides — architecture decisions, profile format spec |
 | `machine/` | Machine state snapshots — VS Code extensions, tool versions |
@@ -232,11 +232,11 @@ With symlinks active, changes flow automatically:
 | File | Entries | Purpose |
 |------|---------|---------|
 | `agent-team-coordination.md` | - | Multi-agent team coordination rules and anti-patterns |
-| `autolearn-patterns.md` | 75 | Learned patterns: lint fixes, CI config, architecture, testing |
+| `autolearn-patterns.md` | 67 | Learned patterns: lint fixes, CI config, architecture, testing |
 | `compaction-recovery.md` | - | Context compaction recovery rules and loop detection |
 | `core-principles.md` | 10 | Immutable core principles (Tier 0) |
 | `error-policy.md` | - | Zero-tolerance error policy and fix-forward workflow (Tier 1) |
-| `known-gotchas.md` | 95 | Platform issues: Windows, GitHub, Go, React, Docker |
+| `known-gotchas.md` | 63 | Platform issues: Windows, GitHub, Go, React, Docker |
 | `markdown-style.md` | - | Markdownlint conventions |
 | `review-policy.md` | - | Independent review policy: mandatory triggers and scope |
 | `subagent-ci-checklist.md` | - | Pre-commit CI validation checklists |

--- a/setup/legacy/verify.sh
+++ b/setup/legacy/verify.sh
@@ -52,7 +52,7 @@ done
 
 echo ""
 echo "Verifying individual skills..."
-for skill in autolearn bash-linux code-review conformance-audit devkit-sync docker-containerization go-development manage-github-issues plan-review powershell-windows quality-control react-frontend-development requirements-generator rules-compact security-review server-management setup-github-actions skill-audit systematic-debugging webapp-testing windows-development; do
+for skill in autolearn bash-linux code-review conformance-audit devkit-sync docker-containerization go-development manage-github-issues metrics plan-review powershell-windows quality-control react-frontend-development requirements-generator rules-compact security-review server-management setup-github-actions skill-audit systematic-debugging webapp-testing windows-development; do
     check "$CLAUDE_HOME/skills/$skill/SKILL.md" "$skill skill"
 done
 


### PR DESCRIPTION
## Summary

- README.md: Fix stale pattern counts (AP: 75->67, KG: 95->63, total: 150->130)
- CLAUDE.md: Fix total pattern count (150->130)
- .samverk/status.md: Fix pattern breakdown (128 AP:67 KG:61 -> 130 AP:67 KG:63)
- setup/legacy/verify.sh: Add missing `metrics` skill to verification list

## Root cause

Rules compaction in PR #331 reduced entry counts significantly (KG from 90 to 60, AP from 77 to 67) but documentation was not updated. The `metrics` skill was added in PR #338 but not added to the legacy verify script.

## Test plan

- [x] All counts verified against actual `grep -c` of entry headings
- [x] markdownlint passes on all 3 modified .md files (0 errors)
- [x] Consistency check: README, CLAUDE.md, and status.md all agree on 130 total (AP:67 + KG:63)

🤖 Generated with [Claude Code](https://claude.com/claude-code)