### PR TITLE
chore(samverk): update project.yaml to Gitea forge

### DIFF
--- a/.samverk/project.yaml
+++ b/.samverk/project.yaml
@@ -3,9 +3,9 @@ schema_version: "1.0.0"
 project:
   name: devkit
   description: "AI development methodology and Claude Code configuration toolkit"
-  forge: github
-  repo: HerbHall/devkit
-  url: https://github.com/HerbHall/devkit
+  forge: gitea
+  repo: samverk/devkit
+  url: https://gitea.herbhall.net/samverk/devkit
   license: MIT
   stack: powershell
   phase: execution


### PR DESCRIPTION
Switch DevKit's Samverk project config from GitHub to Gitea as primary forge.

- `forge: github` → `gitea`
- `repo: HerbHall/devkit` → `samverk/devkit`
- `url: https://github.com/HerbHall/devkit` → `https://gitea.herbhall.net/samverk/devkit`

Part of the dual-forge migration. Samverk dispatcher will now watch DevKit issues on Gitea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)