### PR TITLE
feat(hooks): add SessionStop hook for session-end hygiene

### DIFF
--- a/.sync-manifest.json
+++ b/.sync-manifest.json
@@ -32,7 +32,8 @@
         "claude/agents/vscode-translation-manager.md"
       ],
       "hooks": [
-        "claude/hooks/SessionStart.sh"
+        "claude/hooks/SessionStart.sh",
+        "claude/hooks/SessionStop.sh"
       ],
       "reference": [
         "profiles/",

--- a/claude/hooks/SessionStop.sh
+++ b/claude/hooks/SessionStop.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SessionStop Hook
+# Fires when Claude Code session ends.
+# 1. Warns about uncommitted changes
+# 2. Reminds about /autolearn
+set -euo pipefail
+
+# --- Uncommitted changes check (best-effort, silent outside git repos) ---
+uncommitted=$(git status --porcelain 2>/dev/null) || true
+if [ -n "$uncommitted" ]; then
+    echo "[SessionStop] WARNING: Uncommitted changes detected:"
+    echo "$uncommitted"
+fi
+
+# --- Autolearn reminder ---
+echo "[SessionStop] Reminder: Run /autolearn if this session produced notable learnings."
+
+# --- Session event recording (best-effort, silent on failure) ---
+_devkit_record_stop() {
+    local project db
+    project="$(basename "$PWD")"
+    db="$HOME/databases/claude.db"
+    [ -f "$db" ] || return 0
+    command -v sqlite3 >/dev/null 2>&1 || return 0
+    sqlite3 "$db" "CREATE TABLE IF NOT EXISTS session_events (id INTEGER PRIMARY KEY AUTOINCREMENT, project TEXT, event_type TEXT, event_date TEXT); INSERT INTO session_events (project, event_type, event_date) VALUES ('$project', 'stop', datetime('now'));" 2>/dev/null || true
+}
+_devkit_record_stop
+
+exit 0

--- a/claude/settings.template.json
+++ b/claude/settings.template.json
@@ -27,6 +27,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/SessionStop.sh"
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {


### PR DESCRIPTION
## Summary

- New `claude/hooks/SessionStop.sh`: warns about uncommitted changes at session end, reminds about `/autolearn`
- Registered in `settings.template.json` (Stop hook) and `.sync-manifest.json`

Closes #360

## Test plan

- [ ] `bash -n claude/hooks/SessionStop.sh` passes
- [ ] `python -c "import json; json.load(open('claude/settings.template.json'))"` passes
- [ ] `python -c "import json; json.load(open('.sync-manifest.json'))"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)