### PR TITLE
fix(conformance-audit): forge-aware workflow checks for Gitea projects (#488)

### DIFF
--- a/claude/skills/conformance-audit/references/checklist.md
+++ b/claude/skills/conformance-audit/references/checklist.md
@@ -36,10 +36,10 @@ A project may match multiple stacks (e.g., Go backend + Node frontend). Apply ch
 
 ### 3. CI Workflow
 
-- **What to check**: `.github/workflows/ci.yml` (or variant like `ci-node.yml`, `ci-rust.yml`, `ci-dotnet.yml`)
+- **What to check**: `ci.yml` (or variant) in `.github/workflows/` (GitHub) or `.gitea/workflows/` (Gitea)
 - **Stacks**: All
-- **Pass criteria**: At least one CI workflow file exists under `.github/workflows/` with a name containing `ci` or `lint` or `test` or `build`
-- **Fail indicators**: No `.github/workflows/` directory, or no CI-related workflow files
+- **Pass criteria**: At least one CI workflow file exists under `.github/workflows/` OR `.gitea/workflows/` with a name containing `ci`, `lint`, `test`, or `build`
+- **Fail indicators**: Neither `.github/workflows/` nor `.gitea/workflows/` contains a CI-related workflow file
 - **Fix reference**: `project-templates/ci.yml` (Go), `project-templates/ci-node.yml` (Node), `project-templates/ci-rust.yml` (Rust), `project-templates/ci-dotnet.yml` (.NET)
 - **Note**: CI workflows are too project-specific to auto-create; suggest the template but require manual customization
 
@@ -83,12 +83,17 @@ A project may match multiple stacks (e.g., Go backend + Node frontend). Apply ch
 
 - **What to check**: release-please configuration files exist
 - **Stacks**: All
-- **Pass criteria**: All three files exist:
-  - `.release-please-manifest.json`
-  - `release-please-config.json`
-  - `.github/workflows/release-please.yml`
-- **Fail indicators**: Any of the three files missing
-- **Fix reference**: `project-templates/release-please-manifest.json`, `project-templates/release-please-config.json`, `project-templates/release-please.yml`
+- **Pass criteria**: All three files/conditions are met:
+  - `.release-please-manifest.json` exists
+  - `release-please-config.json` exists
+  - A release-please workflow exists in the project's forge workflows directory:
+    - GitHub projects: `.github/workflows/release-please.yml`
+    - Gitea projects: `.gitea/workflows/release-please.yml`
+- **Fail indicators**: Any of the three missing
+- **Fix reference**:
+  - GitHub: `project-templates/release-please.yml`
+  - Gitea: `project-templates/release-please-gitea.yml`
+  - Both: `project-templates/release-please-manifest.json`, `project-templates/release-please-config.json`
 
 ### 9. LICENSE
 
@@ -116,20 +121,21 @@ A project may match multiple stacks (e.g., Go backend + Node frontend). Apply ch
 
 ### 12. Nightly Build Workflow
 
-- **What to check**: `.github/workflows/nightly.yml` (or variant) exists
+- **What to check**: `nightly.yml` (or variant) in the project's forge workflows directory
 - **Stacks**: Go, Node/Docker extension, Rust (skip for .NET desktop)
-- **Pass criteria**: A workflow file exists under `.github/workflows/` with `nightly` in its name or containing a `schedule:` trigger with a cron expression
-- **Fail indicators**: No nightly/scheduled workflow found
+- **Pass criteria**: A workflow file exists under `.github/workflows/` OR `.gitea/workflows/` with `nightly` in its name or containing a `schedule:` trigger with a cron expression
+- **Fail indicators**: No nightly/scheduled workflow found in either directory
 - **Fix reference**: `project-templates/nightly-go.yml` (Go), `project-templates/nightly-node.yml` (Node), `project-templates/nightly-rust.yml` (Rust)
 - **Note**: Nightly workflows are project-specific; suggest the template but require manual customization
 
 ### 13. Release Gate Workflow
 
-- **What to check**: `.github/workflows/release-gate.yml` exists
+- **What to check**: `release-gate.yml` in the project's forge workflows directory
 - **Stacks**: Only if release-please is configured (check 8 passes)
-- **Pass criteria**: File exists
+- **Pass criteria**: `release-gate.yml` exists under `.github/workflows/` (GitHub) or `.gitea/workflows/` (Gitea)
 - **Fail indicators**: release-please is configured but no release-gate workflow
-- **Fix reference**: `project-templates/release-gate.yml`
+- **Fix reference**: `project-templates/release-gate.yml` (GitHub), `project-templates/release-gate-gitea.yml` (Gitea, see DevKit #489)
+- **Note**: Gitea release-gate template not yet implemented — see issue #489
 
 ### 14. Workflow Trigger Patterns
 

--- a/claude/skills/conformance-audit/workflows/single-project.md
+++ b/claude/skills/conformance-audit/workflows/single-project.md
@@ -89,13 +89,31 @@ else
 fi
 ```
 
+**Forge Detection** (run once before Check 3, reuse `WF_DIR` in all subsequent workflow checks)
+
+```bash
+# Detect which workflows directory this project uses.
+# GitHub-hosted projects use .github/workflows/; Gitea-hosted use .gitea/workflows/.
+if [ -d "$PROJECT/.github/workflows" ]; then
+    WF_DIR="$PROJECT/.github/workflows"
+    FORGE="github"
+elif [ -d "$PROJECT/.gitea/workflows" ]; then
+    WF_DIR="$PROJECT/.gitea/workflows"
+    FORGE="gitea"
+else
+    WF_DIR=""
+    FORGE="unknown"
+fi
+echo "Forge: $FORGE ($WF_DIR)"
+```
+
 **Check 3 -- CI Workflow**
 
 ```bash
-if ls "$PROJECT/.github/workflows/"*.yml 2>/dev/null | grep -qiE 'ci|lint|test|build'; then
-    echo "PASS: CI workflow found"
+if [ -n "$WF_DIR" ] && ls "$WF_DIR/"*.yml 2>/dev/null | grep -qiE 'ci|lint|test|build'; then
+    echo "PASS: CI workflow found ($FORGE)"
 else
-    echo "FAIL: No CI workflow found in .github/workflows/"
+    echo "FAIL: No CI workflow found in .github/workflows/ or .gitea/workflows/"
 fi
 ```
 
@@ -154,9 +172,13 @@ fi
 MISSING=""
 [ ! -f "$PROJECT/.release-please-manifest.json" ] && MISSING="$MISSING manifest"
 [ ! -f "$PROJECT/release-please-config.json" ] && MISSING="$MISSING config"
-[ ! -f "$PROJECT/.github/workflows/release-please.yml" ] && MISSING="$MISSING workflow"
+# Accept release-please.yml in either .github/workflows/ (GitHub) or .gitea/workflows/ (Gitea)
+RP_WF_FOUND=false
+[ -f "$PROJECT/.github/workflows/release-please.yml" ] && RP_WF_FOUND=true
+[ -f "$PROJECT/.gitea/workflows/release-please.yml" ] && RP_WF_FOUND=true
+[ "$RP_WF_FOUND" = "false" ] && MISSING="$MISSING workflow"
 if [ -z "$MISSING" ]; then
-    echo "PASS: release-please fully configured"
+    echo "PASS: release-please fully configured ($FORGE)"
 else
     echo "FAIL: release-please missing:$MISSING"
 fi
@@ -200,10 +222,10 @@ fi
 **Check 12 -- Nightly Workflow** (skip for .NET desktop)
 
 ```bash
-if ls "$PROJECT/.github/workflows/"*nightly* 2>/dev/null | grep -q .; then
-    echo "PASS: Nightly workflow found"
-elif grep -qlr 'schedule:' "$PROJECT/.github/workflows/"*.yml 2>/dev/null; then
-    echo "PASS: Scheduled workflow found"
+if [ -n "$WF_DIR" ] && ls "$WF_DIR/"*nightly* 2>/dev/null | grep -q .; then
+    echo "PASS: Nightly workflow found ($FORGE)"
+elif [ -n "$WF_DIR" ] && grep -qlr 'schedule:' "$WF_DIR/"*.yml 2>/dev/null; then
+    echo "PASS: Scheduled workflow found ($FORGE)"
 else
     echo "FAIL: No nightly or scheduled workflow found"
 fi
@@ -212,8 +234,13 @@ fi
 **Check 13 -- Release Gate** (only if check 8 passed)
 
 ```bash
-if [ -f "$PROJECT/.github/workflows/release-gate.yml" ]; then
-    echo "PASS: release-gate.yml exists"
+# Accept release-gate.yml in either forge's workflows directory.
+# Note: Gitea variant (project-templates/release-gate-gitea.yml) may not exist yet — see DevKit #489.
+RG_FOUND=false
+[ -f "$PROJECT/.github/workflows/release-gate.yml" ] && RG_FOUND=true
+[ -f "$PROJECT/.gitea/workflows/release-gate.yml" ] && RG_FOUND=true
+if [ "$RG_FOUND" = "true" ]; then
+    echo "PASS: release-gate.yml exists ($FORGE)"
 else
     echo "FAIL: release-gate.yml not found"
 fi
@@ -224,12 +251,14 @@ fi
 ```bash
 # FAIL if any non-release-please workflow has 'tags: v*' or "tags: ['v*']"
 TRIGGER_FAIL=""
-for wf in "$PROJECT/.github/workflows/"*.yml; do
-    [ "$(basename "$wf")" = "release-please.yml" ] && continue
-    if grep -q "tags:.*v\*" "$wf" 2>/dev/null; then
-        TRIGGER_FAIL="$TRIGGER_FAIL $(basename "$wf")"
-    fi
-done
+if [ -n "$WF_DIR" ]; then
+    for wf in "$WF_DIR/"*.yml; do
+        [ "$(basename "$wf")" = "release-please.yml" ] && continue
+        if grep -q "tags:.*v\*" "$wf" 2>/dev/null; then
+            TRIGGER_FAIL="$TRIGGER_FAIL $(basename "$wf")"
+        fi
+    done
+fi
 if [ -z "$TRIGGER_FAIL" ]; then
     echo "PASS: No conflicting tag triggers found"
 else
@@ -240,8 +269,8 @@ fi
 **Check 15 -- Retrigger CI** (only if check 8 passed)
 
 ```bash
-if ls "$PROJECT/.github/workflows/"*retrigger* 2>/dev/null | grep -q .; then
-    echo "PASS: Retrigger CI workflow found"
+if [ -n "$WF_DIR" ] && ls "$WF_DIR/"*retrigger* 2>/dev/null | grep -q .; then
+    echo "PASS: Retrigger CI workflow found ($FORGE)"
 else
     echo "FAIL: No retrigger-ci workflow found"
 fi


### PR DESCRIPTION
## Summary

- Adds forge detection block to `single-project.md` (sets `WF_DIR`/`FORGE` variables)
- Updates checks 3, 8, 12, 13, 14, 15 to use `WF_DIR` instead of hardcoded `.github/workflows/`
- Check 8 (release-please) now accepts `.gitea/workflows/release-please.yml` as passing
- Fix reference for check 8 updated to include `project-templates/release-please-gitea.yml`
- Checklist.md pass criteria text updated to document both GitHub and Gitea paths

## Test plan

- [ ] Audit a GitHub-hosted project — all checks behave as before
- [ ] Audit a Gitea-hosted project (e.g. Claude Token Stats) — checks 3, 8, 12 now PASS
- [ ] Audit a project with no workflows directory — checks report FAIL with helpful message

## Related

Closes #488
Blocked by #489 for check 13 (Gitea release-gate template not yet implemented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)