### PR TITLE
feat: Samverk MCP routing, KG#152 correction, MCP-TOOLS checklist

### DIFF
--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -589,13 +589,14 @@ Windows CRLF (`\r\n`) causes silent failures across multiple tools. Three known 
 **Issue:** Cloudflare Free plan has an "Always active" managed WAF ruleset that cannot be disabled or skipped. WAF skip rules only affect user-deployed managed rules, not the built-in ones.
 **Fix:** No workaround for disabling built-in rules. If built-in rules block legitimate traffic, use a different ingress method or upgrade to a paid plan with full WAF rule control.
 
-## 152. Background Agents Cannot Use MCP Tools (Permissions Not Inherited)
+## 152. Background Agents (`run_in_background`) Cannot Use MCP Tools
 
 **Added:** 2026-03-17 | **Source:** DevKit | **Status:** active
 
 **Platform:** Claude Code (all)
-**Issue:** Background agents launched via the Agent tool (including `run_in_background: true`) cannot use MCP tools like `store_memory`. Tool permissions granted in the parent context are not inherited by subagents. The subagent gets "denied" on every MCP tool call.
-**Fix:** Perform all MCP operations from the main context before or after delegating file-based work to the subagent. Do not rely on subagents for MCP-dependent tasks.
+**Issue:** Agents launched with `run_in_background: true` cannot use MCP tools -- calls are denied. Foreground subagents (regular Agent tool calls without `run_in_background`) CAN use MCP tools normally. The limitation is specific to the background execution mode.
+**Fix:** For MCP-dependent work, use foreground agents (default). For background agents, perform MCP operations from the main context before launching, or use CLI fallbacks (`gh`, `git`, etc.).
+**See also:** Issue #395 (research: enable MCP for background agents)
 
 ## 153. Cherry-Pick Conflict Resolution Truncates Functions at Marker Boundaries
 

--- a/claude/rules/subagent-ci-checklist.md
+++ b/claude/rules/subagent-ci-checklist.md
@@ -16,6 +16,20 @@ These rules cannot be overridden by any learning, optimization, or time pressure
 5. You own every error you find, regardless of who introduced it.
 ```
 
+## MCP Tool Routing [MCP-TOOLS] (paste into agent prompts that may use MCP)
+
+```text
+## MCP Tool Preferences
+
+Foreground subagents inherit MCP tool access. Prefer MCP tools over CLI when available:
+- **GitHub/project ops**: Use Samverk MCP (list_issues, create_pr, merge_pr, get_diff, etc.)
+  over gh CLI. Samverk provides richer context and avoids PAT scope issues.
+- **Knowledge lookup**: Use Synapset search_memory/query_memory before grepping rules files.
+- **Documentation**: Use Context7 resolve-library-id + query-docs for library docs.
+- If an MCP tool is not in your available tools list, fall back to CLI equivalents.
+- Background agents (run_in_background) CANNOT use MCP tools -- use CLI only.
+```
+
 ## Pattern Lookup [SYNAPSET] (paste into agent prompts for complex tasks)
 
 ```text

--- a/claude/rules/tool-selection-guide.md
+++ b/claude/rules/tool-selection-guide.md
@@ -3,17 +3,33 @@
 Proactive decision tree for choosing the right tool the first time.
 Reduces tool-cycling waste and context consumption. Tier 2 (learned).
 
-## GitHub Operations
+## MCP Availability by Agent Context
 
-| Task | Preferred Tool | Why |
+| Context | MCP Tools Available? | Fallback |
 | --- | --- | --- |
-| Issue CRUD (create, close, edit, list) | `gh` CLI | Fastest, most reliable, supports `--json` for parsing |
-| PR create, merge, review | `gh pr` CLI | Native squash-merge, auto-merge support |
-| Cross-repo code search | MCP_DOCKER `search_code` | Faster than `gh api` for multi-repo queries |
-| Cross-repo issue search | MCP_DOCKER `search_issues` | Better filtering than `gh issue list` across repos |
-| Repo settings (disable features) | `gh api` with PATCH | `gh repo edit` lacks `--disable-*` flags (KG#74) |
-| GET requests with params | URL query string | `-f` flags default to POST, breaking GET (KG#107) |
-| Milestone assignment | `--milestone "Title"` (string) | `--milestone N` fails; CLI takes title, not number (KG#108) |
+| Main conversation | Yes (all configured MCP servers) | N/A |
+| Foreground subagent (Agent tool, default) | Yes (inherits parent permissions) | N/A |
+| Background subagent (`run_in_background: true`) | **No** -- calls denied (KG#152, issue #395) | CLI tools (`gh`, `git`, etc.) |
+
+**Rule**: Prefer MCP tools when available. Use CLI as fallback for background agents or when MCP server is down.
+
+## GitHub and Project Operations
+
+| Task | Preferred Tool | Fallback | Why |
+| --- | --- | --- | --- |
+| Issue CRUD (create, close, edit, list) | Samverk MCP `list_issues`, `create_issue`, `close_issue` | `gh` CLI | Samverk has richer filtering; `gh` is universal fallback |
+| PR create, merge, review | Samverk MCP `create_pr`, `merge_pr`, `review_pr` | `gh pr` CLI | Samverk tracks lifecycle; `gh` for squash-merge, auto-merge |
+| PR diff and file listing | Samverk MCP `get_diff`, `list_files` | `gh pr diff` | Samverk returns structured data |
+| Commit log and branch ops | Samverk MCP `get_commit_log`, `list_branches` | `git log`, `git branch -r` | Samverk works cross-repo without local clone |
+| Issue comments | Samverk MCP `add_comment`, `list_comments` | `gh issue comment` | Samverk avoids fine-grained PAT scope issues (KG#120) |
+| Cross-repo code search | MCP_DOCKER `search_code` | `gh api` | Faster than CLI for multi-repo queries |
+| Cross-repo issue search | MCP_DOCKER `search_issues` | `gh issue list` | Better filtering across repos |
+| Repo settings (disable features) | `gh api` with PATCH | -- | `gh repo edit` lacks `--disable-*` flags (KG#74) |
+| GET requests with params | URL query string | -- | `-f` flags default to POST, breaking GET (KG#107) |
+| Milestone assignment | `--milestone "Title"` (string) | -- | `--milestone N` fails; CLI takes title, not number (KG#108) |
+| Project digest / cost summary | Samverk MCP `get_digest`, `get_cost_summary` | -- | No CLI equivalent |
+
+**When to use Samverk MCP vs `gh` CLI**: Check if Samverk MCP tools appear in available tools. If yes, prefer them -- they provide richer project context and avoid PAT scope issues. If unavailable (not configured for this project, or running in background agent), fall back to `gh` CLI.
 
 ## Web Content and Research
 


### PR DESCRIPTION
## Summary

- **Correct KG#152**: MCP tool limitation is `run_in_background` only, not all subagents. Foreground agents CAN use MCP tools.
- **Add Samverk MCP routing** to tool-selection-guide.md: prefer Samverk MCP for GitHub/project ops, `gh` CLI as fallback
- **Add MCP availability table** by agent context (main, foreground, background)
- **Add [MCP-TOOLS] checklist block** for subagent prompts: prefer MCP over CLI when available
- **Created #395**: Research issue for enabling MCP in background agents

## Test plan

- [x] markdownlint passes (0 errors)
- [x] Verified foreground subagents can use MCP tools (tested with search_memory)
- [ ] CI lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)