### PR TITLE
docs(rules): ingest KG#25 x2, KG#98 clarification (#469, #470, #472)

### DIFF
--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -152,6 +152,16 @@ All parallel agents write to the same working directory. Sort into branches via 
 **Issue:** When launching 5+ parallel agents with `isolation: "worktree"`, not all agents receive isolated worktrees. In observed sessions, only 2-3 of 5 agents got proper worktree directories. The other agents worked in the shared main working directory, causing cross-contamination (commits appearing in wrong branches, agents needing stash-based sorting).
 **Fix:** After launching 5+ parallel agents, verify worktree-agent-{id} branches exist before assuming isolation (`git branch -r | grep worktree-agent`). Fallback: stash-based sorting from AP#22. Limit parallel worktree agents to 3 when isolation is critical.
 
+### Parallel agents contaminate main worktree when feature branch is checked out
+
+**Issue:** When parallel worktree agents are launched while the main worktree has a feature branch checked out, agents' commits can land on the main worktree's current branch in addition to their isolated worktree branches. Causes duplicate PRs and stacked commits on the wrong branch.
+**Fix:** Before launching parallel agents, run `git checkout main` in the main worktree to avoid contaminating a feature branch.
+
+### After worktree agent completes, main working dir may be on agent's feature branch
+
+**Issue:** After a worktree-isolated Agent tool call completes, the main working directory may be on the agent's feature branch rather than main. Silent failure modes: cherry-pick returns "no changes added to commit", git commit creates commit on wrong branch, git push pushes wrong branch.
+**Fix:** Always run `git branch --show-current` before any post-agent git operations. Run `git checkout main` (or your intended base branch) before cherry-picking, committing, or pushing.
+
 ## 26. Sequential Same-File PR Merge Requires Rebase Between Each
 
 **Added:** 2026-02-17 | **Source:** SubNetree | **Status:** active
@@ -230,6 +240,7 @@ Windows CRLF (`\r\n`) causes silent failures across multiple tools. Three known 
 **Platform:** Claude Code (all)
 **Issue:** Rules files over 40k cause context to be silently dropped at task transitions.
 **Fix:** Run `/rules-compact` to stay below 35k per file. `/conformance-audit` check #17 flags violations.
+**Note:** DevKit CI (`lint.yml`) does NOT enforce these thresholds. Files over 40k will still pass CI — the limits are self-enforced performance guidelines only. Do not treat file size as a hard CI prerequisite when planning issue batches.
 
 ## 99. Copilot Cannot Approve PRs -- Review Is Informational Only (Consolidated Reference)
 


### PR DESCRIPTION
## Summary

Three targeted updates to `known-gotchas.md`, all discovered during the 20-issue batch session (2026-03-20).

**KG#98 clarification (#469):** DevKit CI does NOT enforce the 35k/40k size thresholds. They are self-enforced performance guidelines. Adding a note prevents future sessions from treating file size as a hard CI prerequisite.

**KG#25 addition (#470):** When parallel worktree agents are launched while the main worktree has a feature branch checked out, agents' commits land on that branch too. Fix: `git checkout main` before launching agents.

**KG#25 addition (#472):** After a worktree agent completes, the main working directory may be on the agent's feature branch. Silent failure: cherry-pick / commit / push all operate on the wrong branch. Fix: `git branch --show-current` before any post-agent git operations.

## Test plan

- [x] markdownlint: 0 errors
- [x] entry_count unchanged (these are sub-entries, not new top-level entries)
- [x] No new cross-references added

Closes #469
Closes #470
Closes #472