### PR TITLE
fix(conformance): address 2026-03-21 audit gaps

### DIFF
--- a/.devkit.json
+++ b/.devkit.json
@@ -1,0 +1,9 @@
+{
+  "project": "devkit",
+  "tier": "full",
+  "profile": "devkit",
+  "family": "Toolkit",
+  "managed_by": null,
+  "created": "2026-03-21",
+  "devkit_version": "2.7.1"
+}

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,184 @@
+# Release Gate
+#
+# Evaluates release-please PRs and auto-merges based on release tier.
+# Language-agnostic — only reads release-please manifest and git history.
+#
+# Prerequisites:
+#   - release-please configured (see release-please-config.json template)
+#   - .release-please-manifest.json at repo root
+#   - Auto-merge enabled on the repo:
+#     gh api repos/OWNER/REPO -X PATCH -f allow_auto_merge=true
+#   - retrigger-ci.yml deployed (see retrigger-ci.yml template)
+#
+# Release tiers:
+#   Immediate  — Critical/security fix (fix!:, CVE, breaking change) → auto-merge
+#   Threshold  — Minor+ version bump OR 5+ accumulated fixes → auto-merge
+#   Batched    — Below threshold → labeled, waits for manual merge
+#
+# Customization:
+#   - Fix threshold: change the "5" in FIX_COUNT comparison (line ~67)
+#   - Merge method: change --squash to --merge or --rebase (line ~116)
+
+name: Release Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  evaluate:
+    name: Evaluate Release
+    if: >-
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    runs-on: ubuntu-latest
+    outputs:
+      decision: ${{ steps.gate.outputs.decision }}
+      reason: ${{ steps.gate.outputs.reason }}
+      version_from: ${{ steps.gate.outputs.version_from }}
+      version_to: ${{ steps.gate.outputs.version_to }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Evaluate release criteria
+        id: gate
+        run: |
+          set -euo pipefail
+
+          # Get version info
+          CURRENT=$(git show origin/main:.release-please-manifest.json | jq -r '."."')
+          NEW=$(jq -r '."."' .release-please-manifest.json)
+          echo "version_from=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "version_to=$NEW" >> "$GITHUB_OUTPUT"
+
+          CUR_MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+          CUR_MINOR=$(echo "$CURRENT" | cut -d. -f2)
+          NEW_MAJOR=$(echo "$NEW" | cut -d. -f1)
+          NEW_MINOR=$(echo "$NEW" | cut -d. -f2)
+
+          # Get commits since last release tag
+          LAST_TAG=$(git describe --tags --abbrev=0 origin/main 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ]; then
+            COMMIT_LOG=$(git log "${LAST_TAG}..origin/main" --format="%s" 2>/dev/null || echo "")
+          else
+            COMMIT_LOG=$(git log origin/main --format="%s" 2>/dev/null || echo "")
+          fi
+
+          # Count changelog entries by type
+          FEAT_COUNT=$(echo "$COMMIT_LOG" | grep -c "^feat" || true)
+          FIX_COUNT=$(echo "$COMMIT_LOG" | grep -c "^fix" || true)
+          TOTAL=$((FEAT_COUNT + FIX_COUNT))
+
+          echo "Commits since $LAST_TAG: feat=$FEAT_COUNT fix=$FIX_COUNT total=$TOTAL"
+          echo "Version: $CURRENT -> $NEW"
+
+          # Tier 1: Immediate — critical/security fix
+          HAS_CRITICAL=false
+          if echo "$COMMIT_LOG" | grep -qiE '^fix!:|BREAKING CHANGE'; then
+            HAS_CRITICAL=true
+          fi
+          if echo "$COMMIT_LOG" | grep -qiE 'CVE-|security|vulnerability|critical'; then
+            HAS_CRITICAL=true
+          fi
+
+          if [ "$HAS_CRITICAL" = "true" ]; then
+            echo "decision=immediate" >> "$GITHUB_OUTPUT"
+            echo "reason=Critical or security fix detected" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Tier 2: Threshold — minor/major bump OR 5+ accumulated fixes
+          if [ "$NEW_MAJOR" -gt "$CUR_MAJOR" ]; then
+            echo "decision=threshold" >> "$GITHUB_OUTPUT"
+            echo "reason=Major version bump ($CURRENT -> $NEW)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$NEW_MINOR" -gt "$CUR_MINOR" ]; then
+            echo "decision=threshold" >> "$GITHUB_OUTPUT"
+            echo "reason=Minor version bump with $FEAT_COUNT feature(s) ($CURRENT -> $NEW)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$FIX_COUNT" -ge 5 ]; then
+            echo "decision=threshold" >> "$GITHUB_OUTPUT"
+            echo "reason=$FIX_COUNT bug fixes accumulated ($CURRENT -> $NEW)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Below threshold — stay batched
+          echo "decision=batched" >> "$GITHUB_OUTPUT"
+          echo "reason=Patch only with $TOTAL change(s), below threshold ($CURRENT -> $NEW)" >> "$GITHUB_OUTPUT"
+
+      - name: Label PR with decision
+        run: |
+          DECISION="${{ steps.gate.outputs.decision }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          # Remove old release labels
+          gh pr edit "$PR_NUMBER" --remove-label "release:auto" 2>/dev/null || true
+          gh pr edit "$PR_NUMBER" --remove-label "release:batched" 2>/dev/null || true
+
+          if [ "$DECISION" = "immediate" ] || [ "$DECISION" = "threshold" ]; then
+            gh label create "release:auto" --color "0E8A16" --description "Auto-release approved" --force 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --add-label "release:auto"
+          else
+            gh label create "release:batched" --color "FBCA04" --description "Batched, waiting for threshold" --force 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --add-label "release:batched"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post decision comment
+        run: |
+          DECISION="${{ steps.gate.outputs.decision }}"
+          REASON="${{ steps.gate.outputs.reason }}"
+          FROM="${{ steps.gate.outputs.version_from }}"
+          TO="${{ steps.gate.outputs.version_to }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          if [ "$DECISION" = "immediate" ] || [ "$DECISION" = "threshold" ]; then
+            ICON="+"
+            ACTION="Auto-merge enabled."
+          else
+            ICON="*"
+            ACTION="Waiting for more changes or manual merge."
+          fi
+
+          BODY=$(cat <<EOF
+          ### $ICON Release Gate: \`$DECISION\`
+
+          **Version**: $FROM -> $TO
+          **Reason**: $REASON
+          **Action**: $ACTION
+          EOF
+          )
+
+          # Delete previous bot gate comments to avoid spam
+          gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("Release Gate"))) | .id' \
+            | xargs -I{} gh api -X DELETE "repos/${{ github.repository }}/issues/comments/{}" 2>/dev/null || true
+
+          gh pr comment "$PR_NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  auto-merge:
+    name: Auto-merge Release
+    needs: evaluate
+    if: needs.evaluate.outputs.decision == 'immediate' || needs.evaluate.outputs.decision == 'threshold'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        run: |
+          gh pr merge "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --squash --auto
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/retrigger-ci.yml
+++ b/.github/workflows/retrigger-ci.yml
@@ -1,0 +1,72 @@
+# Re-trigger CI
+#
+# Fixes a GitHub Actions race condition where release-please branch
+# updates don't always trigger CI (pull_request: synchronize event
+# sometimes doesn't fire on workflow-generated commits).
+#
+# How it works:
+#   1. Triggers after Release Please workflow completes
+#   2. Finds the open release-please PR (if any)
+#   3. Checks if CI checks are present on the current HEAD
+#   4. If missing, closes and reopens the PR to force CI re-trigger
+#
+# Prerequisites:
+#   - release-please configured (see release-please-config.json template)
+#   - Auto-merge enabled on the repo:
+#     gh api repos/OWNER/REPO -X PATCH -f allow_auto_merge=true
+
+name: Re-trigger CI
+
+on:
+  workflow_run:
+    workflows: ["Release Please"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  retrigger:
+    name: Re-trigger Stale Release PR
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Find and re-trigger release PR
+        run: |
+          set -euo pipefail
+
+          # Find open release-please PR
+          PR_NUMBER=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head "release-please--branches--main" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open release-please PR found"
+            exit 0
+          fi
+
+          echo "Found release-please PR #$PR_NUMBER"
+
+          # Check if CI checks exist on current HEAD
+          # Replace "Build" with your CI job name
+          CI_STATUS=$(gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json statusCheckRollup \
+            --jq '[.statusCheckRollup[] | select(.name == "Build")] | length')
+
+          if [ "$CI_STATUS" -gt 0 ]; then
+            echo "CI checks already present, no action needed"
+            exit 0
+          fi
+
+          echo "No CI checks found, re-triggering via close/reopen..."
+          gh pr close "$PR_NUMBER" --repo "${{ github.repository }}"
+          sleep 2
+          gh pr reopen "$PR_NUMBER" --repo "${{ github.repository }}"
+          echo "PR #$PR_NUMBER re-opened, CI should trigger"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/Repair-DevkitEnrollment.ps1
+++ b/scripts/Repair-DevkitEnrollment.ps1
@@ -1,0 +1,182 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Creates missing .devkit.json enrollment markers across all DevSpace projects.
+
+.DESCRIPTION
+    Discovers all git projects under devspacePath (2-level: direct and family-folder).
+    For each project missing .devkit.json, creates the marker with auto-detected
+    profile (stack), family (parent directory), and current devkit version.
+
+    Run with -DryRun first to preview. Run without -DryRun to write files.
+    After running, commit the .devkit.json in each project's repo individually.
+
+.PARAMETER DryRun
+    Preview changes without writing any files.
+
+.PARAMETER Force
+    Overwrite existing .devkit.json files (default: skip existing).
+
+.EXAMPLE
+    pwsh scripts/Repair-DevkitEnrollment.ps1 -DryRun
+    pwsh scripts/Repair-DevkitEnrollment.ps1
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$DryRun,
+    [switch]$Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+$configPath = Join-Path $HOME '.devkit-config.json'
+if (-not (Test-Path $configPath)) {
+    Write-Error "~/.devkit-config.json not found"
+    exit 1
+}
+$config = Get-Content $configPath -Raw | ConvertFrom-Json
+$devspacePath = $config.devspacePath
+
+$versionFile = Join-Path $PSScriptRoot '..' 'VERSION'
+$devkitVersion = (Get-Content $versionFile -Raw -ErrorAction SilentlyContinue).Trim()
+if (-not $devkitVersion) { $devkitVersion = 'unknown' }
+
+$today = (Get-Date).ToString('yyyy-MM-dd')
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+function Get-ProjectProfile {
+    param([string]$ProjectPath)
+    $stacks = @()
+    if (Test-Path (Join-Path $ProjectPath 'go.mod')) { $stacks += 'go' }
+    if (Test-Path (Join-Path $ProjectPath 'package.json')) { $stacks += 'node' }
+    if (Test-Path (Join-Path $ProjectPath 'Cargo.toml')) { $stacks += 'rust' }
+    # Check root and one level deep for .csproj (handles src/ layout)
+    $csprojFound = @(Get-ChildItem -Path $ProjectPath -Filter '*.csproj' -Recurse -Depth 2 -ErrorAction SilentlyContinue)
+    if ($csprojFound.Count -gt 0) { $stacks += 'dotnet' }
+    # Docker Desktop extension detection
+    $metadataJson = Join-Path $ProjectPath 'metadata.json'
+    if ((Test-Path $metadataJson) -and (Test-Path (Join-Path $ProjectPath 'Dockerfile'))) {
+        # Replace node with node-extension if it has Docker extension metadata
+        $stacks = @($stacks | Where-Object { $_ -ne 'node' })
+        $stacks += 'node-extension'
+    }
+    if ($stacks.Count -eq 0) { return 'unknown' }
+    return ($stacks -join '-')
+}
+
+function Write-Step { param([string]$msg) Write-Host "  $msg" }
+function Write-OK   { param([string]$msg) Write-Host "  [+] $msg" -ForegroundColor Green }
+function Write-Warn { param([string]$msg) Write-Host "  [~] $msg" -ForegroundColor Yellow }
+function Write-Skip { param([string]$msg) Write-Host "  [-] $msg" -ForegroundColor DarkGray }
+
+# ---------------------------------------------------------------------------
+# Discover projects (2-level)
+# ---------------------------------------------------------------------------
+
+$excludedFamilies = @('.templates', '.shared-vscode', '.coordination', 'research', 'archive')
+$projects = @()
+
+foreach ($familyDir in Get-ChildItem -Path $devspacePath -Directory) {
+    if ($excludedFamilies -contains $familyDir.Name) { continue }
+
+    # Direct project (family IS the project)
+    if (Test-Path (Join-Path $familyDir.FullName '.git')) {
+        $projects += [PSCustomObject]@{
+            Name   = $familyDir.Name
+            Path   = $familyDir.FullName
+            Family = (Split-Path $devspacePath -Leaf)
+        }
+        continue
+    }
+
+    # Family folder — scan children
+    foreach ($projDir in Get-ChildItem -Path $familyDir.FullName -Directory -ErrorAction SilentlyContinue) {
+        if (Test-Path (Join-Path $projDir.FullName '.git')) {
+            $projects += [PSCustomObject]@{
+                Name   = $projDir.Name
+                Path   = $projDir.FullName
+                Family = $familyDir.Name
+            }
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "Repair DevKit Enrollment" -ForegroundColor Cyan
+Write-Host "------------------------" -ForegroundColor DarkGray
+Write-Host "  DevSpace:       $devspacePath"
+Write-Host "  DevKit version: $devkitVersion"
+Write-Host "  Projects found: $($projects.Count)"
+if ($DryRun) { Write-Host "  Mode:           DRY-RUN (no files written)" -ForegroundColor Yellow }
+Write-Host ""
+
+$created = 0
+$skipped = 0
+$updated = 0
+
+foreach ($proj in $projects) {
+    $markerPath = Join-Path $proj.Path '.devkit.json'
+    $exists     = Test-Path $markerPath
+    $profile    = Get-ProjectProfile -ProjectPath $proj.Path
+
+    if ($exists -and -not $Force) {
+        Write-Skip "$($proj.Family)/$($proj.Name) — already enrolled (skip, use -Force to overwrite)"
+        $skipped++
+        continue
+    }
+
+    $marker = [ordered]@{
+        project        = $proj.Name
+        tier           = 'full'
+        profile        = $profile
+        family         = $proj.Family
+        managed_by     = $null
+        created        = $today
+        devkit_version = $devkitVersion
+    }
+
+    $json = $marker | ConvertTo-Json -Depth 2
+
+    if ($DryRun) {
+        if ($exists) {
+            Write-Warn "$($proj.Family)/$($proj.Name) — would UPDATE .devkit.json (profile: $profile)"
+        } else {
+            Write-OK "$($proj.Family)/$($proj.Name) — would CREATE .devkit.json (profile: $profile)"
+        }
+    } else {
+        Set-Content -Path $markerPath -Value $json -Encoding UTF8
+        if ($exists) {
+            Write-Warn "$($proj.Family)/$($proj.Name) — UPDATED .devkit.json"
+            $updated++
+        } else {
+            Write-OK "$($proj.Family)/$($proj.Name) — CREATED .devkit.json"
+            $created++
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "Summary" -ForegroundColor Cyan
+Write-Host "-------" -ForegroundColor DarkGray
+if ($DryRun) {
+    Write-Host "  Would create: $($projects.Count - $skipped)"
+    Write-Host "  Would skip:   $skipped (already enrolled)"
+} else {
+    Write-Host "  Created: $created"
+    Write-Host "  Updated: $updated"
+    Write-Host "  Skipped: $skipped"
+    if ($created -gt 0 -or $updated -gt 0) {
+        Write-Host ""
+        Write-Host "Next: commit .devkit.json in each project repo individually." -ForegroundColor Yellow
+        Write-Host "  git -C <project> add .devkit.json && git -C <project> commit -m 'chore: add DevKit enrollment marker'"
+    }
+}

--- a/setup/legacy/verify.sh
+++ b/setup/legacy/verify.sh
@@ -52,7 +52,7 @@ done
 
 echo ""
 echo "Verifying individual skills..."
-for skill in autolearn bash-linux code-review conformance-audit devkit-sync docker-containerization go-development manage-github-issues metrics plan-review powershell-windows quality-control react-frontend-development requirements-generator rules-compact samverk-checkout samverk-dispatch security-review server-management setup-github-actions skill-audit synapset systematic-debugging webapp-testing windows-development; do
+for skill in autolearn bash-linux code-review conformance-audit devkit-sync docker-containerization go-development manage-github-issues metrics plan-review powershell-windows quality-control react-frontend-development requirements-generator rules-compact samverk-checkout samverk-dispatch security-review server-management setup-github-actions skill-audit skill-template skills-dashboard synapset systematic-debugging webapp-testing windows-development; do
     check "$CLAUDE_HOME/skills/$skill/SKILL.md" "$skill skill"
 done
 


### PR DESCRIPTION
## Summary

Addresses conformance gaps found in the 2026-03-21 full audit (22-point checklist).

### Fixed in this PR

| Check | Fix |
|-------|-----|
| #13 Release gate | Added `.github/workflows/release-gate.yml` from template |
| #15 Retrigger CI | Added `.github/workflows/retrigger-ci.yml` from template |
| #22 Enrollment marker | Added `.devkit.json` |
| verify.sh skill count | Added `skill-template` and `skills-dashboard` (was 25, now 27) |

### New tooling: `Repair-DevkitEnrollment.ps1`

Creates `.devkit.json` in all 16 remaining DevSpace projects with auto-detected profile, family, and devkit_version.

```powershell
pwsh scripts/Repair-DevkitEnrollment.ps1 -DryRun  # preview
pwsh scripts/Repair-DevkitEnrollment.ps1           # write files
```

### Remaining cross-project gaps (not fixed here)

- **15 projects** need `.devkit.json` -- use `Repair-DevkitEnrollment.ps1`
- **Synapset** (Gitea: `samverk-admin/synapset`) needs release-please + release-gate + retrigger-ci workflows
- **4 projects** missing LICENSE: Timberborn-Mods, claude-sync, mccrl21, herbhall.net
- **16/17 projects** missing retrigger-ci (only samverk has it)
- **10+ projects** missing nightly workflow

### Already correct (audit agent misread)

README skill count 27 ✓, AP/KG entry counts ✓, rules file sizes ✓, Action versions v3+ ✓

## Test plan

- [x] Dry-run: 15 projects would-create, devkit skips (already enrolled)
- [x] verify.sh: 27 skills now matches claude/skills/ count
- [ ] CI: markdownlint, PSScriptAnalyzer, workflow validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)