### PR TITLE
docs(rules): ingest AP#138-139, AP#127 ext, KG#168, KG#25 ext from issues #434-438 (#441)

### DIFF
--- a/claude/rules/autolearn-patterns.md
+++ b/claude/rules/autolearn-patterns.md
@@ -1,7 +1,7 @@
 ---
 description: Learned patterns from past sessions. Read when encountering similar situations.
 tier: 2
-entry_count: 66
+entry_count: 68
 last_updated: "2026-03-18"
 ---
 
@@ -645,6 +645,11 @@ MUI Popper needs `anchorEl` during render. `useRef` + `ref.current` triggers Rea
 **Context:** Parallel worktree agents both modifying the same file create merge conflicts if both branches merge independently.
 **Fix:** Merge the first branch to main via fast-forward, then rebase the second branch onto updated main before merging. Both merges stay fast-forward with zero conflicts.
 
+### Inter-wave rebase required after each wave merges (from issue #434)
+
+**Context:** Worktree agents branch from main at launch time. After Wave N merges, Wave N+1 branches are behind main and show as CONFLICTING on GitHub.
+**Fix:** After merging a wave, run `git rebase --onto origin/main <old-base> <branch>` for each next-wave branch. Find old-base with `git log --oneline <branch>` -- second commit is the fork point. Different agents may fork from different main commits -- verify per branch. Also: worktree branches often have unstaged `index.html` changes from embedded SPA builds -- run `git checkout -- path/to/index.html` before rebase.
+
 ## 132. Exclude Release-Please CHANGELOG From Markdownlint
 
 **Added:** 2026-03-17 | **Source:** DevKit | **Status:** active
@@ -685,3 +690,19 @@ MUI Popper needs `anchorEl` during render. `useRef` + `ref.current` triggers Rea
 **Category:** gotcha
 **Context:** Tests asserting exact counts (e.g., `len(tools) != 41`) fail whenever a new item is added. Common in tool-discovery tests, route-registration tests, and enum exhaustiveness checks.
 **Fix:** Before creating a PR that adds tools/routes/handlers, search for `len(...) != N` or `assert.Equal(t, N, len(...))` patterns and update the expected count. For non-correctness counts, prefer `>= N` over exact equality.
+
+## 138. Use GIT_EDITOR=true for Non-Interactive Rebase Continue
+
+**Added:** 2026-03-18 | **Source:** Synapset | **Status:** active
+
+**Category:** correction
+**Context:** `git rebase --continue --no-edit` fails with `error: unknown option 'no-edit'`. The `--no-edit` flag is not valid for `git rebase --continue`.
+**Fix:** Use `GIT_EDITOR=true git rebase --continue` instead. Setting `GIT_EDITOR` to `true` (a no-op binary) suppresses the editor without the invalid flag, silently accepting the default commit message.
+
+## 139. Narrow Read List for Re-Running Failed Worktree Agents
+
+**Added:** 2026-03-18 | **Source:** Synapset | **Status:** active
+
+**Category:** workflow-pattern
+**Context:** A worktree agent exhausted ~140k tokens without committing (truncated output, incomplete work). Re-running with more context or broader permissions failed again. A focused re-run succeeded in ~50k tokens.
+**Fix:** Re-run with a narrow, explicit read list -- not a broader context. The re-run prompt should: (1) explicitly list the specific files to read FIRST before writing anything (file paths, struct names), (2) keep implementation steps minimal and concrete, (3) include a mandatory pre-commit CI checklist. Agents that explore broadly before writing rarely converge -- a narrow read list upfront prevents expensive exploration loops.

--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -1,7 +1,7 @@
 ---
 description: Known gotchas and platform-specific issues. Read when debugging unexpected behavior.
 tier: 2
-entry_count: 47
+entry_count: 48
 last_updated: "2026-03-18"
 ---
 
@@ -146,6 +146,11 @@ All parallel agents write to the same working directory. Sort into branches via 
 
 **Issue:** `git checkout <branch>` fails with "already used by worktree" when the branch is checked out in any worktree (including agent worktrees).
 **Fix:** Run `git worktree remove <path> --force` before checking out in the main tree. Prune worktrees after parallel agents complete.
+
+### Shared registration files are the most common parallel agent conflict surface (from issue #437)
+
+**Issue:** Two parallel worktree agents both modifying a shared registration file (e.g. `tools.go`, `router.go`, `routes.go`, skill routing tables) create a two-block rebase conflict when the second branch is rebased onto main after the first merges.
+**Fix:** When planning parallel agents that all add to a shared registration file, assign file ownership -- only ONE agent touches the shared file. Others wait or use a different integration point. Extends the general parallel-agent rule with the most common specific case.
 
 ## 26. Sequential Same-File PR Merge Requires Rebase Between Each
 
@@ -601,3 +606,12 @@ Note: reference the binary directly (`$HOME/.local/bin/trivy`) in the install st
 **Platform:** markdownlint-cli2 (all)
 **Issue:** Running `npx markdownlint-cli2` with a glob that accidentally includes non-`.md` files (e.g. `.gitignore`, `.sh` scripts) produces false positives. `#` comment lines are parsed as H1 headings, triggering MD022 (no blank line around headings), MD025 (multiple H1), and MD032 (no blank line around lists).
 **Fix:** Always scope markdownlint globs to `**/*.md` only. CI lint job already does this correctly — the issue only appears in manual local runs where a non-md file is passed directly or included via a broad glob.
+
+## 168. New Trivy CVE Day-Of Blocks All PRs — Hotfix With .trivyignore First
+
+**Added:** 2026-03-18 | **Source:** Synapset | **Status:** active
+
+**Platform:** GitHub Actions (CI with Trivy)
+**Issue:** A CVE published to GitHub Security Advisories at 13:00 UTC caused all PRs to fail Trivy scans from ~19:35 UTC onward on the same day -- including PRs that added zero new dependencies. Trivy downloads a fresh vulnerability DB on each CI run.
+**Fix:** For transitive deps with no fixed version, add a `.trivyignore` file suppressing the specific GHSA ID with a justification comment: (1) it is a transitive dep not directly used, (2) no fix is available, (3) attack surface is limited. Remove when upstream patches.
+**Critical ordering:** Merge the `.trivyignore` hotfix PR *before* feature PRs so CI unblocks across the board. The hotfix PR itself passes Trivy because the ignore is included in its own CI run.


### PR DESCRIPTION
Ingests 5 autolearn issues into rules files.

## Changes

**autolearn-patterns.md** (entry_count 66→68):
- AP#127: added sub-entry for inter-wave rebase after merges
- AP#138: `GIT_EDITOR=true git rebase --continue` avoids editor hang (new)
- AP#139: narrow read list for failed agent re-runs (new)

**known-gotchas.md** (entry_count 47→48):
- KG#25: added sub-entry for shared registration files as most common parallel conflict
- KG#168: Trivy CVE day-of blocks PRs — `.trivyignore` hotfix pattern (new)

Closes #434, Closes #435, Closes #436, Closes #437, Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)