### PR TITLE
docs: autolearn session -- CHANGELOG exclusion + metadata validator gotcha

### DIFF
--- a/claude/rules/autolearn-patterns.md
+++ b/claude/rules/autolearn-patterns.md
@@ -1,7 +1,7 @@
 ---
 description: Learned patterns from past sessions. Read when encountering similar situations.
 tier: 2
-entry_count: 68
+entry_count: 69
 last_updated: "2026-03-17"
 ---
 
@@ -687,3 +687,11 @@ MUI Popper needs `anchorEl` during render. `useRef` + `ref.current` triggers Rea
 **Context:** Parallel PRs modifying a shared Go interface (e.g., Provider with Embed/EmbedBatch/Ping) create cascading conflicts in mock implementations across test files. Automated keep-both-sides scripts cannot resolve these correctly.
 **Fix:** Merge the interface-changing PR first, then rebase dependent PRs onto updated main. When conflicts arise on already-pushed PRs, spawn a fresh worktree agent to rebuild the change on current main -- faster and more reliable than manual conflict resolution.
 **See also:** AP#127 (worktree isolation), KG#149 (worktree branch collision), AP#82 (rebase conflict resolution)
+
+## 132. Exclude Release-Please CHANGELOG From Markdownlint
+
+**Added:** 2026-03-17 | **Source:** DevKit | **Status:** active
+
+**Category:** ci-config
+**Context:** Release-please generates CHANGELOG.md with asterisk list markers (`*`) and double blank lines. These violate MD004 and MD012 but cannot be fixed -- the file is regenerated on each release.
+**Fix:** Add `"CHANGELOG.md"` to the `ignores` array in `.markdownlint-cli2.jsonc`. Do not attempt `replace_all` on asterisk-space -- it corrupts bold markers (`**text:**`) inside list items.

--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -1,7 +1,7 @@
 ---
 description: Known gotchas and platform-specific issues. Read when debugging unexpected behavior.
 tier: 2
-entry_count: 57
+entry_count: 58
 last_updated: "2026-03-17"
 ---
 
@@ -623,3 +623,11 @@ Windows CRLF (`\r\n`) causes silent failures across multiple tools. Three known 
 **Platform:** Claude Code (all)
 **Issue:** stdio-based MCP servers (sqlite, memory, sequential-thinking, context7, ms365-onenote) hang indefinitely when they fail to initialize (wrong path, missing auth, process crash). Tool calls never return and the session must be manually cancelled. The "If unavailable, skip" instruction in workflows has no way to detect unavailability before attempting the call.
 **Fix:** Before calling any stdio MCP tool, verify it appears in the available tools list. If not listed, skip the call entirely. For workflows, add explicit pre-check instructions. HTTP-based MCP servers (Synapset) fail fast with connection errors instead of hanging.
+
+## 156. DevKit CI Metadata Validator Parses All Cross-References in Text
+
+**Added:** 2026-03-17 | **Source:** DevKit | **Status:** active
+
+**Platform:** DevKit CI (lint.yml)
+**Issue:** The metadata validator (`Validate rule metadata` job) scans all text for `KG#N` and `AP#N` patterns and checks for matching `## N.` entries in the target file. References in descriptive prose (e.g., "archived as KG#148") trigger validation failures if the entry was archived. Additionally, extra pipe-separated fields on `**Added:**` lines (e.g., `| **Researched:** 2026-03-17`) break status parsing because the validator expects exactly 3 fields: Added, Source, Status.
+**Fix:** When referencing archived entries, omit the `KG#`/`AP#` prefix (use descriptive text instead). Never add extra pipe fields to `**Added:**` lines.


### PR DESCRIPTION
## Summary

- **AP#132**: Exclude release-please CHANGELOG.md from markdownlint (asterisk markers are upstream-controlled, `replace_all` on them corrupts bold markers)
- **KG#156**: CI metadata validator parses all KG#N/AP#N patterns in text and validates cross-references; extra pipe fields in Added lines break status parsing

## Test plan

- [x] Markdown lint passes on both files
- [x] Entry counts updated in frontmatter (AP: 69, KG: 58)

🤖 Generated with [Claude Code](https://claude.com/claude-code)