### PR TITLE
docs: ingest autolearn issues #385, #386, #387

### DIFF
--- a/claude/rules/autolearn-patterns.md
+++ b/claude/rules/autolearn-patterns.md
@@ -1,8 +1,8 @@
 ---
 description: Learned patterns from past sessions. Read when encountering similar situations.
 tier: 2
-entry_count: 67
-last_updated: "2026-03-15"
+entry_count: 68
+last_updated: "2026-03-17"
 ---
 
 # Learned Patterns
@@ -678,3 +678,12 @@ MUI Popper needs `anchorEl` during render. `useRef` + `ref.current` triggers Rea
 **Category:** workflow-pattern
 **Context:** Automated issue processing via agent dispatcher needs routing and failure handling.
 **Fix:** Label issues `status:queued` for overnight processing. Route short issues to triage/haiku. Mark hung issues `status:needs-human` to stop retries.
+
+## 131. Merge Interface-Changing PRs First to Avoid Cascading Conflicts
+
+**Added:** 2026-03-17 | **Source:** Synapset | **Status:** active
+
+**Category:** workflow-pattern
+**Context:** Parallel PRs modifying a shared Go interface (e.g., Provider with Embed/EmbedBatch/Ping) create cascading conflicts in mock implementations across test files. Automated keep-both-sides scripts cannot resolve these correctly.
+**Fix:** Merge the interface-changing PR first, then rebase dependent PRs onto updated main. When conflicts arise on already-pushed PRs, spawn a fresh worktree agent to rebuild the change on current main -- faster and more reliable than manual conflict resolution.
+**See also:** AP#127 (worktree isolation), KG#149 (worktree branch collision), AP#82 (rebase conflict resolution)

--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -1,7 +1,7 @@
 ---
 description: Known gotchas and platform-specific issues. Read when debugging unexpected behavior.
 tier: 2
-entry_count: 54
+entry_count: 56
 last_updated: "2026-03-17"
 ---
 
@@ -596,3 +596,20 @@ Windows CRLF (`\r\n`) causes silent failures across multiple tools. Three known 
 **Platform:** Claude Code (all)
 **Issue:** Background agents launched via the Agent tool (including `run_in_background: true`) cannot use MCP tools like `store_memory`. Tool permissions granted in the parent context are not inherited by subagents. The subagent gets "denied" on every MCP tool call.
 **Fix:** Perform all MCP operations from the main context before or after delegating file-based work to the subagent. Do not rely on subagents for MCP-dependent tasks.
+
+## 153. Cherry-Pick Conflict Resolution Truncates Functions at Marker Boundaries
+
+**Added:** 2026-03-17 | **Source:** Synapset | **Status:** active
+
+**Platform:** Git (all)
+**Issue:** Automated cherry-pick/rebase conflict resolution scripts that "keep both sides" can break code when the `=======` marker falls inside a function body. Naive marker removal produces functions missing closing `}` and `)`.
+**Fix:** Always compile-check after automated conflict resolution. Better approach: use a fresh worktree agent to rebuild changes cleanly on current main instead of manual conflict resolution.
+
+## 154. Gitea actcache Grows Unbounded and Fills Disk
+
+**Added:** 2026-03-17 | **Source:** Synapset | **Status:** active
+
+**Platform:** Gitea Actions / act_runner (host mode)
+**Issue:** Gitea Actions runner actcache at `/home/git/.cache/actcache/cache` grows ~650MB per CI run with no automatic eviction. Combined with trivy temp files and Go build cache, disk fills completely. Gitea returns "database or disk is full" on merge API calls.
+**Fix:** Periodic cleanup via cron: `find /home/git/.cache/actcache/cache -maxdepth 1 -mtime +7 -exec rm -rf {} +`. Also clean `/tmp/tmp.*` and Go build cache.
+**See also:** KG#148 (archived, trivy binary accumulation -- same root cause)


### PR DESCRIPTION
## Summary

- KG#153: Cherry-pick conflict resolution truncates functions at marker boundaries
- KG#154: Gitea actcache grows unbounded, fills disk (extends archived KG#148)
- AP#131: Merge interface-changing PRs first to avoid cascading conflicts

Closes #385, Closes #386, Closes #387

## Test plan

- [x] markdownlint passes (0 errors)
- [x] KG at 34,403 bytes (under 35k target)
- [ ] CI lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)