### PR TITLE
feat(hooks): add pre-commit and commit-msg git hook templates

### DIFF
--- a/git-templates/hooks/commit-msg
+++ b/git-templates/hooks/commit-msg
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Commit-msg hook: validates conventional commit format.
+# Install: git config core.hooksPath git-templates/hooks
+set -euo pipefail
+
+MSG_FILE="$1"
+
+# Strip comments and leading/trailing blank lines
+SUBJECT=$(sed '/^#/d' "$MSG_FILE" | sed '/^$/d' | head -n 1)
+
+if [ -z "$SUBJECT" ]; then
+  echo "[commit-msg] ERROR: Commit message is empty."
+  exit 1
+fi
+
+# Allow merge, revert, fixup, and squash commits without validation
+if echo "$SUBJECT" | grep -qE '^Merge '; then
+  exit 0
+fi
+if echo "$SUBJECT" | grep -qE '^Revert '; then
+  exit 0
+fi
+if echo "$SUBJECT" | grep -qE '^(fixup|squash)! '; then
+  exit 0
+fi
+
+# Validate conventional commit format
+if ! echo "$SUBJECT" | grep -qE '^(feat|fix|refactor|docs|test|chore|ci|perf|build|style|revert)(\(.+\))?(!)?: .+'; then
+  echo "[commit-msg] ERROR: Commit message does not follow conventional commit format."
+  echo ""
+  echo "  Expected: <type>(<scope>): <description>"
+  echo ""
+  echo "  Types: feat, fix, refactor, docs, test, chore, ci, perf, build, style, revert"
+  echo ""
+  echo "  Examples:"
+  echo "    feat: add user authentication"
+  echo "    fix(auth): resolve token refresh issue"
+  echo "    chore!: drop support for Node 14"
+  echo "    docs(readme): update installation instructions"
+  echo ""
+  echo "  Your message: $SUBJECT"
+  exit 1
+fi

--- a/git-templates/hooks/pre-commit
+++ b/git-templates/hooks/pre-commit
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Pre-commit hook: lightweight checks on every commit.
+# Complements the pre-push hook which runs full CI checks.
+# Install: git config core.hooksPath git-templates/hooks
+set -euo pipefail
+
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+if [ -z "$STAGED_FILES" ]; then
+  exit 0
+fi
+
+# --- Secret pattern scan ---
+SECRET_PATTERNS=(
+  'AKIA[A-Z0-9]{16}'
+  '-----BEGIN.*PRIVATE KEY-----'
+  'sk-[a-zA-Z0-9]{20,}'
+  'ghp_[a-zA-Z0-9]{36}'
+  'glpat-[a-zA-Z0-9\-]{20,}'
+)
+
+FOUND_SECRETS=0
+
+for file in $STAGED_FILES; do
+  # Skip binary files
+  if git diff --cached --numstat "$file" | grep -q '^-'; then
+    continue
+  fi
+
+  for pattern in "${SECRET_PATTERNS[@]}"; do
+    if git diff --cached "$file" | grep -Eq "$pattern"; then
+      if [ "$FOUND_SECRETS" -eq 0 ]; then
+        echo "[pre-commit] ERROR: Potential secret detected in staged files:"
+      fi
+      echo "  $file  (pattern: $pattern)"
+      FOUND_SECRETS=1
+    fi
+  done
+done
+
+if [ "$FOUND_SECRETS" -ne 0 ]; then
+  echo ""
+  echo "If this is a false positive, use: git commit --no-verify"
+  exit 1
+fi
+
+# --- File size guard (10MB = 10485760 bytes) ---
+MAX_SIZE=10485760
+
+for file in $STAGED_FILES; do
+  # Use git cat-file to check size of the staged blob
+  FILE_SIZE=$(git cat-file -s "$(git ls-files -s "$file" | awk '{print $2}')" 2>/dev/null || echo 0)
+  if [ "$FILE_SIZE" -gt "$MAX_SIZE" ]; then
+    echo "[pre-commit] ERROR: File exceeds 10MB limit:"
+    echo "  $file  ($(( FILE_SIZE / 1048576 ))MB)"
+    exit 1
+  fi
+done
+
+echo "[pre-commit] checks passed"


### PR DESCRIPTION
## Summary

- New `git-templates/hooks/pre-commit`: secret pattern scan (AWS, GitHub, GitLab, OpenAI keys) + file size guard (>10MB)
- New `git-templates/hooks/commit-msg`: conventional commit format validation with merge/revert/fixup allowlist

Closes #361

## Test plan

- [ ] `bash -n git-templates/hooks/pre-commit` passes
- [ ] `bash -n git-templates/hooks/commit-msg` passes
- [ ] Valid conventional commits accepted (`feat:`, `fix(scope):`, `Merge branch`)
- [ ] Invalid messages rejected (`bad message`, `Add feature`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)