### PR TITLE
feat(templates): add Gitea variants for release-gate and retrigger-ci (#489)

### DIFF
--- a/project-templates/release-gate-gitea.yml
+++ b/project-templates/release-gate-gitea.yml
@@ -1,0 +1,237 @@
+# Release Gate (Gitea)
+#
+# Gitea-compatible equivalent of release-gate.yml.
+# Uses Gitea REST API (curl) in place of the gh CLI.
+#
+# Evaluates release-please PRs and enables merge-when-checks-succeed
+# based on release tier.  Language-agnostic — only reads the
+# release-please manifest and git history.
+#
+# Prerequisites:
+#   - release-please configured via release-please-gitea.yml
+#   - .release-please-manifest.json at repo root
+#   - RELEASE_PLEASE_TOKEN secret (PAT with repo scope)
+#   - retrigger-ci-gitea.yml deployed (see template)
+#
+# Release tiers:
+#   Immediate  — Critical/security fix (fix!:, CVE, breaking) → auto-merge
+#   Threshold  — Minor+ version bump OR 5+ accumulated fixes → auto-merge
+#   Batched    — Below threshold → labeled, waits for manual merge
+#
+# Customization:
+#   - Fix threshold: change the "5" in FIX_COUNT comparison (line ~95)
+#   - Merge method: change "squash" in the merge API call (line ~165)
+
+name: Release Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  evaluate:
+    name: Evaluate Release
+    # Filter by autorelease label — Gitea release-please uses PAT, not a bot
+    # account, so we cannot filter by user.login like the GitHub variant.
+    if: contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    runs-on: ubuntu-latest
+    outputs:
+      decision: ${{ steps.gate.outputs.decision }}
+      reason: ${{ steps.gate.outputs.reason }}
+      version_from: ${{ steps.gate.outputs.version_from }}
+      version_to: ${{ steps.gate.outputs.version_to }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Evaluate release criteria
+        id: gate
+        run: |
+          set -euo pipefail
+
+          # Get version info from manifests
+          CURRENT=$(git show origin/main:.release-please-manifest.json | python3 -c "import sys,json; print(json.load(sys.stdin)['.'])")
+          NEW=$(python3 -c "import json; print(json.load(open('.release-please-manifest.json'))['.'])")
+          echo "version_from=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "version_to=$NEW" >> "$GITHUB_OUTPUT"
+
+          CUR_MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+          CUR_MINOR=$(echo "$CURRENT" | cut -d. -f2)
+          NEW_MAJOR=$(echo "$NEW" | cut -d. -f1)
+          NEW_MINOR=$(echo "$NEW" | cut -d. -f2)
+
+          # Get commits since last release tag
+          LAST_TAG=$(git describe --tags --abbrev=0 origin/main 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ]; then
+            COMMIT_LOG=$(git log "${LAST_TAG}..origin/main" --format="%s" 2>/dev/null || echo "")
+          else
+            COMMIT_LOG=$(git log origin/main --format="%s" 2>/dev/null || echo "")
+          fi
+
+          # Count changelog entries by type
+          FEAT_COUNT=$(echo "$COMMIT_LOG" | grep -c "^feat" || true)
+          FIX_COUNT=$(echo "$COMMIT_LOG" | grep -c "^fix" || true)
+          TOTAL=$((FEAT_COUNT + FIX_COUNT))
+
+          echo "Commits since $LAST_TAG: feat=$FEAT_COUNT fix=$FIX_COUNT total=$TOTAL"
+          echo "Version: $CURRENT -> $NEW"
+
+          # Tier 1: Immediate — critical/security fix
+          HAS_CRITICAL=false
+          if echo "$COMMIT_LOG" | grep -qiE '^fix!:|BREAKING CHANGE'; then
+            HAS_CRITICAL=true
+          fi
+          if echo "$COMMIT_LOG" | grep -qiE 'CVE-|security|vulnerability|critical'; then
+            HAS_CRITICAL=true
+          fi
+
+          if [ "$HAS_CRITICAL" = "true" ]; then
+            echo "decision=immediate" >> "$GITHUB_OUTPUT"
+            echo "reason=Critical or security fix detected" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Tier 2: Threshold — minor/major bump OR 5+ accumulated fixes
+          if [ "$NEW_MAJOR" -gt "$CUR_MAJOR" ]; then
+            echo "decision=threshold" >> "$GITHUB_OUTPUT"
+            echo "reason=Major version bump ($CURRENT -> $NEW)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$NEW_MINOR" -gt "$CUR_MINOR" ]; then
+            echo "decision=threshold" >> "$GITHUB_OUTPUT"
+            echo "reason=Minor version bump with $FEAT_COUNT feature(s) ($CURRENT -> $NEW)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$FIX_COUNT" -ge 5 ]; then
+            echo "decision=threshold" >> "$GITHUB_OUTPUT"
+            echo "reason=$FIX_COUNT bug fixes accumulated ($CURRENT -> $NEW)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Below threshold — stay batched
+          echo "decision=batched" >> "$GITHUB_OUTPUT"
+          echo "reason=Patch only with $TOTAL change(s), below threshold ($CURRENT -> $NEW)" >> "$GITHUB_OUTPUT"
+
+      - name: Label PR with decision
+        env:
+          GITEA_API: ${{ gitea.server_url }}/api/v1
+          GITEA_REPO: ${{ github.repository }}
+          GITEA_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          DECISION: ${{ steps.gate.outputs.decision }}
+        run: |
+          set -euo pipefail
+
+          # Helper: get or create a label, return its ID
+          get_or_create_label() {
+            local NAME="$1" COLOR="$2" DESC="$3"
+            ID=$(curl -s "$GITEA_API/repos/$GITEA_REPO/labels" \
+              -H "Authorization: token $GITEA_TOKEN" \
+              | python3 -c "import sys,json; ls=json.load(sys.stdin); m=[l['id'] for l in ls if l['name']=='$NAME']; print(m[0] if m else '')")
+            if [ -z "$ID" ]; then
+              ID=$(curl -s -X POST "$GITEA_API/repos/$GITEA_REPO/labels" \
+                -H "Authorization: token $GITEA_TOKEN" \
+                -H "Content-Type: application/json" \
+                -d "{\"name\":\"$NAME\",\"color\":\"$COLOR\",\"description\":\"$DESC\"}" \
+                | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+            fi
+            echo "$ID"
+          }
+
+          AUTO_ID=$(get_or_create_label "release:auto" "#0E8A16" "Auto-release approved")
+          BATCH_ID=$(get_or_create_label "release:batched" "#FBCA04" "Batched, waiting for threshold")
+
+          # Remove both labels from the PR, then apply the correct one
+          curl -s -X DELETE "$GITEA_API/repos/$GITEA_REPO/issues/$PR_NUMBER/labels/$AUTO_ID" \
+            -H "Authorization: token $GITEA_TOKEN" 2>/dev/null || true
+          curl -s -X DELETE "$GITEA_API/repos/$GITEA_REPO/issues/$PR_NUMBER/labels/$BATCH_ID" \
+            -H "Authorization: token $GITEA_TOKEN" 2>/dev/null || true
+
+          if [ "$DECISION" = "immediate" ] || [ "$DECISION" = "threshold" ]; then
+            LABEL_ID="$AUTO_ID"
+          else
+            LABEL_ID="$BATCH_ID"
+          fi
+
+          curl -s -X POST "$GITEA_API/repos/$GITEA_REPO/issues/$PR_NUMBER/labels" \
+            -H "Authorization: token $GITEA_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"labels\":[$LABEL_ID]}"
+
+      - name: Post decision comment
+        env:
+          GITEA_API: ${{ gitea.server_url }}/api/v1
+          GITEA_REPO: ${{ github.repository }}
+          GITEA_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          DECISION: ${{ steps.gate.outputs.decision }}
+          REASON: ${{ steps.gate.outputs.reason }}
+          FROM: ${{ steps.gate.outputs.version_from }}
+          TO: ${{ steps.gate.outputs.version_to }}
+        run: |
+          set -euo pipefail
+
+          if [ "$DECISION" = "immediate" ] || [ "$DECISION" = "threshold" ]; then
+            ICON="✅"
+            ACTION="Auto-merge enabled (merge-when-checks-succeed)."
+          else
+            ICON="⏳"
+            ACTION="Waiting for more changes or manual merge."
+          fi
+
+          BODY="### $ICON Release Gate: \`$DECISION\`
+
+**Version**: $FROM → $TO
+**Reason**: $REASON
+**Action**: $ACTION"
+
+          # Delete previous gate comments to avoid spam
+          curl -s "$GITEA_API/repos/$GITEA_REPO/issues/$PR_NUMBER/comments" \
+            -H "Authorization: token $GITEA_TOKEN" \
+            | python3 -c "
+import sys, json
+comments = json.load(sys.stdin)
+for c in comments:
+    if 'Release Gate' in c.get('body', '') and c.get('user', {}).get('login', '') != '':
+        print(c['id'])
+" | while read -r CID; do
+            curl -s -X DELETE "$GITEA_API/repos/$GITEA_REPO/issues/comments/$CID" \
+              -H "Authorization: token $GITEA_TOKEN" 2>/dev/null || true
+          done
+
+          curl -s -X POST "$GITEA_API/repos/$GITEA_REPO/issues/$PR_NUMBER/comments" \
+            -H "Authorization: token $GITEA_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"body\":$(echo "$BODY" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))')}"
+
+  auto-merge:
+    name: Auto-merge Release
+    needs: evaluate
+    if: needs.evaluate.outputs.decision == 'immediate' || needs.evaluate.outputs.decision == 'threshold'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable merge-when-checks-succeed
+        env:
+          GITEA_API: ${{ gitea.server_url }}/api/v1
+          GITEA_REPO: ${{ github.repository }}
+          GITEA_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Gitea merge-when-checks-succeed: POST to merge endpoint with the flag.
+          # Gitea queues the merge; it will execute once all required checks pass.
+          curl -s -X POST "$GITEA_API/repos/$GITEA_REPO/pulls/$PR_NUMBER/merge" \
+            -H "Authorization: token $GITEA_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "Do": "squash",
+              "merge_when_checks_succeed": true,
+              "merge_message_field": "Auto-merged by release gate"
+            }'
+          echo "Merge-when-checks-succeed enabled for PR #$PR_NUMBER"

--- a/project-templates/retrigger-ci-gitea.yml
+++ b/project-templates/retrigger-ci-gitea.yml
@@ -1,0 +1,92 @@
+# Re-trigger CI (Gitea)
+#
+# Gitea-compatible equivalent of retrigger-ci.yml.
+# Uses Gitea REST API (curl) in place of the gh CLI.
+#
+# Triggers when release-please pushes to a release branch. If CI checks
+# are not yet present on the open release PR, closes and reopens it to
+# force CI re-evaluation.
+#
+# Note: Gitea act_runner may not support the workflow_run trigger used
+# by the GitHub variant. This template uses a push trigger on the
+# release-please branch pattern instead, which fires reliably.
+#
+# Prerequisites:
+#   - release-please-gitea.yml deployed
+#   - RELEASE_PLEASE_TOKEN secret (PAT with repo scope)
+
+name: Re-trigger CI
+
+on:
+  push:
+    branches:
+      - "release-please--**"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  retrigger:
+    name: Re-trigger Release PR CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find and re-trigger release PR
+        env:
+          GITEA_API: ${{ gitea.server_url }}/api/v1
+          GITEA_REPO: ${{ github.repository }}
+          GITEA_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          # Find the open release-please PR for this branch
+          PR_NUMBER=$(curl -s "$GITEA_API/repos/$GITEA_REPO/pulls?state=open&limit=50" \
+            -H "Authorization: token $GITEA_TOKEN" \
+            | python3 -c "
+import sys, json
+prs = json.load(sys.stdin)
+branch = '$BRANCH'
+match = [p['number'] for p in prs if p.get('head', {}).get('label', '') == branch
+         or p.get('head', {}).get('ref', '') == branch]
+print(match[0] if match else '')
+")
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open release-please PR found for branch $BRANCH"
+            exit 0
+          fi
+
+          echo "Found release-please PR #$PR_NUMBER for branch $BRANCH"
+
+          # Check if CI status checks are present on the PR's current HEAD
+          # Gitea returns statuses via the commit status API.
+          PR_SHA=$(curl -s "$GITEA_API/repos/$GITEA_REPO/pulls/$PR_NUMBER" \
+            -H "Authorization: token $GITEA_TOKEN" \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
+
+          STATUS_COUNT=$(curl -s "$GITEA_API/repos/$GITEA_REPO/statuses/$PR_SHA" \
+            -H "Authorization: token $GITEA_TOKEN" \
+            | python3 -c "import sys,json; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
+
+          if [ "$STATUS_COUNT" -gt 0 ]; then
+            echo "CI checks already present ($STATUS_COUNT statuses), no action needed"
+            exit 0
+          fi
+
+          echo "No CI checks found on $PR_SHA, re-triggering via close/reopen..."
+
+          # Close PR
+          curl -s -X PATCH "$GITEA_API/repos/$GITEA_REPO/pulls/$PR_NUMBER" \
+            -H "Authorization: token $GITEA_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"state": "closed"}' > /dev/null
+
+          sleep 3
+
+          # Reopen PR
+          curl -s -X PATCH "$GITEA_API/repos/$GITEA_REPO/pulls/$PR_NUMBER" \
+            -H "Authorization: token $GITEA_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"state": "open"}' > /dev/null
+
+          echo "PR #$PR_NUMBER reopened — CI should now trigger"


### PR DESCRIPTION
## Summary

- `project-templates/release-gate-gitea.yml` — Gitea equivalent of release-gate.yml using Gitea REST API (curl) instead of gh CLI
- `project-templates/retrigger-ci-gitea.yml` — Gitea equivalent using push-on-release-branch trigger instead of workflow_run

**Key differences from GitHub variants:**
- Filters by `autorelease: pending` label (not by bot user.login) — Gitea release-please uses a PAT so the author is the token owner
- Label management uses Gitea label IDs (get-or-create by name, apply by ID)
- Auto-merge via `POST /pulls/{index}/merge` with `merge_when_checks_succeed: true`
- retrigger-ci uses `push: branches: ["release-please--**"]` (workflow_run may not be supported in all act_runner versions)
- CI status check detection via Gitea commit statuses API

## Test plan

- [ ] Deploy release-please-gitea.yml + release-gate-gitea.yml + retrigger-ci-gitea.yml to a test Gitea repo
- [ ] Merge a fix commit — verify release-please creates a PR with `autorelease: pending` label
- [ ] Verify release-gate evaluates the tier and adds `release:batched` or `release:auto` label
- [ ] Verify merge-when-checks-succeed activates when decision is threshold/immediate

## Related

Closes #489
Depends on #488 (conformance check 13 now includes `.gitea/workflows/release-gate.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)