### PR TITLE
feat: add samverk-checkout skill for MCP work protocol

### DIFF
--- a/.samverk/status.md
+++ b/.samverk/status.md
@@ -1,6 +1,6 @@
 ---
 phase: execution
-updated: 2026-03-17T06:00:00Z
+updated: 2026-03-17T16:45:00Z
 updated_by: claude-code
 managed_by: samverk
 ---
@@ -15,20 +15,24 @@ Active maintenance and execution. AI tooling methodology, Claude Code configurat
 ## What Is Running
 
 - Symlinked rules loaded by all Claude Code sessions via ~/.claude/
-- 23 skills, 7 agents, 11 rules files, 121 active patterns (AP: 67, KG: 54)
+- 24 skills, 7 agents, 11 rules files, 123 active patterns (AP: 68, KG: 55)
 - 3 Claude Code hooks (SessionStart, SessionStop, SubagentVerify) + 3 git hooks (pre-push, pre-commit, commit-msg)
 - Credentials migrated to PowerShell SecretStore vault (HomeLabVault)
 
 ## In Flight
 
-(none)
+None.
 
 ## Queued
 
-(none)
+- #400 (Samverk MCP checkout/checkin skill) -- priority:high, ready to build
+- #401 (autolearn: static prompts go stale) -- ready to work
+- #393 (create Gitea repo) -- blocked on Samverk #626
+- #394 (migration plan) -- blocked on #393 + Samverk #632
 
 ## Recently Completed
 
+- **v2.6.0 release** (2026-03-17): Samverk MCP routing, samverk-dispatch skill, errcheck/MCP hang fixes
 - **v2.5.0 release** (2026-03-17): Synapset-backed compaction, conformance check #20, archive recovery, hook expansion
 - **Synapset-backed compaction**: New archive architecture -- tombstone + Synapset ID (PRs #372-#380)
 - Legacy archive backfill: 51 entries stored in Synapset (SYN#515-565), archives converted to tombstone format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,8 @@ bash setup/legacy/verify.sh
 devkit/
 ├── claude/              - Claude Code config (rules, skills, agents, hooks)
 │   ├── CLAUDE.md        - Global instructions (installed to ~/.claude/)
-│   ├── rules/           - Auto-loaded pattern files (11 files, 121 patterns)
-│   ├── skills/          - Invokable skills (23 skills with workflow files)
+│   ├── rules/           - Auto-loaded pattern files (11 files, 123 patterns)
+│   ├── skills/          - Invokable skills (25 skills with workflow files)
 │   ├── agents/          - Agent templates (7 agents)
 │   └── hooks/           - SessionStart hook
 ├── devspace/            - Workspace shared configs (.editorconfig, VS Code)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Setup creates symlinks from `~/.claude/` to the DevKit clone (or copies files in
 | Component | Count | Location |
 |-----------|-------|----------|
 | Rules (auto-loaded every session) | 11 files | `claude/rules/` |
-| Skills (invoke with `/skill-name`) | 24 skills | `claude/skills/` |
+| Skills (invoke with `/skill-name`) | 25 skills | `claude/skills/` |
 | Agent templates | 7 agents | `claude/agents/` |
 | Claude Code hooks (SessionStart, SessionStop, SubagentVerify) | 3 | `claude/hooks/` |
 | Git hooks (pre-push, pre-commit, commit-msg) | 3 | `git-templates/hooks/` |
@@ -62,7 +62,7 @@ See [Settings Strategy](docs/settings-strategy.md) for the two-layer permission 
 
 | Directory | Purpose |
 |-----------|---------|
-| `claude/` | Global Claude Code config — CLAUDE.md, 11 rules files (121 patterns), 24 skills, 7 agent templates, 6 hooks |
+| `claude/` | Global Claude Code config — CLAUDE.md, 11 rules files (123 patterns), 25 skills, 7 agent templates, 6 hooks |
 | `devspace/` | Workspace shared configs — .editorconfig, .markdownlint.json, VS Code fragments |
 | `docs/` | Human-readable guides — architecture decisions, profile format spec |
 | `machine/` | Machine state snapshots — VS Code extensions, tool versions |
@@ -272,6 +272,8 @@ Claude.ai Chat uses a separate skill store - install via Settings > Skills in th
 | conformance-audit | 20-point project conformance checklist against DevKit standards | Code |
 | rules-compact | Compact oversized rules files: archive stale, deduplicate, consolidate | Code |
 | skill-audit | Audit skill quality: wait states, routing, references, frontmatter, rules metadata | Code |
+| samverk-dispatch | Dispatcher work protocol: claim issues, process queues, decompose work | Code |
+| samverk-checkout | MCP checkout/checkin protocol: claim, heartbeat, complete, release | Code |
 
 ### Agent Templates
 

--- a/claude/skills/samverk-checkout/SKILL.md
+++ b/claude/skills/samverk-checkout/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: samverk-checkout
+description: Samverk MCP work checkout/checkin protocol -- claim issues with worker_id tracking, heartbeat, complete, and release using the 5 coordination MCP tools.
+user_invocable: true
+---
+
+# Samverk Checkout
+
+Lightweight protocol layer for claiming and releasing Samverk-managed issues via MCP. Handles worker identity, heartbeat, resilience to server restarts, and batch processing. Use this when you need direct control over the checkout/checkin lifecycle without the full dispatch workflow.
+
+<essential_principles>
+
+**Samverk MCP is required.** This skill depends on Samverk MCP tools (`claim_issue`, `request_work`, `complete_issue`, `release_issue`, `heartbeat_issue`). If these tools are not in your available tools list, cancel immediately and inform the user.
+
+**Worker ID is session-scoped.** Generate a `worker_id` once at the start of the session and pass it explicitly to every MCP tool call. The format is `interactive:<hostname>` (e.g., `interactive:HERB-DESKTOP`). Never rely on the server default -- each call without a `worker_id` generates a new timestamp-based ID, which breaks ownership verification.
+
+**Claims are in-memory on the MCP server.** Claims do not survive server restarts. If any tool returns a "not claimed" error, re-claim the issue before retrying the operation.
+
+**Clean exit is mandatory.** If you cannot complete an issue, always call `release_issue` with a descriptive reason. Never leave a claim dangling.
+
+**Heartbeat periodically.** Call `heartbeat_issue` after every major step (exploration, implementation milestone, test run). Current server has no timeout enforcement, but this future-proofs the claim and provides activity tracking.
+
+</essential_principles>
+
+<intake>
+**samverk-checkout triggered.** What would you like to do?
+
+1. **Checkout** -- Claim a specific issue by number
+2. **Request Next** -- Get the highest-priority queued issue and claim it
+3. **Complete** -- Mark a claimed issue as done (with PR link)
+4. **Release** -- Return a claimed issue to the queue
+5. **Batch** -- Process multiple issues from the queue sequentially
+6. **Status** -- Check current claim status and send heartbeat
+
+Type a number, keyword, or **skip** to dismiss.
+
+> Note: This skill blocks on user input. If triggered unintentionally,
+> type **skip** or **dismiss** to cancel.
+</intake>
+
+<routing>
+| Response | Workflow |
+|----------|----------|
+| 1, "checkout", "claim", "claim #N", "check out", "pick up" | workflows/checkout.md |
+| 2, "request", "next", "request next", "request work", "queue" | workflows/request-next.md |
+| 3, "complete", "done", "finish", "close", "complete #N" | workflows/complete.md |
+| 4, "release", "abort", "return", "unclaim", "release #N" | workflows/release.md |
+| 5, "batch", "batch mode", "process queue", "work through" | workflows/batch.md |
+| 6, "status", "heartbeat", "check", "ping" | workflows/status.md |
+
+If the user types **skip** or **dismiss**, briefly confirm cancellation (e.g., "samverk-checkout cancelled.") and end the skill without running any workflow.
+
+If the input does not clearly match any option above and is not "skip" or "dismiss", respond:
+"samverk-checkout was triggered but your input didn't match a workflow. Options: 1-6 (listed above). Type **skip** to dismiss."
+
+**After reading the workflow, follow it exactly.**
+</routing>
+
+<tool_restrictions>
+
+Samverk MCP tools (required):
+
+- `claim_issue(number, worker_id?)` -- Claim a specific issue
+- `request_work(project?, labels?, priority?, complexity?, worker_id?)` -- Get next queued issue
+- `complete_issue(number, pr_number?, summary?, worker_id?)` -- Mark issue done
+- `release_issue(number, reason, worker_id?)` -- Return issue to queue
+- `heartbeat_issue(number, worker_id?)` -- Reset heartbeat timer
+- `get_issue(number)` -- Read issue details
+- `set_project(project)` -- Set active project context
+
+Other tools used:
+
+- Bash (git commands, hostname lookup)
+
+</tool_restrictions>
+
+<usage_recording>
+
+After selecting a workflow, record the invocation per `claude/shared/record-usage.md`.
+
+</usage_recording>

--- a/claude/skills/samverk-checkout/workflows/batch.md
+++ b/claude/skills/samverk-checkout/workflows/batch.md
@@ -1,0 +1,116 @@
+# Samverk Checkout: Batch Mode
+
+Process multiple issues from the queue sequentially. Claims one at a time, completes or releases each before claiming the next.
+
+## Prerequisites
+
+- Samverk MCP tools must be available
+- User should specify how many issues to process (default: 3)
+
+## Steps
+
+### 1. Generate worker ID
+
+```bash
+hostname
+```
+
+Set `WORKER_ID` to `interactive:<hostname>`. Use for ALL calls in this batch.
+
+### 2. Set project context
+
+Read `.samverk/project.yaml` to get the project name, then:
+
+```text
+set_project(project)
+```
+
+### 3. Confirm batch parameters
+
+Ask the user (or use defaults):
+
+- **Count** -- how many issues to process (default: 3, max: 10)
+- **Filters** -- optional label, priority, or complexity filters
+
+### 4. Process loop
+
+For each issue in the batch:
+
+#### 4a. Request next issue
+
+```text
+request_work(project: "<project>", worker_id: "<WORKER_ID>")
+```
+
+If no work available, report "Queue empty after N of M issues processed" and stop.
+
+#### 4b. Read and assess
+
+```text
+get_issue(number: <N>)
+```
+
+Display the issue title and labels. Assess whether it can be completed in this session.
+
+If the issue is too complex or blocked, release immediately:
+
+```text
+release_issue(number: <N>, reason: "Skipped in batch: <reason>", worker_id: "<WORKER_ID>")
+```
+
+Then continue to the next iteration (4a).
+
+#### 4c. Heartbeat
+
+```text
+heartbeat_issue(number: <N>, worker_id: "<WORKER_ID>")
+```
+
+#### 4d. Implement
+
+Follow the standard implementation workflow (explore, code, test, lint). Call `heartbeat_issue` after each major step.
+
+#### 4e. Push and create PR
+
+```bash
+git push -u origin feature/issue-N-description
+gh pr create --title "feat: <description>" --body "Closes #N"
+```
+
+#### 4f. Complete
+
+```text
+complete_issue(number: <N>, pr_number: <PR>, summary: "<summary>", worker_id: "<WORKER_ID>")
+```
+
+#### 4g. Report progress
+
+"Completed issue #N (M of total). Moving to next issue."
+
+### 5. Batch summary
+
+After all issues are processed (or the queue is empty), report:
+
+- Issues completed: list with PR numbers
+- Issues skipped/released: list with reasons
+- Issues remaining in queue (if known)
+
+## Error Recovery
+
+### "Not claimed" during batch
+
+Re-claim the current issue and retry. If re-claim fails, skip to the next issue:
+
+```text
+claim_issue(number: <N>, worker_id: "<WORKER_ID>")
+```
+
+### Implementation failure mid-batch
+
+Release the current issue with details of what was done, then continue to the next:
+
+```text
+release_issue(number: <N>, reason: "Failed during batch: <error details>", worker_id: "<WORKER_ID>")
+```
+
+Do not abort the entire batch for a single issue failure.

--- a/claude/skills/samverk-checkout/workflows/checkout.md
+++ b/claude/skills/samverk-checkout/workflows/checkout.md
@@ -1,0 +1,77 @@
+# Samverk Checkout: Claim Issue
+
+Claim a specific issue by number with proper worker identity tracking.
+
+## Prerequisites
+
+- Samverk MCP tools must be available
+- User must provide an issue number (or ask for one)
+
+## Steps
+
+### 1. Generate worker ID
+
+Determine the hostname for the worker ID:
+
+```bash
+hostname
+```
+
+Set `WORKER_ID` to `interactive:<hostname>` (e.g., `interactive:HERB-DESKTOP`). Use this value for ALL subsequent MCP calls in this session.
+
+### 2. Set project context
+
+Read `.samverk/project.yaml` to get the project name, then:
+
+```text
+set_project(project)
+```
+
+### 3. Claim the issue
+
+```text
+claim_issue(number: <N>, worker_id: "<WORKER_ID>")
+```
+
+**If claim succeeds:** Continue to step 4.
+
+**If claim fails (already claimed):** Report to user: "Issue #N is already claimed by another worker. Try a different issue or use **request next** to get the next available." Then stop.
+
+### 4. Read the issue
+
+```text
+get_issue(number: <N>)
+```
+
+Display a brief summary to the user:
+
+- Title and labels
+- Acceptance criteria (if present)
+- Referenced files or dependencies
+
+### 5. Heartbeat
+
+```text
+heartbeat_issue(number: <N>, worker_id: "<WORKER_ID>")
+```
+
+### 6. Report to user
+
+Confirm the checkout:
+
+"Issue #N claimed as `<WORKER_ID>`. Ready to work. Use `/samverk-checkout complete` when done, or `/samverk-checkout release` to return it to the queue."
+
+Remind the user to call `heartbeat_issue` periodically during long sessions (every 15 minutes or after major milestones).
+
+## Error Recovery
+
+### "Not claimed" on heartbeat after claim succeeded
+
+The MCP server may have restarted between claim and heartbeat. Re-claim:
+
+```text
+claim_issue(number: <N>, worker_id: "<WORKER_ID>")
+heartbeat_issue(number: <N>, worker_id: "<WORKER_ID>")
+```
+
+If re-claim also fails, report to user and stop.

--- a/claude/skills/samverk-checkout/workflows/complete.md
+++ b/claude/skills/samverk-checkout/workflows/complete.md
@@ -1,0 +1,52 @@
+# Samverk Checkout: Complete Issue
+
+Mark a claimed issue as done, transitioning it to `status:needs-qc`.
+
+## Prerequisites
+
+- Samverk MCP tools must be available
+- User must provide the issue number (or confirm the currently claimed issue)
+- A PR number is recommended but optional
+
+## Steps
+
+### 1. Determine worker ID
+
+Use the same `WORKER_ID` from the checkout step in this session (`interactive:<hostname>`). If the session started fresh (no prior checkout), generate it:
+
+```bash
+hostname
+```
+
+Set `WORKER_ID` to `interactive:<hostname>`.
+
+### 2. Gather completion details
+
+Ask the user (or infer from context) for:
+
+- **Issue number** (required)
+- **PR number** (optional -- pass if a PR was created)
+- **Summary** (optional -- 1-3 sentences describing what was done)
+
+### 3. Complete the issue
+
+```text
+complete_issue(number: <N>, pr_number: <PR>, summary: "<summary>", worker_id: "<WORKER_ID>")
+```
+
+**If success:** Continue to step 4.
+
+**If "not claimed" error:** The server may have restarted. Re-claim and retry:
+
+```text
+claim_issue(number: <N>, worker_id: "<WORKER_ID>")
+complete_issue(number: <N>, pr_number: <PR>, summary: "<summary>", worker_id: "<WORKER_ID>")
+```
+
+If re-claim fails (another worker claimed it), report to user and stop.
+
+### 4. Confirm to user
+
+"Issue #N marked complete. Status transitioned to `needs-qc`."
+
+If a PR was linked: "PR #P associated with the completion."

--- a/claude/skills/samverk-checkout/workflows/release.md
+++ b/claude/skills/samverk-checkout/workflows/release.md
@@ -1,0 +1,50 @@
+# Samverk Checkout: Release Issue
+
+Return a claimed issue to the queue so another worker can pick it up.
+
+## Prerequisites
+
+- Samverk MCP tools must be available
+- User must provide the issue number and a reason for releasing
+
+## Steps
+
+### 1. Determine worker ID
+
+Use the same `WORKER_ID` from the checkout step in this session (`interactive:<hostname>`). If the session started fresh, generate it:
+
+```bash
+hostname
+```
+
+Set `WORKER_ID` to `interactive:<hostname>`.
+
+### 2. Gather release details
+
+Ask the user (or infer from context) for:
+
+- **Issue number** (required)
+- **Reason** (required -- why the issue is being returned to the queue)
+
+Good reasons include:
+
+- "Blocked on dependency #M"
+- "Out of scope for current session"
+- "Needs human decision on architecture"
+- "Partial implementation on branch `feature/issue-N-desc` -- remaining: <what's left>"
+
+### 3. Release the issue
+
+```text
+release_issue(number: <N>, reason: "<reason>", worker_id: "<WORKER_ID>")
+```
+
+**If success:** Continue to step 4.
+
+**If "not claimed" error:** The claim was already lost (server restart or expiry). Report to user: "Issue #N was not claimed -- the server may have restarted. No action needed; the issue is already in the queue."
+
+### 4. Confirm to user
+
+"Issue #N released back to the queue. Reason: `<reason>`. Status transitioned to `queued`."
+
+If partial work exists on a branch, remind the user: "Partial work is on branch `<branch>`. The next worker will see the release reason in the issue comments."

--- a/claude/skills/samverk-checkout/workflows/request-next.md
+++ b/claude/skills/samverk-checkout/workflows/request-next.md
@@ -1,0 +1,67 @@
+# Samverk Checkout: Request Next
+
+Request the highest-priority queued issue from the dispatcher and auto-claim it.
+
+## Prerequisites
+
+- Samverk MCP tools must be available
+
+## Steps
+
+### 1. Generate worker ID
+
+Determine the hostname for the worker ID:
+
+```bash
+hostname
+```
+
+Set `WORKER_ID` to `interactive:<hostname>` (e.g., `interactive:HERB-DESKTOP`). Use this value for ALL subsequent MCP calls in this session.
+
+### 2. Set project context
+
+Read `.samverk/project.yaml` to get the project name, then:
+
+```text
+set_project(project)
+```
+
+### 3. Request work
+
+```text
+request_work(project: "<project>", worker_id: "<WORKER_ID>")
+```
+
+Optional filters (use if the user specified preferences):
+
+- `labels` -- filter by label (e.g., `"agent:code-gen"`)
+- `priority` -- filter by priority label (e.g., `"priority:high"`)
+- `complexity` -- filter by complexity label
+
+**If work is returned:** The issue is auto-claimed. Continue to step 4.
+
+**If no work available:** Report to user: "No queued issues match the criteria. The queue may be empty or all issues are claimed." Then stop.
+
+### 4. Read the issue
+
+```text
+get_issue(number: <returned_number>)
+```
+
+Display a brief summary:
+
+- Issue number, title, and labels
+- Acceptance criteria (if present)
+- Priority and complexity indicators
+
+### 5. Heartbeat
+
+```text
+heartbeat_issue(number: <N>, worker_id: "<WORKER_ID>")
+```
+
+### 6. Report to user
+
+Confirm the checkout:
+
+"Claimed issue #N: `<title>`. Worker ID: `<WORKER_ID>`. Use `/samverk-checkout complete` when done, or `/samverk-checkout release` to return it to the queue."

--- a/claude/skills/samverk-checkout/workflows/status.md
+++ b/claude/skills/samverk-checkout/workflows/status.md
@@ -1,0 +1,50 @@
+# Samverk Checkout: Status
+
+Check the status of a claimed issue and send a heartbeat to keep the claim alive.
+
+## Prerequisites
+
+- Samverk MCP tools must be available
+- User must provide an issue number (or confirm the currently claimed issue)
+
+## Steps
+
+### 1. Determine worker ID
+
+Use the same `WORKER_ID` from the checkout step in this session (`interactive:<hostname>`). If the session started fresh, generate it:
+
+```bash
+hostname
+```
+
+Set `WORKER_ID` to `interactive:<hostname>`.
+
+### 2. Send heartbeat
+
+```text
+heartbeat_issue(number: <N>, worker_id: "<WORKER_ID>")
+```
+
+The response includes:
+
+- **Claim duration** -- how long the issue has been claimed
+- **Status** -- current claim status
+
+### 3. Read issue state
+
+```text
+get_issue(number: <N>)
+```
+
+Check current labels and status for any changes since checkout.
+
+### 4. Report to user
+
+Display:
+
+- Issue #N: `<title>`
+- Claim status: active / not claimed
+- Claim duration: `<duration>`
+- Current labels: `<labels>`
+
+**If "not claimed" error on heartbeat:** The claim was lost (server restart or another worker). Report: "Issue #N is not currently claimed by `<WORKER_ID>`. The server may have restarted. Use `/samverk-checkout checkout` to re-claim it."

--- a/setup/legacy/verify.sh
+++ b/setup/legacy/verify.sh
@@ -52,7 +52,7 @@ done
 
 echo ""
 echo "Verifying individual skills..."
-for skill in autolearn bash-linux code-review conformance-audit devkit-sync docker-containerization go-development manage-github-issues metrics plan-review powershell-windows quality-control react-frontend-development requirements-generator rules-compact security-review server-management setup-github-actions skill-audit systematic-debugging webapp-testing windows-development; do
+for skill in autolearn bash-linux code-review conformance-audit devkit-sync docker-containerization go-development manage-github-issues metrics plan-review powershell-windows quality-control react-frontend-development requirements-generator rules-compact samverk-checkout samverk-dispatch security-review server-management setup-github-actions skill-audit synapset systematic-debugging webapp-testing windows-development; do
     check "$CLAUDE_HOME/skills/$skill/SKILL.md" "$skill skill"
 done
 


### PR DESCRIPTION
## Summary

- New `samverk-checkout` skill with 6 workflows for the Samverk MCP checkout/checkin protocol
- Covers: checkout (claim by number), request-next (from queue), complete, release, batch processing, and status/heartbeat
- Handles worker_id session scoping, server restart resilience (re-claim on "not claimed"), and periodic heartbeat
- Updates skill counts in README (25), CLAUDE.md, and verify.sh (adds samverk-dispatch + synapset which were missing from PR #398)

Closes #400

## Test plan

- [ ] CI passes (markdownlint, skill routing validation, skill count check)
- [ ] All 6 workflow files referenced in SKILL.md routing table exist on disk
- [ ] verify.sh skill list matches actual claude/skills/ directories
- [ ] README skill count (25) matches directory count

🤖 Generated with [Claude Code](https://claude.com/claude-code)