### PR TITLE
docs(rules): ingest KG#167 -- markdownlint false positives on non-.md files

### DIFF
--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -1,7 +1,7 @@
 ---
 description: Known gotchas and platform-specific issues. Read when debugging unexpected behavior.
 tier: 2
-entry_count: 46
+entry_count: 47
 last_updated: "2026-03-18"
 ---
 
@@ -593,3 +593,11 @@ Diagnose manually: `ssh root@host 'lsof /usr/local/bin/<binary>'` then kill list
 ```
 
 Note: reference the binary directly (`$HOME/.local/bin/trivy`) in the install step since `$GITHUB_PATH` is not applied to PATH until the **next** step.
+
+## 167. markdownlint-cli2 False Positives on Non-.md Files
+
+**Added:** 2026-03-18 | **Source:** DevKit | **Status:** active
+
+**Platform:** markdownlint-cli2 (all)
+**Issue:** Running `npx markdownlint-cli2` with a glob that accidentally includes non-`.md` files (e.g. `.gitignore`, `.sh` scripts) produces false positives. `#` comment lines are parsed as H1 headings, triggering MD022 (no blank line around headings), MD025 (multiple H1), and MD032 (no blank line around lists).
+**Fix:** Always scope markdownlint globs to `**/*.md` only. CI lint job already does this correctly — the issue only appears in manual local runs where a non-md file is passed directly or included via a broad glob.


### PR DESCRIPTION
## Summary

- Add KG#167: markdownlint-cli2 produces false positives when run against non-`.md` files — `#` comment lines trigger MD022/MD025/MD032 as if they were H1 headings
- Update `entry_count` frontmatter: 46 → 47

**Source:** DevKit audit session 2026-03-18 — encountered when accidentally including `.gitignore` in a markdownlint glob during manual verification.

## Test plan

- [ ] CI markdown lint passes
- [ ] CI rule metadata validator passes (Added/Source/Status format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)