### PR TITLE
docs: multi-forge release strategy — METHODOLOGY + ADR-0018 (#490)

### DIFF
--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -211,12 +211,38 @@ This project is NOT worth pursuing if:
 **Process**:
 
 1. Write/update README
-2. Create GitHub release with changelog
+2. Tag and publish release (see forge selection guide below)
 3. Submit to relevant lists/directories (if applicable)
 4. Run `/autolearn` (session review) to capture all learnings
 5. Update devkit repo if new patterns or skills were created
 
 **Gate**: Is the README honest about what's shipped? Are the learnings captured? Ship it.
+
+#### Forge Selection Guide
+
+DevKit provides two release-please templates. Choose based on where `origin` points:
+
+| Primary forge | Workflow template | Fix reference |
+|--------------|-------------------|---------------|
+| GitHub | `project-templates/release-please.yml` | Uses `googleapis/release-please-action@v4` |
+| Gitea | `project-templates/release-please-gitea.yml` | Uses `npx release-please` CLI directly |
+
+**Dual-forge projects** (origin on one forge, mirror on another):
+
+- Run release-please on the **primary forge only**
+- Tags created by release-please propagate to the secondary forge via `devkit-sync` or manual `git push --tags <remote>`
+- Do not run release-please on both forges — it will create duplicate release PRs and conflicting tags
+
+**Supporting workflows** (also forge-specific):
+
+| Workflow | GitHub template | Gitea template |
+|----------|----------------|----------------|
+| Release gating | `release-gate.yml` | `release-gate-gitea.yml` |
+| CI retrigger | `retrigger-ci.yml` | `retrigger-ci-gitea.yml` |
+
+All four templates use the same conventions: conventional commits, `VERSION` file as source of truth, `CHANGELOG.md` updated on each release. The user experience is identical regardless of forge.
+
+**Required secret**: `RELEASE_PLEASE_TOKEN` — a PAT with repo scope. Set via `scripts/Set-DevkitSecrets.ps1` (reads from `~/.devkit-config.json` `.Secrets` block).
 
 ---
 

--- a/docs/ADR-0018-multi-forge-release-strategy.md
+++ b/docs/ADR-0018-multi-forge-release-strategy.md
@@ -1,0 +1,77 @@
+# ADR-0018: Multi-Forge Release Strategy
+
+**Status**: Accepted
+**Date**: 2026-03-21
+**Deciders**: Herb Hall
+
+## Context
+
+DevKit projects may be hosted on GitHub, Gitea, or both. ADR-0015 standardised
+on release-please with a GitHub Action, but did not address Gitea-hosted or
+dual-forge scenarios. Claude Token Stats (Gitea-only) was the first project to
+surface this gap.
+
+Three options were considered:
+
+1. **GitHub-only releases** — all projects pushed to GitHub for release tooling
+2. **Per-forge templates** — identical tool, forge-specific workflow file
+3. **Custom abstraction** — build a forge-agnostic release tool from scratch
+
+## Decision
+
+**Option 2: Per-forge templates** — same tool (release-please), same conventions
+(conventional commits, `VERSION` file, `CHANGELOG.md`), different CI runtime.
+
+DevKit provides two equivalent workflow templates:
+
+| Forge | Template | Mechanism |
+|-------|----------|-----------|
+| GitHub | `project-templates/release-please.yml` | `googleapis/release-please-action@v4` |
+| Gitea | `project-templates/release-please-gitea.yml` | `npx release-please` CLI |
+
+Orchestration workflows (release-gate, retrigger-ci) follow the same pattern:
+Gitea variants use `curl` + Gitea REST API in place of the `gh` CLI.
+
+## Consequences
+
+**Positive:**
+
+- Zero new tooling — release-please already has Gitea API support via `--repo-url`
+- Consistent developer experience: same PR flow, same commit conventions, same
+  `CHANGELOG.md` format regardless of forge
+- Forge-detection added to conformance audit (check 3, 8, 12, 13, 15) so audits
+  correctly evaluate Gitea projects without false FAILs
+- `RELEASE_PLEASE_TOKEN` is the single secret required on all forges
+
+**Negative / Constraints:**
+
+- Dual-forge projects must designate one forge as authoritative for versioning
+- Gitea release-gate uses `merge_when_checks_succeed` instead of `gh pr merge --auto`;
+  behaviour may differ subtly
+- `workflow_run` trigger unavailable in some act_runner versions — Gitea retrigger-ci
+  uses `push: branches: ["release-please--**"]` as a workaround
+
+## Forge Selection Rules
+
+1. Inspect the `origin` remote. GitHub URL → use GitHub templates. Gitea URL → use
+   Gitea templates.
+2. For dual-forge (origin = GitHub, gitea = mirror or vice versa): run release-please
+   on the **primary forge only**. Tags propagate to the secondary forge via
+   `git push --tags <remote>` or `devkit-sync`.
+3. Never run release-please on both forges simultaneously — duplicate release PRs and
+   conflicting tags will result.
+
+## Implementation
+
+- `project-templates/release-please-gitea.yml` — Gitea release workflow
+- `project-templates/release-gate-gitea.yml` — Gitea release gate (DevKit #489)
+- `project-templates/retrigger-ci-gitea.yml` — Gitea CI retrigger (DevKit #489)
+- Conformance audit checks 3, 8, 12, 13, 15 updated (DevKit #488)
+- `METHODOLOGY.md` Phase 5 updated with forge selection guide
+
+## References
+
+- ADR-0015: Release Standardization (chose release-please, VERSION file)
+- ADR-0016: Release Gating Strategy (tiers: immediate / threshold / batched)
+- DevKit issues #488, #489, #490
+- Claude Token Stats issue #1 (first Gitea-hosted project using this pattern)


### PR DESCRIPTION
## Summary

- `METHODOLOGY.md` Phase 5: adds forge selection guide (decision table + dual-forge rule + template reference)
- `docs/ADR-0018-multi-forge-release-strategy.md`: new ADR documenting the decision, consequences, and forge selection rules

## Key decisions documented

- Same tool (release-please) on both forges — no custom abstraction
- Primary forge handles release-please; tags propagate to secondary via `git push --tags`
- Never run release-please on both forges simultaneously
- `RELEASE_PLEASE_TOKEN` is the one required secret on all forges

## Test plan

- [ ] Review METHODOLOGY.md Phase 5 — is the forge selection guide clear and accurate?
- [ ] Review ADR-0018 — does it correctly capture the decision and constraints?

## Related

Closes #490
Part of series: #488 (conformance), #489 (templates), #490 (docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)