### PR TITLE
docs: ingest autolearn issues #367 and #371

### DIFF
--- a/.samverk/status.md
+++ b/.samverk/status.md
@@ -15,7 +15,7 @@ Active maintenance and execution. AI tooling methodology, Claude Code configurat
 ## What Is Running
 
 - Symlinked rules loaded by all Claude Code sessions via ~/.claude/
-- 23 skills, 7 agents, 11 rules files, 133 active patterns (AP: 67, KG: 66)
+- 23 skills, 7 agents, 11 rules files, 136 active patterns (AP: 67, KG: 69)
 - 3 Claude Code hooks (SessionStart, SessionStop, SubagentVerify) + 3 git hooks (pre-push, pre-commit, commit-msg)
 - Credentials migrated to PowerShell SecretStore vault (HomeLabVault)
 

--- a/claude/rules/autolearn-patterns.md
+++ b/claude/rules/autolearn-patterns.md
@@ -653,7 +653,7 @@ MUI Popper needs `anchorEl` during render. `useRef` + `ref.current` triggers Rea
 **Category:** workflow-pattern
 **Context:** Using `isolation: "worktree"` in Agent tool calls gives each parallel agent a fully isolated git copy. No shared working tree conflicts (solves KG#25). Each agent commits to its own branch in its own worktree.
 **Fix:** Use `isolation: "worktree"` for parallel code-gen agents. Merge via API after all complete. Proven: 3 waves x 2 agents = 7 total agents, all CI-clean first pass. Supersedes stash/pop workflow from AP#48 for new work.
-**See also:** KG#25 (parallel agents share working tree), AP#48 (legacy stash/pop approach)
+**See also:** KG#25 (parallel agents share working tree), KG#149 (worktree branch collision), AP#48 (legacy stash/pop approach)
 
 ## 128. Safe Deploy Pattern with Idle-Wait Gate for Background Workers
 

--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -1,8 +1,8 @@
 ---
 description: Known gotchas and platform-specific issues. Read when debugging unexpected behavior.
 tier: 2
-entry_count: 66
-last_updated: "2026-03-16"
+entry_count: 69
+last_updated: "2026-03-17"
 ---
 
 # Known Gotchas
@@ -699,3 +699,29 @@ Windows CRLF (`\r\n`) causes silent failures across multiple tools. Three known 
 **Platform:** Gitea Actions / act_runner (host mode)
 **Issue:** `security.yml` downloads trivy (155MB) to `/tmp` per run, never cleans up. On host-mode act_runners, 15+ runs accumulates 2.3GB of stale binaries. Disk full causes `actions/checkout@v4` to fail silently in 0 seconds.
 **Fix:** Add `if: always()` cleanup step to remove trivy temp files after each run. For host-mode runners, consider a cron job to sweep `/tmp/trivy*` periodically.
+
+## 149. Worktree Isolation Agents Can Commit to Wrong Branch
+
+**Added:** 2026-03-17 | **Source:** DevKit | **Status:** active
+
+**Platform:** Claude Code (all)
+**Issue:** Parallel agents with `isolation: "worktree"` can commit to the wrong branch. Both agents' commits end up on one branch while the other branch has no unique commits. Root cause likely related to worktree sharing the same remote origin.
+**Fix:** Verify branch assignments after parallel worktree agents complete. Recovery: cherry-pick each commit onto fresh branches from main, then create PRs from the fixed branches.
+**See also:** KG#25 (parallel agents share working tree), AP#127 (worktree isolation pattern)
+
+## 150. Go MCP SDK Rejects Non-Localhost Host Headers Behind Reverse Proxy
+
+**Added:** 2026-03-17 | **Source:** Samverk | **Status:** active
+
+**Platform:** Go (mcp-go SDK) / Cloudflare Tunnel
+**Issue:** Go MCP SDK `StreamableHTTPHandler` rejects requests with non-localhost `Host` headers, returning 403 "Forbidden: invalid Host header". Reverse proxies (Cloudflare Tunnel, nginx) forward the original hostname, triggering the rejection.
+**Fix:** Add `httpHostHeader: localhost:PORT` to cloudflared ingress config. For other proxies, rewrite the Host header to `localhost:PORT` before forwarding.
+**Debugging tip:** Cloudflare Security Analytics "Mitigation: Not mitigated" immediately shows the block is from the origin server, not Cloudflare edge. Check this FIRST before investigating WAF rules.
+
+## 151. Cloudflare Free Plan WAF Managed Ruleset Cannot Be Disabled
+
+**Added:** 2026-03-17 | **Source:** Samverk | **Status:** active
+
+**Platform:** Cloudflare (Free plan)
+**Issue:** Cloudflare Free plan has an "Always active" managed WAF ruleset that cannot be disabled or skipped. WAF skip rules only affect user-deployed managed rules, not the built-in ones.
+**Fix:** No workaround for disabling built-in rules. If built-in rules block legitimate traffic, use a different ingress method or upgrade to a paid plan with full WAF rule control.


### PR DESCRIPTION
## Summary

- Add KG#149: Worktree isolation agents can commit to wrong branch (extends KG#25, AP#127)
- Add KG#150: Go MCP SDK rejects non-localhost Host headers behind reverse proxy
- Add KG#151: Cloudflare Free WAF managed ruleset cannot be disabled on Free plan
- Update AP#127 with cross-reference to KG#149
- Update pattern counts: 136 active (AP: 67, KG: 69)

Closes #367, Closes #371

## Test plan

- [x] markdownlint passes on all changed files (0 errors)
- [ ] CI lint workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)