### PR TITLE
docs: update counts and status for hook expansion

### DIFF
--- a/.samverk/status.md
+++ b/.samverk/status.md
@@ -1,6 +1,6 @@
 ---
 phase: execution
-updated: 2026-03-17T12:00:00Z
+updated: 2026-03-17T06:00:00Z
 updated_by: claude-code
 managed_by: samverk
 ---
@@ -16,7 +16,7 @@ Active maintenance and execution. AI tooling methodology, Claude Code configurat
 
 - Symlinked rules loaded by all Claude Code sessions via ~/.claude/
 - 23 skills, 7 agents, 11 rules files, 133 active patterns (AP: 67, KG: 66)
-- SessionStart hook for context injection
+- 3 Claude Code hooks (SessionStart, SessionStop, SubagentVerify) + 3 git hooks (pre-push, pre-commit, commit-msg)
 - Credentials migrated to PowerShell SecretStore vault (HomeLabVault)
 
 ## In Flight
@@ -29,6 +29,7 @@ Active maintenance and execution. AI tooling methodology, Claude Code configurat
 
 ## Recently Completed
 
+- **Hook expansion Phase 1-2**: SessionStop, SubagentVerify, commit/push reminder, pre-commit, commit-msg (PRs #365-#369)
 - Cross-client Claude configuration guide (PR #358)
 - KG#135 fix: OAuth not required for Custom Connectors (PR #357)
 - Synapset skill with structured retrieval guide (PR #356)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Setup creates symlinks from `~/.claude/` to the DevKit clone (or copies files in
 | Rules (auto-loaded every session) | 11 files | `claude/rules/` |
 | Skills (invoke with `/skill-name`) | 23 skills | `claude/skills/` |
 | Agent templates | 7 agents | `claude/agents/` |
-| SessionStart hook | 1 | `claude/hooks/` |
+| Claude Code hooks (SessionStart, SessionStop, SubagentVerify) | 3 | `claude/hooks/` |
+| Git hooks (pre-push, pre-commit, commit-msg) | 3 | `git-templates/hooks/` |
 | Setup scripts (PowerShell + legacy bash) | 7+3 | `setup/` + `setup/legacy/` |
 
 ### Templates (customize per user/machine)
@@ -61,7 +62,7 @@ See [Settings Strategy](docs/settings-strategy.md) for the two-layer permission 
 
 | Directory | Purpose |
 |-----------|---------|
-| `claude/` | Global Claude Code config — CLAUDE.md, 11 rules files (133 patterns), 23 skills, 7 agent templates, hooks |
+| `claude/` | Global Claude Code config — CLAUDE.md, 11 rules files (133 patterns), 23 skills, 7 agent templates, 3 hooks |
 | `devspace/` | Workspace shared configs — .editorconfig, .markdownlint.json, VS Code fragments |
 | `docs/` | Human-readable guides — architecture decisions, profile format spec |
 | `machine/` | Machine state snapshots — VS Code extensions, tool versions |


### PR DESCRIPTION
## Summary

- README: hook count updated from 1 SessionStart to 3 Claude Code hooks + 3 git hooks
- status.md: hook expansion PRs #365-#369 added to recently completed

Closes #364

## Test plan

- [ ] `npx markdownlint-cli2 README.md .samverk/status.md` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)