### PR TITLE
chore(rules): session review -- Gitea org lifecycle + transfer/rename gotcha

### DIFF
--- a/claude/rules/autolearn-patterns.md
+++ b/claude/rules/autolearn-patterns.md
@@ -1,7 +1,7 @@
 ---
 description: Learned patterns from past sessions. Read when encountering similar situations.
 tier: 2
-entry_count: 66
+entry_count: 67
 last_updated: "2026-03-18"
 ---
 
@@ -685,3 +685,13 @@ MUI Popper needs `anchorEl` during render. `useRef` + `ref.current` triggers Rea
 **Category:** gotcha
 **Context:** Tests asserting exact counts (e.g., `len(tools) != 41`) fail whenever a new item is added. Common in tool-discovery tests, route-registration tests, and enum exhaustiveness checks.
 **Fix:** Before creating a PR that adds tools/routes/handlers, search for `len(...) != N` or `assert.Equal(t, N, len(...))` patterns and update the expected count. For non-correctness counts, prefer `>= N` over exact equality.
+
+## 138. Two-Org Gitea Lifecycle Model for Samverk Projects
+
+**Added:** 2026-03-18 | **Source:** DevKit | **Status:** active
+
+**Category:** architecture-pattern
+**Context:** Gitea server hosts both dispatcher-managed production work and pre-intake exploratory research. Without org separation, research repos mix with production ones and become confusing.
+**Fix:** Use two orgs: (1) `samverk-research` -- new ideas, exploratory work, pre-viability repos; (2) `samverk` -- dispatcher-managed production projects (devkit, samverk, synapset). When a research project proves viable, transfer once from `samverk-research` to `samverk` and set `lifecycle.phase: intake` in `.samverk/project.yaml`. No further org transfers -- phase progression stays within the `samverk` org.
+**Why:** Keeps unmanaged exploratory repos from cluttering the dispatcher's project registry. Org membership signals management status at a glance.
+**See also:** KG#168 (Gitea transfer + rename sequence)

--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -1,7 +1,7 @@
 ---
 description: Known gotchas and platform-specific issues. Read when debugging unexpected behavior.
 tier: 2
-entry_count: 47
+entry_count: 48
 last_updated: "2026-03-18"
 ---
 
@@ -601,3 +601,25 @@ Note: reference the binary directly (`$HOME/.local/bin/trivy`) in the install st
 **Platform:** markdownlint-cli2 (all)
 **Issue:** Running `npx markdownlint-cli2` with a glob that accidentally includes non-`.md` files (e.g. `.gitignore`, `.sh` scripts) produces false positives. `#` comment lines are parsed as H1 headings, triggering MD022 (no blank line around headings), MD025 (multiple H1), and MD032 (no blank line around lists).
 **Fix:** Always scope markdownlint globs to `**/*.md` only. CI lint job already does this correctly — the issue only appears in manual local runs where a non-md file is passed directly or included via a broad glob.
+
+## 168. Gitea Repo Transfer Does Not Rename -- Separate PATCH Required
+
+**Added:** 2026-03-18 | **Source:** DevKit | **Status:** active
+
+**Platform:** Gitea REST API
+**Issue:** `POST /api/v1/repos/{owner}/{repo}/transfer` moves a repo to a new org but keeps the original name. There is no `new_name` field in the transfer payload -- the request silently succeeds with the old name intact.
+**Fix:** Always follow transfer with a rename step:
+
+```bash
+# Step 1: Transfer org
+curl -X POST "$GITEA_URL/api/v1/repos/old-org/my-repo/transfer" \
+  -H "Authorization: token $TOKEN" \
+  -d '{"new_owner": "new-org"}'
+
+# Step 2: Rename (separate call, after transfer completes)
+curl -X PATCH "$GITEA_URL/api/v1/repos/new-org/my-repo" \
+  -H "Authorization: token $TOKEN" \
+  -d '{"name": "new-name"}'
+```
+
+Full repo management sequence: (1) `POST /api/v1/orgs` -- create org, (2) transfer, (3) rename, (4) `PATCH` description.


### PR DESCRIPTION
## Summary

- AP#138: Two-org Gitea lifecycle model (`samverk-research` = pre-intake, `samverk` = dispatcher-managed production). One-way transfer at intake.
- KG#168: Gitea REST API repo transfer does not rename — separate PATCH required after transfer.

## Synapset

- SYN#641: Gitea two-org lifecycle decision
- SYN#642: Gitea transfer/rename gotcha

🤖 Generated with [Claude Code](https://claude.com/claude-code)