### PR TITLE
chore(rules): autolearn 2026-03-21 -- KG#178-179, AP#145-146

### DIFF
--- a/claude/rules/autolearn-patterns.md
+++ b/claude/rules/autolearn-patterns.md
@@ -1,7 +1,7 @@
 ---
 description: Learned patterns from past sessions. Read when encountering similar situations.
 tier: 2
-entry_count: 58
+entry_count: 60
 last_updated: "2026-03-21"
 ---
 
@@ -661,3 +661,42 @@ Each window gets the correct UI with zero navigation overhead. Typical window co
 
 Backend opens a named window: `app.get_webview_window("dashboard").show()`
 **See also:** KG#176 (Tauri 2 API gotchas — getCurrentWindow import path)
+
+## 145. DevKit Promote Workflow: Reset Stable to `origin/main` After PR Merge
+
+**Added:** 2026-03-21 | **Source:** devkit | **Status:** active
+
+**Category:** workflow-pattern
+**Context:** `sync.ps1 -Promote` does `git merge --ff-only <dev-branch>` in the stable worktree. This updates stable to the dev branch tip. But GitHub may have additional commits on `main` from other PRs merged before or after yours (e.g., the PR's own squash/merge commit has a different SHA than the feature branch tip). After any PR merge to GitHub main, stable ends up behind `origin/main`.
+**Fix:** After `-Promote` succeeds, always reset stable to `origin/main`:
+
+```bash
+git -C ~/.devkit-stable fetch origin
+git -C ~/.devkit-stable reset --hard origin/main
+```
+
+Then verify: `git -C ~/.devkit-stable log --oneline -1` should show the merge commit from GitHub.
+**Why:** `-Promote` is designed for dev→stable promotion. GitHub's merge creates a new commit (merge or squash) not present in the dev branch. Stable only gets that commit via `origin/main` reset.
+
+## 146. Two-Level Project Discovery for Family-Folder Directory Structures
+
+**Added:** 2026-03-21 | **Source:** devkit | **Status:** active
+
+**Category:** pattern
+**Context:** When a workspace is restructured from flat (`D:\DevSpace\Project\`) to family-folder layout (`D:\DevSpace\Family\Project\`), any script that discovers projects with a flat one-level `Get-ChildItem` stops finding projects entirely. Fails silently (zero projects found) unless `.Count` is checked first.
+**Fix:** Search two levels deep — check if the direct child has `.git`, and if not, check its children:
+
+```powershell
+$projectDirs = @(Get-ChildItem -Path $devspacePath -Directory | ForEach-Object {
+    $direct = $_
+    if (Test-Path (Join-Path $direct.FullName '.git')) {
+        $direct
+    } else {
+        Get-ChildItem -Path $direct.FullName -Directory |
+            Where-Object { Test-Path (Join-Path $_.FullName '.git') }
+    }
+})
+```
+
+**Combine with:** Always wrap in `@()` (see KG#179). Check for family-folder structure any time DevSpace path conventions change.
+**See also:** AP#138 (Two-org Gitea lifecycle model), KG#179 (PowerShell null Count)

--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -1,7 +1,7 @@
 ---
 description: Known gotchas and platform-specific issues. Read when debugging unexpected behavior.
 tier: 2
-entry_count: 37
+entry_count: 39
 last_updated: "2026-03-21"
 ---
 
@@ -558,3 +558,41 @@ formatter={(value, _name, props) => {
 ```
 
 Applies to both AreaChart and BarChart Tooltip formatters in Recharts 3.x.
+
+## 178. Git Worktree `.git` Pointer Breaks When Main Repo Is Moved
+
+**Added:** 2026-03-21 | **Source:** devkit | **Status:** active
+
+**Platform:** Git (all) / Windows
+**Issue:** A git worktree has a `.git` file (not directory) containing `gitdir: <absolute-path>/.git/worktrees/<name>`. When the main repository is moved to a new directory, this absolute path becomes stale. `git status` in the worktree fails with `fatal: not a git repository: <old-path>/.git/worktrees/<name>`. Any script that calls `git -C <worktree>` also fails silently or with that error.
+**Fix:** Update the `.git` file in the worktree to point to the new location:
+
+```bash
+# Old: gitdir: D:/DevSpace/devkit/.git/worktrees/-devkit-stable
+# New:
+echo "gitdir: D:/DevSpace/Toolkit/devkit/.git/worktrees/-devkit-stable" > ~/.devkit-stable/.git
+```
+
+**Detect:** `cat <worktree>/.git` — if the path after `gitdir:` no longer exists, the pointer is stale.
+**Verify fix:** `git -C <worktree> status` should return branch info, not a fatal error.
+**See also:** AP#22 (Git stash and branch workflows)
+
+## 179. PowerShell Pipeline to `$null` -- `.Count` Throws on Zero Results
+
+**Added:** 2026-03-21 | **Source:** devkit | **Status:** active
+
+**Platform:** PowerShell (all)
+**Issue:** `Get-ChildItem | Where-Object { ... }` returns `$null` (not an empty array `@()`) when no items match. Calling `.Count` on `$null` throws `The property 'Count' cannot be found on this object`. Also affects `ForEach-Object` and other pipeline cmdlets. Note: `.Count` on a single non-null object also throws since most objects lack this property.
+**Fix:** Always wrap pipeline output in `@()` when the result will be tested with `.Count` or iterated:
+
+```powershell
+# Bad -- crashes when 0 or 1 results
+$dirs = Get-ChildItem -Path $path -Directory | Where-Object { Test-Path (Join-Path $_.FullName '.git') }
+if ($dirs.Count -eq 0) { ... }  # throws on $null
+
+# Good
+$dirs = @(Get-ChildItem -Path $path -Directory | Where-Object { Test-Path (Join-Path $_.FullName '.git') })
+if ($dirs.Count -eq 0) { ... }  # always safe
+```
+
+**See also:** KG#104 (PowerShell tool and variable gotchas)


### PR DESCRIPTION
## Summary

Four learnings captured from the 2026-03-21 session (PR #494 merge + stable promote + dispatcher restart).

- **KG#178**: Git worktree `.git` pointer breaks when main repo is moved to a new path — update the absolute `gitdir:` path in `<worktree>/.git`
- **KG#179**: PowerShell `Get-ChildItem | Where-Object` returns `$null` (not `@()`) on 0 matches — `.Count` throws; always wrap in `@()`
- **AP#145**: `sync.ps1 -Promote` only fast-forwards stable to dev branch tip; GitHub merge creates a new commit not in dev — always reset stable to `origin/main` after PR merge
- **AP#146**: Flat project discovery breaks after family-folder restructure — search 2 levels deep

Synapset: IDs 752-755 (pool: devkit)

## Test plan

- [x] `entry_count` frontmatter updated (KG: 37→39, AP: 58→60)
- [x] CI markdownlint, metadata validator pass
- [ ] CI lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)