### PR TITLE
fix(docs): correct pattern counts and status drift

### DIFF
--- a/.samverk/status.md
+++ b/.samverk/status.md
@@ -1,6 +1,6 @@
 ---
 phase: execution
-updated: 2026-03-15T23:00:00Z
+updated: 2026-03-17T12:00:00Z
 updated_by: claude-code
 managed_by: samverk
 ---
@@ -15,7 +15,7 @@ Active maintenance and execution. AI tooling methodology, Claude Code configurat
 ## What Is Running
 
 - Symlinked rules loaded by all Claude Code sessions via ~/.claude/
-- 22 skills, 7 agents, 11 rules files, 130 active patterns (AP: 67, KG: 63)
+- 23 skills, 7 agents, 11 rules files, 133 active patterns (AP: 67, KG: 66)
 - SessionStart hook for context injection
 - Credentials migrated to PowerShell SecretStore vault (HomeLabVault)
 
@@ -25,16 +25,19 @@ Active maintenance and execution. AI tooling methodology, Claude Code configurat
 
 ## Queued
 
-- Sync batch-ingested entries to Synapset pool (#333) -- closes coverage gap found during deep migration evaluation
+(none)
 
 ## Recently Completed
 
-- **v2.4.0 release** -- autonomous autolearn routing (PR #322)
+- Cross-client Claude configuration guide (PR #358)
+- KG#135 fix: OAuth not required for Custom Connectors (PR #357)
+- Synapset skill with structured retrieval guide (PR #356)
+- Autolearn ingests: trivy cleanup, Gitea merge API, Ollama gotchas, SQLite PRAGMA (PRs #347-#355)
+- Metrics: HTML dashboard, Synapset tracking, weekly GH Action, conformance persistence (PRs #338-#352)
+- Synapset batch-ingest sync (PR #339) -- closes #333
+- Rules compaction: KG 44k->35k, AP 38k->35k (PR #331)
 - Autolearn batch ingest: 15 issues -> 14 KG + 3 AP + 1 WP entries (PR #329)
-- Rules compaction: KG 44k->35k (90->60), AP 38k->35k (77->67) (PR #331)
-- Synapset deep migration evaluated: full migration not viable, dual-store is the target architecture
-- Synapset integration verified working (3 pools, dual-store operational)
-- v2.3.0: Synapset backend, MCP research, cross-ref verification
+- **v2.4.0 release** -- autonomous autolearn routing (PR #322)
 
 ## Related Projects
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ bash setup/legacy/verify.sh
 devkit/
 ├── claude/              - Claude Code config (rules, skills, agents, hooks)
 │   ├── CLAUDE.md        - Global instructions (installed to ~/.claude/)
-│   ├── rules/           - Auto-loaded pattern files (11 files, 130 patterns)
+│   ├── rules/           - Auto-loaded pattern files (11 files, 133 patterns)
 │   ├── skills/          - Invokable skills (23 skills with workflow files)
 │   ├── agents/          - Agent templates (7 agents)
 │   └── hooks/           - SessionStart hook

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See [Settings Strategy](docs/settings-strategy.md) for the two-layer permission 
 
 | Directory | Purpose |
 |-----------|---------|
-| `claude/` | Global Claude Code config — CLAUDE.md, 11 rules files (130 patterns), 23 skills, 7 agent templates, hooks |
+| `claude/` | Global Claude Code config — CLAUDE.md, 11 rules files (133 patterns), 23 skills, 7 agent templates, hooks |
 | `devspace/` | Workspace shared configs — .editorconfig, .markdownlint.json, VS Code fragments |
 | `docs/` | Human-readable guides — architecture decisions, profile format spec |
 | `machine/` | Machine state snapshots — VS Code extensions, tool versions |


### PR DESCRIPTION
## Summary

- Audit found status.md, README.md, and CLAUDE.md with stale pattern counts (130->133) and skill counts (22->23)
- Removed #333 from queued (merged in PR #339)
- Updated recently completed section with PRs #338-#358

## Audit Details

| Claim | Was | Actual | Fixed |
|-------|-----|--------|-------|
| Pattern count | 130 (AP:67, KG:63) | 133 (AP:67, KG:66) | Yes |
| Skill count (status.md) | 22 | 23 | Yes |
| #333 queued | Listed | Merged (PR #339) | Removed |
| Recently completed | Stopped at PR #331 | Through PR #358 | Updated |

## Test plan

- [ ] Verify counts match: `ls -d claude/skills/*/SKILL.md | wc -l` = 23
- [ ] Verify KG count: `grep -c "^## [0-9]" claude/rules/known-gotchas.md` = 66

🤖 Generated with [Claude Code](https://claude.com/claude-code)