### PR TITLE
docs: sync counts and status for v2.5.0

### DIFF
--- a/.samverk/status.md
+++ b/.samverk/status.md
@@ -29,16 +29,11 @@ Active maintenance and execution. AI tooling methodology, Claude Code configurat
 
 ## Recently Completed
 
-- **Synapset-backed compaction**: Compacted KG 38k->30k, 15 entries archived to Synapset with tombstones
+- **v2.5.0 release** (2026-03-17): Synapset-backed compaction, conformance check #20, archive recovery, hook expansion
+- **Synapset-backed compaction**: New archive architecture -- tombstone + Synapset ID (PRs #372-#380)
+- Legacy archive backfill: 51 entries stored in Synapset (SYN#515-565), archives converted to tombstone format
+- Release-please permissions fix: enabled PR creation, synced manifest to v2.4.0 (PR #382)
 - **Hook expansion Phase 1-2**: SessionStop, SubagentVerify, commit/push reminder, pre-commit, commit-msg (PRs #365-#369)
-- Cross-client Claude configuration guide (PR #358)
-- KG#135 fix: OAuth not required for Custom Connectors (PR #357)
-- Synapset skill with structured retrieval guide (PR #356)
-- Autolearn ingests: trivy cleanup, Gitea merge API, Ollama gotchas, SQLite PRAGMA (PRs #347-#355)
-- Metrics: HTML dashboard, Synapset tracking, weekly GH Action, conformance persistence (PRs #338-#352)
-- Synapset batch-ingest sync (PR #339) -- closes #333
-- Rules compaction: KG 44k->35k, AP 38k->35k (PR #331)
-- Autolearn batch ingest: 15 issues -> 14 KG + 3 AP + 1 WP entries (PR #329)
 - **v2.4.0 release** -- autonomous autolearn routing (PR #322)
 
 ## Related Projects

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ bash setup/legacy/verify.sh
 devkit/
 ├── claude/              - Claude Code config (rules, skills, agents, hooks)
 │   ├── CLAUDE.md        - Global instructions (installed to ~/.claude/)
-│   ├── rules/           - Auto-loaded pattern files (11 files, 133 patterns)
+│   ├── rules/           - Auto-loaded pattern files (11 files, 121 patterns)
 │   ├── skills/          - Invokable skills (23 skills with workflow files)
 │   ├── agents/          - Agent templates (7 agents)
 │   └── hooks/           - SessionStart hook

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See [Settings Strategy](docs/settings-strategy.md) for the two-layer permission 
 
 | Directory | Purpose |
 |-----------|---------|
-| `claude/` | Global Claude Code config — CLAUDE.md, 11 rules files (133 patterns), 23 skills, 7 agent templates, 3 hooks |
+| `claude/` | Global Claude Code config — CLAUDE.md, 11 rules files (121 patterns), 23 skills, 7 agent templates, 6 hooks |
 | `devspace/` | Workspace shared configs — .editorconfig, .markdownlint.json, VS Code fragments |
 | `docs/` | Human-readable guides — architecture decisions, profile format spec |
 | `machine/` | Machine state snapshots — VS Code extensions, tool versions |
@@ -237,7 +237,7 @@ With symlinks active, changes flow automatically:
 | `compaction-recovery.md` | - | Context compaction recovery rules and loop detection |
 | `core-principles.md` | 10 | Immutable core principles (Tier 0) |
 | `error-policy.md` | - | Zero-tolerance error policy and fix-forward workflow (Tier 1) |
-| `known-gotchas.md` | 63 | Platform issues: Windows, GitHub, Go, React, Docker |
+| `known-gotchas.md` | 54 | Platform issues: Windows, GitHub, Go, React, Docker |
 | `markdown-style.md` | - | Markdownlint conventions |
 | `review-policy.md` | - | Independent review policy: mandatory triggers and scope |
 | `subagent-ci-checklist.md` | - | Pre-commit CI validation checklists |
@@ -269,7 +269,7 @@ Claude.ai Chat uses a separate skill store - install via Settings > Skills in th
 | code-review | Independent code review gate before commits | Code |
 | plan-review | Independent plan review gate before implementation | Code |
 | devkit-sync | Multi-machine DevKit sync: status, push, pull, init, diff, verify, promote, update | Code |
-| conformance-audit | 19-point project conformance checklist against DevKit standards | Code |
+| conformance-audit | 20-point project conformance checklist against DevKit standards | Code |
 | rules-compact | Compact oversized rules files: archive stale, deduplicate, consolidate | Code |
 | skill-audit | Audit skill quality: wait states, routing, references, frontmatter, rules metadata | Code |
 

--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -1,7 +1,7 @@
 ---
 description: Known gotchas and platform-specific issues. Read when debugging unexpected behavior.
 tier: 2
-entry_count: 55
+entry_count: 54
 last_updated: "2026-03-17"
 ---
 


### PR DESCRIPTION
## Summary

Fix documentation drift discovered by roadmap-vs-reality audit:
- README: KG 63->54, conformance 19->20 points, patterns 133->121, hooks 3->6
- CLAUDE.md: patterns 133->121
- status.md: v2.5.0 release, trimmed old entries
- known-gotchas.md: frontmatter 55->54 (actual count)

## Test plan

- [x] markdownlint passes (0 errors)
- [ ] CI lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)