### PR TITLE
feat: archive recovery workflow and Synapset conformance check

### DIFF
--- a/claude/skills/conformance-audit/SKILL.md
+++ b/claude/skills/conformance-audit/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: conformance-audit
-description: Cross-project conformance auditing against DevKit standards (19-point checklist). Full audits, single-project checks, and auto-fix of common gaps.
+description: Cross-project conformance auditing against DevKit standards (20-point checklist). Full audits, single-project checks, and auto-fix of common gaps.
 user_invocable: true
 ---
 
 # Conformance Audit
 
-Cross-project conformance auditing against DevKit standards. Run a 17-point checklist across all projects, audit a single project, or auto-fix common gaps.
+Cross-project conformance auditing against DevKit standards. Run a 20-point checklist across all projects, audit a single project, or auto-fix common gaps.
 
 <essential_principles>
 
-**The 19-point checklist is the single source of truth for conformance.** All audit workflows reference `references/checklist.md` for check definitions, pass criteria, and fix references. Do not invent checks outside this list.
+**The 20-point checklist is the single source of truth for conformance.** All audit workflows reference `references/checklist.md` for check definitions, pass criteria, and fix references. Do not invent checks outside this list.
 
 **Stack detection determines which checks apply.** Go projects need `.golangci.yml`, Rust needs clippy in CI, Node needs `eslint.config.js`, etc. Checks that do not apply to the detected stack are reported as "skip", not "fail".
 

--- a/claude/skills/conformance-audit/references/checklist.md
+++ b/claude/skills/conformance-audit/references/checklist.md
@@ -182,6 +182,15 @@ A project may match multiple stacks (e.g., Go backend + Node frontend). Apply ch
 - **Fail indicators**: README entry counts diverge from frontmatter `entry_count`; verify.sh lists fewer skills than `claude/skills/` contains; verify.ps1 missing tools referenced in CLAUDE.md
 - **Fix reference**: AP#121 (structured 10-dimension audit prompt); run from main context with Explore subagent
 
+### 20. Synapset Archive Sync (Informational)
+
+- **What to check**: Active rules entries (AP/KG) have corresponding Synapset memories for semantic search discovery
+- **Stacks**: DevKit only (skip for non-DevKit projects)
+- **Pass criteria**: Sample 5 active entries from each rules file, query Synapset by entry ID tag (`query_memory(pool: "devkit", tags: "KG#N")`). At least 80% should return a match
+- **Fail indicators**: Multiple active entries missing from Synapset corpus
+- **Fix reference**: Run `/rules-compact` batch-ingest sync, or manually `store_memory` for missing entries
+- **Note**: This check is **informational only** (does not affect score). Skip entirely if Synapset MCP tools are unavailable
+
 ## Scoring
 
 - **Pass**: Check criteria met

--- a/claude/skills/rules-compact/SKILL.md
+++ b/claude/skills/rules-compact/SKILL.md
@@ -143,6 +143,15 @@ After archiving or consolidating, cross-references between AP and KG files may p
 
 Report any fixes made. This step prevents cross-reference drift (see MCP Memory entity `cross-reference-drift-after-compaction`).
 
+## Step 9: Recover archived entry (on-demand)
+
+If someone needs to view or restore an archived entry:
+
+1. Query Synapset by entry ID tag: `query_memory(pool: "devkit", tags: "<entry_id>")`
+2. If found, display the full archived text
+3. To restore: copy the entry back to the active rules file, remove the archive tombstone, update frontmatter counts
+4. If Synapset is unavailable, recover from git history: `git log -p --all -S "<entry title>" -- claude/rules/<filename>`
+
 </workflow>
 
 <success_criteria>


### PR DESCRIPTION
## Summary

- Add Step 9 to `/rules-compact`: recover archived entries from Synapset by entry ID tag, with git history fallback
- Add Check #20 to conformance audit: Synapset archive sync (informational only, does not affect score)
- Update conformance checklist count from 19 to 20

Closes #374, Closes #375

## Test plan

- [x] markdownlint passes on all changed files (0 errors)
- [ ] CI lint workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)