### PR TITLE
feat(workspace): VS Code workspace convention, orphan recovery, and ongoing sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Setup creates symlinks from `~/.claude/` to the DevKit clone (or copies files in
 | Component | Count | Location |
 |-----------|-------|----------|
 | Rules (auto-loaded every session) | 11 files | `claude/rules/` |
-| Skills (invoke with `/skill-name`) | 27 skills | `claude/skills/` |
+| Skills (invoke with `/skill-name`) | 28 skills | `claude/skills/` |
 | Agent templates | 7 agents | `claude/agents/` |
 | Claude Code hooks (SessionStart, SessionStop, SubagentVerify) | 3 | `claude/hooks/` |
 | Git hooks (pre-push, pre-commit, commit-msg) | 3 | `git-templates/hooks/` |
@@ -62,7 +62,7 @@ See [Settings Strategy](docs/settings-strategy.md) for the two-layer permission 
 
 | Directory | Purpose |
 |-----------|---------|
-| `claude/` | Global Claude Code config — CLAUDE.md, 11 rules files (112 patterns), 27 skills, 7 agent templates, 6 hooks |
+| `claude/` | Global Claude Code config — CLAUDE.md, 11 rules files (112 patterns), 28 skills, 7 agent templates, 6 hooks |
 | `devspace/` | Workspace shared configs — .editorconfig, .markdownlint.json, VS Code fragments |
 | `docs/` | Human-readable guides — architecture decisions, profile format spec |
 | `machine/` | Machine state snapshots — VS Code extensions, tool versions |

--- a/claude/skills/workspace/SKILL.md
+++ b/claude/skills/workspace/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: workspace
+description: VS Code workspace management — scaffold, check health, repair orphans, and sync extension recommendations across DevKit-managed projects.
+user_invocable: true
+---
+
+# DevKit Workspace
+
+Manage VS Code workspace files across DevKit-managed projects. All operations follow the convention defined in `docs/vscode-workspaces.md`.
+
+<essential_principles>
+
+**One workspace file per project, at the project root.** Canonical location: `<project-root>/<project-name>.code-workspace`. The `folders[0].path` is always `.`.
+
+**Stack-detect, then merge.** Settings and extensions come from `devspace/shared-vscode/` fragments. Projects own their copies and can add project-specific extensions — the sync scripts preserve those additions.
+
+**On-demand only.** Workspace sync is not in any automatic hook. Run explicitly to keep things clean.
+
+</essential_principles>
+
+<intake>
+
+**workspace triggered.** What do you need?
+
+1. **Check** -- Audit all registered projects for missing, misplaced, or stale workspace files
+2. **Scaffold** -- Create a workspace file for the current project (or a specified path)
+3. **Repair** -- Fix orphaned or stale workspace files across D:\DevSpace\
+4. **Sync all** -- Sync extension recommendations for all registered projects
+
+Type a number, keyword, or **skip** to dismiss.
+
+</intake>
+
+<routing>
+
+| Input | Workflow |
+|-------|----------|
+| 1, check, audit, health | `workflows/check.md` |
+| 2, scaffold, create, new | `workflows/scaffold.md` |
+| 3, repair, fix, orphan | `workflows/repair.md` |
+| 4, sync, sync-all, extensions | `workflows/sync-all.md` |
+| skip, dismiss, cancel, exit | End skill — no action |
+
+</routing>

--- a/claude/skills/workspace/workflows/check.md
+++ b/claude/skills/workspace/workflows/check.md
@@ -1,0 +1,37 @@
+# Workspace Health Check
+
+Audits all registered projects for workspace file issues without modifying anything.
+
+## Steps
+
+1. Read `~/.devkit-registry.json` to get the project list.
+
+2. For each registered project, check:
+   - Does `<project-root>/<project-name>.code-workspace` exist?
+   - Is `folders[0].path` set to `.`?
+   - Does the `extensions.recommendations` array have any entries?
+   - Does the registry entry have a `vscodeWorkspace.lastSynced` timestamp?
+
+3. Classify each project:
+   - **clean**: workspace exists, `folders[0].path = "."`, extensions present
+   - **missing**: no `.code-workspace` file exists
+   - **stale-path**: workspace exists but `folders[0].path` is not `.`
+   - **no-extensions**: workspace exists but `extensions.recommendations` is empty
+   - **never-synced**: workspace exists but `vscodeWorkspace.lastSynced` is null
+
+4. Report findings in a table:
+
+   | Project | Path | Status | Last Synced |
+   |---------|------|--------|-------------|
+   | SubNetree | D:\DevSpace\SubNetree | clean | 2026-03-21 |
+   | Runbooks | D:\DevSpace\Runbooks | missing | — |
+
+5. Suggest next steps based on findings:
+   - Missing → run `/workspace repair` or scaffold individually
+   - Stale-path → run `/workspace repair`
+   - Never-synced → run `/workspace sync-all`
+
+## Notes
+
+- This workflow is read-only. No files are modified.
+- If the registry is missing, report it and suggest running `devkit-sync` to register projects.

--- a/claude/skills/workspace/workflows/repair.md
+++ b/claude/skills/workspace/workflows/repair.md
@@ -1,0 +1,47 @@
+# Repair Workspace Files
+
+Runs `scripts/Repair-WorkspaceFiles.ps1` to locate, classify, and repair orphaned or stale workspace files under `D:\DevSpace\`.
+
+## Steps
+
+1. Locate the DevKit `scripts/` directory. If DevKit is installed at `~/.devkit-stable/`, the script is at:
+
+   ```text
+   C:\Users\<user>\.devkit-stable\scripts\Repair-WorkspaceFiles.ps1
+   ```
+
+2. Run a dry-run first to show what would change:
+
+   ```powershell
+   pwsh -File "$env:USERPROFILE\.devkit-stable\scripts\Repair-WorkspaceFiles.ps1" -WhatIf
+   ```
+
+3. Show the dry-run output to the user and ask for confirmation before applying.
+
+4. If the user confirms, run without `-WhatIf` to apply repairs:
+
+   ```powershell
+   pwsh -File "$env:USERPROFILE\.devkit-stable\scripts\Repair-WorkspaceFiles.ps1"
+   ```
+
+5. Report the summary (valid / misplaced / stale-path / missing / repaired).
+
+6. For any scaffolded (`missing`) files, remind the user to:
+   - Review the scaffolded workspace file
+   - Merge settings from `devspace/shared-vscode/<stack>.jsonc` into the `settings` block
+   - Run `/workspace sync-all` to populate extension recommendations
+
+## What the Script Repairs
+
+| Classification | Action |
+|----------------|--------|
+| `valid` | No change |
+| `misplaced` | Moves workspace to `<project-root>/<project-name>.code-workspace`, rewrites `folders[0].path` to `.` |
+| `stale-path` | Rewrites `folders[0].path` to `.` in place |
+| `missing` | Scaffolds a new workspace from `project-templates/workspace.code-workspace` |
+
+## Notes
+
+- The script requires the DevKit registry (`~/.devkit-registry.json`) to detect missing workspace files. If the registry is absent, it still repairs existing files but cannot detect missing ones.
+- Always run with `-WhatIf` first on production machines to preview changes.
+- The script does not modify `valid` files.

--- a/claude/skills/workspace/workflows/scaffold.md
+++ b/claude/skills/workspace/workflows/scaffold.md
@@ -1,0 +1,47 @@
+# Scaffold Workspace
+
+Creates a new `.code-workspace` file for a project using the DevKit template with the correct stack fragment merged in.
+
+## Steps
+
+1. Determine the target project path:
+   - If the user specified a path, use that.
+   - Otherwise, use the current working directory as the project root.
+
+2. Detect the project name from the directory name (e.g., `SubNetree` from `D:\DevSpace\SubNetree`).
+
+3. Check whether `<project-root>/<project-name>.code-workspace` already exists:
+   - If it exists and is valid, report it and ask whether to overwrite or abort.
+   - If it exists but has issues (stale-path, no extensions), offer to repair instead.
+
+4. Detect the stack profile from the project root:
+   - `go.mod` present → `go`
+   - `package.json` present → `typescript`
+   - `Cargo.toml` present → `rust` (note: no fragment yet, falls back to base)
+   - `*.csproj` present → `csharp` (note: no fragment yet, falls back to base)
+   - None of the above → `base`
+
+5. Load the matching settings fragment from `devspace/shared-vscode/<stack>.jsonc` (if available).
+
+6. Load extension recommendations from `devspace/shared-vscode/extensions.jsonc` for the detected stack plus general extensions.
+
+7. Create the workspace file at the canonical path:
+   - `folders[0].path` = `.`
+   - `settings` = merged from stack fragment (or empty object if no fragment)
+   - `extensions.recommendations` = stack + general extensions
+
+8. Update `~/.devkit-registry.json` to set:
+   - `vscodeWorkspace.path` = absolute path to the new workspace file
+   - `vscodeWorkspace.lastSynced` = current ISO 8601 timestamp
+   - `vscodeWorkspace.stackProfile` = detected stack
+
+9. Report the created file path and remind the user to:
+   - Review settings in the workspace file
+   - Remove any settings that duplicate VS Code User Settings
+   - Open VS Code using the new workspace file: `code <project-name>.code-workspace`
+
+## Notes
+
+- For `rust` and `csharp` stacks, no settings fragment exists yet — the workspace is scaffolded with an empty settings block and general extensions only.
+- The scaffolded file is a starting point. Projects own their copy and can diverge from the template as needed.
+- If `devspace/shared-vscode/extensions.jsonc` is not found relative to the DevKit root, extensions are scaffolded as an empty array with a warning.

--- a/claude/skills/workspace/workflows/sync-all.md
+++ b/claude/skills/workspace/workflows/sync-all.md
@@ -1,0 +1,50 @@
+# Sync All Workspace Extensions
+
+Runs `scripts/Sync-WorkspaceExtensions.ps1` against all registered projects to ensure extension recommendations reflect the current stack fragments in `devspace/shared-vscode/`.
+
+## Steps
+
+1. Locate the DevKit `scripts/` directory:
+
+   ```text
+   C:\Users\<user>\.devkit-stable\scripts\Sync-WorkspaceExtensions.ps1
+   ```
+
+2. Run a dry-run first to show what would change:
+
+   ```powershell
+   pwsh -File "$env:USERPROFILE\.devkit-stable\scripts\Sync-WorkspaceExtensions.ps1" -WhatIf
+   ```
+
+3. Show the dry-run output. If changes are needed, ask for confirmation before applying.
+
+4. If the user confirms (or if there are no changes), run without `-WhatIf`:
+
+   ```powershell
+   pwsh -File "$env:USERPROFILE\.devkit-stable\scripts\Sync-WorkspaceExtensions.ps1"
+   ```
+
+5. Report the summary (clean / updated / missing / errors).
+
+6. Verify that `vscodeWorkspace.lastSynced` was updated in `~/.devkit-registry.json` for each touched project.
+
+7. If any projects show as `missing` (no workspace file), suggest running `/workspace repair` first.
+
+## What the Script Does
+
+For each registered project:
+
+1. Detects the stack (`go`, `typescript`, `rust`, `base`) from files at the project root.
+2. Loads stack + general extension recommendations from `devspace/shared-vscode/extensions.jsonc`.
+3. Merges them into `extensions.recommendations` in the project's `.code-workspace`.
+   - Extensions already in the fragment: kept as-is.
+   - Project-specific extensions not in the fragment: preserved.
+   - Extensions that were removed from the fragment: removed from the workspace file.
+4. Updates `vscodeWorkspace.lastSynced` and `vscodeWorkspace.stackProfile` in the registry.
+
+## Notes
+
+- Only registered projects (in `~/.devkit-registry.json`) are synced.
+- Projects with no `.code-workspace` file are reported but not modified — run `/workspace repair` first.
+- Project-specific extension additions that are not in the DevKit fragment are always preserved.
+- This workflow does not touch `settings` in workspace files — only `extensions.recommendations`.

--- a/devspace/shared-vscode/README.md
+++ b/devspace/shared-vscode/README.md
@@ -4,8 +4,10 @@ Reusable VS Code setting snippets for project workspace files. These are **NOT a
 
 ## How to Use
 
+**Manual (copy-paste):**
+
 1. Open the fragment file relevant to your project type
-2. Copy the settings you need into your project's `.code-workspace` file or `.vscode/settings.json`
+2. Copy the settings you need into your project's `.code-workspace` file
 3. Adjust paths and project-specific values
 
 ```jsonc
@@ -15,10 +17,16 @@ Reusable VS Code setting snippets for project workspace files. These are **NOT a
         // Paste from typescript.jsonc, go.jsonc, etc.
     },
     "extensions": {
-        // Paste from extensions.jsonc
+        "recommendations": [
+            // Paste from extensions.jsonc for your stack
+        ]
     }
 }
 ```
+
+**Automated (DevKit skill):**
+
+Use `/workspace scaffold` to create a new workspace file with the correct fragment merged in automatically, or `/workspace sync-all` to sync extension recommendations across all registered projects. See `docs/vscode-workspaces.md` for full details on the workspace convention and automation tools.
 
 ## Important
 
@@ -32,4 +40,6 @@ Reusable VS Code setting snippets for project workspace files. These are **NOT a
 |----------|--------------------|
 | `typescript.jsonc` | TypeScript, React, Node.js |
 | `go.jsonc` | Go |
-| `extensions.jsonc` | Common extension recommendations by project type |
+| `extensions.jsonc` | Common extension recommendations by project type (all stacks) |
+
+Rust and C# projects fall back to base extensions only — no settings fragment exists yet. See `docs/vscode-workspaces.md` for the stack detection heuristic.

--- a/docs/project-registry-schema.md
+++ b/docs/project-registry-schema.md
@@ -30,6 +30,11 @@ The project registry tracks which projects on a machine consume DevKit configura
       "samverk": {
         "managed": "boolean",
         "phase": "string (current lifecycle phase)"
+      },
+      "vscodeWorkspace": {
+        "path": "string (absolute path to .code-workspace file, or null if not present)",
+        "lastSynced": "string (ISO 8601 datetime, or null)",
+        "stackProfile": "string (go | typescript | rust | base — detected or overridden stack)"
       }
     }
   ]
@@ -53,6 +58,10 @@ The project registry tracks which projects on a machine consume DevKit configura
 | `samverk` | object? | Optional Samverk overlay status (present only for Samverk-managed projects) |
 | `samverk.managed` | boolean | Whether the Samverk overlay is applied |
 | `samverk.phase` | string | Current lifecycle phase (read from `.samverk/project.yaml`) |
+| `vscodeWorkspace` | object? | Optional VS Code workspace tracking (populated by `devkit workspace sync`) |
+| `vscodeWorkspace.path` | string\|null | Absolute path to `.code-workspace` file, or `null` if not present |
+| `vscodeWorkspace.lastSynced` | string\|null | Timestamp of last extension sync (ISO 8601 datetime), or `null` |
+| `vscodeWorkspace.stackProfile` | string | Detected or overridden stack: `go`, `typescript`, `rust`, or `base` |
 
 ## Example
 
@@ -72,6 +81,11 @@ The project registry tracks which projects on a machine consume DevKit configura
       "samverk": {
         "managed": true,
         "phase": "execution"
+      },
+      "vscodeWorkspace": {
+        "path": "D:\\DevSpace\\SubNetree\\subnetree.code-workspace",
+        "lastSynced": "2026-03-21T10:00:00Z",
+        "stackProfile": "go"
       }
     },
     {

--- a/docs/vscode-workspaces.md
+++ b/docs/vscode-workspaces.md
@@ -1,0 +1,107 @@
+# VS Code Workspace Convention
+
+Defines how DevKit-managed projects structure, locate, and maintain their VS Code workspace files.
+
+## Canonical Location
+
+One workspace file per project, at the project root, named after the project:
+
+```text
+<project-root>/<project-name>.code-workspace
+```
+
+Examples:
+
+- `D:\DevSpace\SubNetree\subnetree.code-workspace`
+- `D:\DevSpace\Runbooks\runbooks.code-workspace`
+- `D:\DevSpace\Toolkit\samverk\samverk.code-workspace`
+
+## Required Structure
+
+Every DevKit-managed workspace file must have these three top-level sections:
+
+```jsonc
+{
+    "folders": [
+        { "path": "." }
+    ],
+    "settings": {
+        // Stack-specific settings merged from devspace/shared-vscode/<stack>.jsonc
+        // Do not duplicate User Settings or .editorconfig values
+    },
+    "extensions": {
+        "recommendations": [
+            // Merged from devspace/shared-vscode/extensions.jsonc for this stack
+        ]
+    }
+}
+```
+
+The `folders` array always contains a single entry pointing to `.` (the project root). Multi-root workspaces are out of scope for DevKit-managed projects.
+
+## Stack Detection Heuristic
+
+When scaffolding or syncing a workspace, the stack is detected from files at the project root:
+
+| Indicator file | Stack profile | Fragment source |
+|---|---|---|
+| `go.mod` | `go` | `devspace/shared-vscode/go.jsonc` |
+| `package.json` | `typescript` | `devspace/shared-vscode/typescript.jsonc` |
+| `Cargo.toml` | `rust` | `devspace/shared-vscode/rust.jsonc` (stub — falls back to base) |
+| `*.csproj` or `*.sln` | `csharp` | none yet — falls back to base |
+| none of the above | `base` | no settings fragment; base extensions only |
+
+For projects with multiple indicators (e.g., a Go backend + React frontend), the Go fragment takes precedence. The `stackProfile` field in the registry can be set explicitly to override heuristic detection for polyglot projects.
+
+## Relation to `.vscode/settings.json`
+
+These two files serve different purposes and must not duplicate each other:
+
+| File | Purpose |
+|------|---------|
+| `<project>.code-workspace` | Project-scoped editor configuration — stack settings, extension recommendations |
+| `.vscode/settings.json` | Claude Code project settings — tool permissions, hooks, MCP config |
+
+Workspace-level settings live in `.code-workspace`. `.vscode/settings.json` is reserved for Claude Code and project-specific tool configuration. See `docs/settings-strategy.md` for the full settings hierarchy.
+
+## What NOT to Put in the Workspace File
+
+- **User Settings values**: Font family, theme, auto-save, git auto-fetch — these belong in VS Code User Settings (Tier 1 in `docs/settings-strategy.md`).
+- **`.editorconfig` values**: Indent style, charset, line endings — the `D:\DevSpace\.editorconfig` file handles these via auto-cascade. Do not duplicate them as VS Code settings.
+- **Secrets or credentials**: Workspace files are committed; never put tokens, passwords, or API keys in them.
+
+## `.gitignore` Policy
+
+`.code-workspace` files are committed. They define project-scoped editor configuration that every developer on the project should inherit. Do not add them to `.gitignore`.
+
+## Registry Tracking
+
+The project registry (`~/.devkit-registry.json`) records workspace state for each project. See `docs/project-registry-schema.md` for the `vscodeWorkspace` field definitions.
+
+The `devkit workspace sync` skill reads and updates these fields automatically.
+
+## Automation
+
+| Tool | Purpose |
+|------|---------|
+| `scripts/Repair-WorkspaceFiles.ps1` | One-time recovery: locates, classifies, and repairs orphaned or missing workspace files |
+| `scripts/Sync-WorkspaceExtensions.ps1` | Ongoing sync: ensures extension recommendations reflect the current stack fragments |
+| `/workspace` skill | Claude Code skill for interactive workspace management (check, scaffold, repair, sync-all) |
+
+Run `Repair-WorkspaceFiles.ps1 -WhatIf` first to preview changes before applying.
+
+## Rust Projects
+
+No `rust.jsonc` fragment exists yet. Rust projects fall back to `base` (extensions only, no settings fragment). A future issue will add the fragment when DevKit onboards a Rust project. Until then, document in project CLAUDE.md if project-specific Rust settings are needed.
+
+## Deciding Whether to Add Workspace Sync to Automatic Hooks
+
+**Decision: on-demand only (not automatic).**
+
+Workspace sync is not added to `setup/sync.ps1` or any SessionStart hook. Reasons:
+
+1. Workspace files are committed — unintended automated edits would create noisy commits.
+2. Extension lists are stable; they only change when fragments are updated (infrequent).
+3. On-demand via `/workspace sync-all` provides explicit control with a clear audit trail.
+
+Revisit this decision if the workspace skill shows high manual invocation rate (>2x/week per project).

--- a/project-templates/workspace.code-workspace
+++ b/project-templates/workspace.code-workspace
@@ -1,0 +1,39 @@
+{
+    // DevKit workspace template — see docs/vscode-workspaces.md for the convention
+    //
+    // Usage:
+    //   1. Copy this file to <project-root>/<project-name>.code-workspace
+    //   2. Replace the settings block with the relevant devspace/shared-vscode/<stack>.jsonc fragment
+    //   3. Replace extensions.recommendations with the stack-specific list from
+    //      devspace/shared-vscode/extensions.jsonc
+    //   4. Remove settings that duplicate your VS Code User Settings
+    //
+    // Or use: /workspace scaffold  (DevKit skill — auto-detects stack and merges fragments)
+    "folders": [
+        {
+            "path": "."
+        }
+    ],
+    "settings": {
+        // Merge stack-specific settings from devspace/shared-vscode/<stack>.jsonc here.
+        // Remove this comment block after merging.
+        //
+        // Go projects:         copy from go.jsonc
+        // TypeScript projects: copy from typescript.jsonc
+        // Rust projects:       no fragment yet — leave settings empty
+        // Other/base:          leave settings empty
+    },
+    "extensions": {
+        "recommendations": [
+            // Merge from devspace/shared-vscode/extensions.jsonc for your stack.
+            // Example for a Go project:
+            //   "golang.go",
+            //   "zxh404.vscode-proto3"
+            //
+            // Always include general extensions if not in your global VS Code profile:
+            //   "eamodio.gitlens",
+            //   "davidanson.vscode-markdownlint",
+            //   "editorconfig.editorconfig"
+        ]
+    }
+}

--- a/scripts/Repair-WorkspaceFiles.ps1
+++ b/scripts/Repair-WorkspaceFiles.ps1
@@ -1,0 +1,307 @@
+<#
+.SYNOPSIS
+    Locates, classifies, and repairs VS Code workspace files under D:\DevSpace\.
+
+.DESCRIPTION
+    Scans for .code-workspace files and validates each against the DevKit convention:
+    - Canonical location: <project-root>/<project-name>.code-workspace
+    - folders[0].path must resolve to a real directory containing a .git folder
+
+    Classifies each file as:
+    - valid:     path resolves correctly; workspace is at project root
+    - misplaced: workspace file is not at the project root (left behind after a move)
+    - stale-path: workspace is at the right location but folders[0].path is non-existent
+    - missing:   project is in registry but has no .code-workspace file
+
+    Repairs automatically unless -WhatIf is specified.
+
+.PARAMETER DevSpaceRoot
+    Root directory to scan. Defaults to D:\DevSpace\.
+
+.PARAMETER RegistryPath
+    Path to the devkit registry JSON. Defaults to ~/.devkit-registry.json.
+
+.PARAMETER TemplatePath
+    Path to workspace.code-workspace template. Defaults to the DevKit project-templates location.
+
+.PARAMETER WhatIf
+    Preview changes without applying them.
+
+.EXAMPLE
+    # Dry run
+    pwsh -File devkit/scripts/Repair-WorkspaceFiles.ps1 -WhatIf
+
+    # Apply repairs
+    pwsh -File devkit/scripts/Repair-WorkspaceFiles.ps1
+
+.NOTES
+    See docs/vscode-workspaces.md for the full workspace convention.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$DevSpaceRoot = 'D:\DevSpace',
+    [string]$RegistryPath = (Join-Path $env:USERPROFILE '.devkit-registry.json'),
+    [string]$TemplatePath = '',
+    [switch]$WhatIf
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# -- Resolve template path --
+if (-not $TemplatePath) {
+    $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+    $devkitRoot = Split-Path -Parent $scriptDir
+    $TemplatePath = Join-Path $devkitRoot 'project-templates\workspace.code-workspace'
+}
+
+# -- Helpers --
+
+function Get-WorkspaceFolderPath {
+    param([string]$WorkspaceFile)
+    try {
+        $content = Get-Content $WorkspaceFile -Raw
+        # Strip JSONC comments before parsing
+        $stripped = $content -replace '//[^\r\n]*', '' -replace '/\*[\s\S]*?\*/', ''
+        $json = $stripped | ConvertFrom-Json
+        if ($json.folders -and $json.folders.Count -gt 0) {
+            return $json.folders[0].path
+        }
+    }
+    catch {
+        Write-Warning "  Could not parse $WorkspaceFile : $_"
+    }
+    return $null
+}
+
+function Resolve-WorkspaceFolderPath {
+    param([string]$WorkspaceFile, [string]$FolderPath)
+    $dir = Split-Path -Parent $WorkspaceFile
+    return [System.IO.Path]::GetFullPath((Join-Path $dir $FolderPath))
+}
+
+function Test-GitRoot {
+    param([string]$Path)
+    return (Test-Path $Path) -and (Test-Path (Join-Path $Path '.git'))
+}
+
+function Get-ProjectRootFromWorkspace {
+    param([string]$WorkspaceFile)
+    # Walks up from workspace file to find the first directory containing .git
+    $dir = Split-Path -Parent $WorkspaceFile
+    while ($dir -and (Test-Path $dir)) {
+        if (Test-Path (Join-Path $dir '.git')) {
+            return $dir
+        }
+        $parent = Split-Path -Parent $dir
+        if ($parent -eq $dir) { break }
+        $dir = $parent
+    }
+    return $null
+}
+
+function Detect-StackProfile {
+    param([string]$ProjectRoot)
+    if (Test-Path (Join-Path $ProjectRoot 'go.mod')) { return 'go' }
+    if (Test-Path (Join-Path $ProjectRoot 'package.json')) { return 'typescript' }
+    if (Test-Path (Join-Path $ProjectRoot 'Cargo.toml')) { return 'rust' }
+    $csprojFiles = Get-ChildItem $ProjectRoot -Filter '*.csproj' -ErrorAction SilentlyContinue
+    if ($csprojFiles -or (Test-Path (Join-Path $ProjectRoot '*.sln'))) { return 'csharp' }
+    return 'base'
+}
+
+function New-WorkspaceFromTemplate {
+    param([string]$DestPath, [string]$TemplatePath)
+    if (Test-Path $TemplatePath) {
+        Copy-Item $TemplatePath $DestPath
+    }
+    else {
+        # Minimal fallback if template is missing
+        $minimal = @'
+{
+    "folders": [
+        { "path": "." }
+    ],
+    "settings": {},
+    "extensions": {
+        "recommendations": []
+    }
+}
+'@
+        Set-Content $DestPath $minimal -Encoding UTF8
+    }
+}
+
+# -- Load registry (if available) --
+$registryProjects = @()
+if (Test-Path $RegistryPath) {
+    try {
+        $registry = Get-Content $RegistryPath -Raw | ConvertFrom-Json
+        $registryProjects = $registry.projects
+    }
+    catch {
+        Write-Warning "Could not read registry at $RegistryPath : $_"
+    }
+}
+
+# -- Results --
+$results = @{
+    valid     = [System.Collections.Generic.List[string]]::new()
+    misplaced = [System.Collections.Generic.List[hashtable]]::new()
+    stalePath = [System.Collections.Generic.List[hashtable]]::new()
+    missing   = [System.Collections.Generic.List[string]]::new()
+    repaired  = [System.Collections.Generic.List[string]]::new()
+    errors    = [System.Collections.Generic.List[string]]::new()
+}
+
+Write-Host ''
+Write-Host '== DevKit Workspace Repair ==' -ForegroundColor Cyan
+if ($WhatIf) {
+    Write-Host '   (dry run -- no changes will be made)' -ForegroundColor Yellow
+}
+Write-Host ''
+
+# -- Phase 1: Scan existing .code-workspace files --
+Write-Host 'Scanning for .code-workspace files under ' -NoNewline
+Write-Host $DevSpaceRoot -ForegroundColor White
+Write-Host ''
+
+$workspaceFiles = Get-ChildItem $DevSpaceRoot -Recurse -Filter '*.code-workspace' -ErrorAction SilentlyContinue
+
+foreach ($file in $workspaceFiles) {
+    $filePath = $file.FullName
+    $fileDir  = $file.DirectoryName
+    $fileName = $file.BaseName  # e.g., "subnetree" from "subnetree.code-workspace"
+
+    $folderRelPath = Get-WorkspaceFolderPath $filePath
+    if ($null -eq $folderRelPath) {
+        $results.errors.Add($filePath)
+        Write-Host "  [ERROR]     $filePath" -ForegroundColor Red
+        Write-Host "              Could not parse folders[0].path"
+        continue
+    }
+
+    $resolvedFolder = Resolve-WorkspaceFolderPath $filePath $folderRelPath
+    $folderExists   = Test-Path $resolvedFolder
+    $isGitRoot      = $folderExists -and (Test-GitRoot $resolvedFolder)
+
+    # Is the workspace at the canonical project root?
+    $projectRoot = Get-ProjectRootFromWorkspace $filePath
+    $atProjectRoot = ($projectRoot -ne $null) -and ($fileDir -eq $projectRoot)
+
+    if ($folderExists -and $isGitRoot -and $atProjectRoot) {
+        # valid
+        $results.valid.Add($filePath)
+        Write-Host "  [VALID]     $filePath" -ForegroundColor Green
+    }
+    elseif (-not $folderExists -and $atProjectRoot) {
+        # stale-path: file is at root but folders[0].path does not resolve
+        $results.stalePath.Add(@{ file = $filePath; resolved = $resolvedFolder })
+        Write-Host "  [STALE-PATH] $filePath" -ForegroundColor Yellow
+        Write-Host "               folders[0].path -> $resolvedFolder (not found)"
+
+        if (-not $WhatIf -and $PSCmdlet.ShouldProcess($filePath, 'Rewrite folders[0].path to .')) {
+            # Rewrite folders[0].path to "."
+            $raw = Get-Content $filePath -Raw
+            $raw = $raw -replace '"path"\s*:\s*"[^"]*"', '"path": "."'
+            Set-Content $filePath $raw -Encoding UTF8
+            $results.repaired.Add($filePath)
+            Write-Host "               -> Rewritten to '.' " -ForegroundColor Cyan
+        }
+        elseif ($WhatIf) {
+            Write-Host "               -> Would rewrite folders[0].path to '.'" -ForegroundColor Cyan
+        }
+    }
+    elseif (-not $atProjectRoot) {
+        # misplaced: workspace is not at the project root
+        $canonicalRoot = if ($projectRoot) { $projectRoot } else { $resolvedFolder }
+        $canonicalName = Split-Path -Leaf $canonicalRoot
+        $canonicalDest = Join-Path $canonicalRoot "$canonicalName.code-workspace"
+
+        $results.misplaced.Add(@{ file = $filePath; dest = $canonicalDest; root = $canonicalRoot })
+        Write-Host "  [MISPLACED] $filePath" -ForegroundColor Yellow
+        Write-Host "               -> Canonical location: $canonicalDest"
+
+        if (-not $WhatIf -and $PSCmdlet.ShouldProcess($filePath, "Move to $canonicalDest")) {
+            if (-not (Test-Path $canonicalDest)) {
+                Move-Item $filePath $canonicalDest
+                # Rewrite folders[0].path to "." in the moved file
+                $raw = Get-Content $canonicalDest -Raw
+                $raw = $raw -replace '"path"\s*:\s*"[^"]*"', '"path": "."'
+                Set-Content $canonicalDest $raw -Encoding UTF8
+                $results.repaired.Add($canonicalDest)
+                Write-Host "               -> Moved and rewritten" -ForegroundColor Cyan
+            }
+            else {
+                Write-Warning "               -> Destination already exists; skipped"
+                $results.errors.Add($filePath)
+            }
+        }
+        elseif ($WhatIf) {
+            Write-Host "               -> Would move and rewrite folders[0].path to '.'" -ForegroundColor Cyan
+        }
+    }
+    else {
+        # edge case: folder exists but is not a git root
+        $results.errors.Add($filePath)
+        Write-Host "  [UNKNOWN]   $filePath" -ForegroundColor DarkYellow
+        Write-Host "               folders[0].path = $resolvedFolder (exists but not a git root)"
+    }
+}
+
+# -- Phase 2: Check registry for missing workspace files --
+if ($registryProjects.Count -gt 0) {
+    Write-Host ''
+    Write-Host 'Checking registry for projects without workspace files...'
+    Write-Host ''
+
+    foreach ($project in $registryProjects) {
+        $projectPath = $project.path
+        if (-not (Test-Path $projectPath)) { continue }
+
+        $projectName   = Split-Path -Leaf $projectPath
+        $expectedPath  = Join-Path $projectPath "$projectName.code-workspace"
+
+        if (-not (Test-Path $expectedPath)) {
+            $results.missing.Add($projectPath)
+            Write-Host "  [MISSING]   $expectedPath" -ForegroundColor Yellow
+
+            if (-not $WhatIf -and $PSCmdlet.ShouldProcess($expectedPath, 'Scaffold from template')) {
+                New-WorkspaceFromTemplate $expectedPath $TemplatePath
+                $results.repaired.Add($expectedPath)
+                $stackProfile = Detect-StackProfile $projectPath
+                Write-Host "               -> Scaffolded from template (stack: $stackProfile)" -ForegroundColor Cyan
+                Write-Host "               -> Review and merge settings from devspace/shared-vscode/$stackProfile.jsonc" -ForegroundColor DarkCyan
+            }
+            elseif ($WhatIf) {
+                $stackProfile = Detect-StackProfile $projectPath
+                Write-Host "               -> Would scaffold from template (stack: $stackProfile)" -ForegroundColor Cyan
+            }
+        }
+    }
+}
+
+# -- Summary --
+Write-Host ''
+Write-Host '== Summary ==' -ForegroundColor Cyan
+Write-Host "  Valid:      $($results.valid.Count)"
+Write-Host "  Misplaced:  $($results.misplaced.Count)"
+Write-Host "  Stale-path: $($results.stalePath.Count)"
+Write-Host "  Missing:    $($results.missing.Count)"
+Write-Host "  Errors:     $($results.errors.Count)"
+if (-not $WhatIf) {
+    Write-Host "  Repaired:   $($results.repaired.Count)" -ForegroundColor Cyan
+}
+Write-Host ''
+
+if ($results.repaired.Count -gt 0 -and -not $WhatIf) {
+    Write-Host 'Repaired files:' -ForegroundColor Cyan
+    foreach ($f in $results.repaired) {
+        Write-Host "  $f"
+    }
+    Write-Host ''
+    Write-Host 'Next steps:' -ForegroundColor White
+    Write-Host '  - Review repaired workspace files'
+    Write-Host '  - For scaffolded files: merge settings from devspace/shared-vscode/<stack>.jsonc'
+    Write-Host '  - Run: pwsh -File scripts/Sync-WorkspaceExtensions.ps1 -WhatIf'
+}

--- a/scripts/Sync-WorkspaceExtensions.ps1
+++ b/scripts/Sync-WorkspaceExtensions.ps1
@@ -1,0 +1,270 @@
+<#
+.SYNOPSIS
+    Syncs VS Code extension recommendations in .code-workspace files with DevKit stack fragments.
+
+.DESCRIPTION
+    For each registered project, detects the stack, loads the matching fragment from
+    devspace/shared-vscode/extensions.jsonc, and merges the recommended extensions into the
+    project's .code-workspace file — preserving any project-specific additions not in the fragment.
+
+    Updates vscodeWorkspace.lastSynced and vscodeWorkspace.stackProfile in ~/.devkit-registry.json.
+
+.PARAMETER DevkitRoot
+    Path to the DevKit repo root. Defaults to the directory containing this script's parent.
+
+.PARAMETER RegistryPath
+    Path to the devkit registry JSON. Defaults to ~/.devkit-registry.json.
+
+.PARAMETER ProjectPath
+    Limit sync to a single project at this path. Omit to sync all registered projects.
+
+.PARAMETER WhatIf
+    Preview changes without applying them.
+
+.EXAMPLE
+    # Dry run against all registered projects
+    pwsh -File devkit/scripts/Sync-WorkspaceExtensions.ps1 -WhatIf
+
+    # Apply to all projects
+    pwsh -File devkit/scripts/Sync-WorkspaceExtensions.ps1
+
+    # Apply to a specific project
+    pwsh -File devkit/scripts/Sync-WorkspaceExtensions.ps1 -ProjectPath D:\DevSpace\SubNetree
+
+.NOTES
+    See docs/vscode-workspaces.md for the full workspace convention.
+    This script is also the backend for the /workspace sync-all skill.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$DevkitRoot = '',
+    [string]$RegistryPath = (Join-Path $env:USERPROFILE '.devkit-registry.json'),
+    [string]$ProjectPath = '',
+    [switch]$WhatIf
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# -- Resolve DevKit root --
+if (-not $DevkitRoot) {
+    $scriptDir  = Split-Path -Parent $MyInvocation.MyCommand.Path
+    $DevkitRoot = Split-Path -Parent $scriptDir
+}
+
+$extensionsFragment = Join-Path $DevkitRoot 'devspace\shared-vscode\extensions.jsonc'
+
+# -- Helpers --
+
+function Get-ExtensionsFragment {
+    param([string]$FragmentPath)
+    if (-not (Test-Path $FragmentPath)) {
+        Write-Warning "Extensions fragment not found: $FragmentPath"
+        return $null
+    }
+    $raw = Get-Content $FragmentPath -Raw
+    # Strip JSONC comments
+    $stripped = $raw -replace '//[^\r\n]*', '' -replace '/\*[\s\S]*?\*/', ''
+    return $stripped | ConvertFrom-Json
+}
+
+function Detect-StackProfile {
+    param([string]$Root)
+    if (Test-Path (Join-Path $Root 'go.mod'))       { return 'go' }
+    if (Test-Path (Join-Path $Root 'package.json')) { return 'typescript' }
+    if (Test-Path (Join-Path $Root 'Cargo.toml'))   { return 'rust' }
+    $csprojs = Get-ChildItem $Root -Filter '*.csproj' -ErrorAction SilentlyContinue
+    if ($csprojs) { return 'csharp' }
+    return 'base'
+}
+
+function Get-StackExtensions {
+    param([object]$Fragment, [string]$Stack)
+    $cmdArgs = [System.Collections.Generic.List[string]]::new()
+
+    # Always add general extensions
+    if ($Fragment.general) {
+        foreach ($ext in $Fragment.general) { $cmdArgs.Add($ext) }
+    }
+
+    switch ($Stack) {
+        'go'         { if ($Fragment.go)         { foreach ($e in $Fragment.go)         { $cmdArgs.Add($e) } } }
+        'typescript' { if ($Fragment.typescript) { foreach ($e in $Fragment.typescript) { $cmdArgs.Add($e) } } }
+        'csharp'     { if ($Fragment.csharp)     { foreach ($e in $Fragment.csharp)     { $cmdArgs.Add($e) } } }
+        'docker'     { if ($Fragment.docker)     { foreach ($e in $Fragment.docker)     { $cmdArgs.Add($e) } } }
+        # rust and base: general only
+    }
+
+    return $cmdArgs | Sort-Object -Unique
+}
+
+function Get-WorkspaceRecommendations {
+    param([string]$WorkspacePath)
+    try {
+        $raw = Get-Content $WorkspacePath -Raw
+        $stripped = $raw -replace '//[^\r\n]*', '' -replace '/\*[\s\S]*?\*/', ''
+        $json = $stripped | ConvertFrom-Json
+        if ($json.extensions -and $json.extensions.recommendations) {
+            return [string[]]$json.extensions.recommendations
+        }
+    }
+    catch {
+        Write-Warning "  Could not parse $WorkspacePath : $_"
+    }
+    return @()
+}
+
+function Set-WorkspaceRecommendations {
+    param([string]$WorkspacePath, [string[]]$Recommendations)
+    $raw = Get-Content $WorkspacePath -Raw
+    # Strip JSONC comments for parsing
+    $stripped = $raw -replace '//[^\r\n]*', '' -replace '/\*[\s\S]*?\*/', ''
+    $json = $stripped | ConvertFrom-Json
+
+    if (-not $json.extensions) {
+        $json | Add-Member -NotePropertyName 'extensions' -NotePropertyValue ([PSCustomObject]@{ recommendations = @() })
+    }
+    $json.extensions.recommendations = $Recommendations
+
+    # Write back as JSON (loses original comments, but that is acceptable for managed files)
+    $json | ConvertTo-Json -Depth 10 | Set-Content $WorkspacePath -Encoding UTF8
+}
+
+function Update-Registry {
+    param([string]$RegistryPath, [string]$ProjectPath, [string]$WorkspacePath, [string]$Stack)
+    if (-not (Test-Path $RegistryPath)) { return }
+
+    $registry = Get-Content $RegistryPath -Raw | ConvertFrom-Json
+    $updated  = $false
+
+    foreach ($project in $registry.projects) {
+        if ($project.path -eq $ProjectPath) {
+            if (-not $project.vscodeWorkspace) {
+                $project | Add-Member -NotePropertyName 'vscodeWorkspace' -NotePropertyValue ([PSCustomObject]@{
+                    path        = $WorkspacePath
+                    lastSynced  = $null
+                    stackProfile = $Stack
+                })
+            }
+            $project.vscodeWorkspace.path         = $WorkspacePath
+            $project.vscodeWorkspace.lastSynced   = (Get-Date -Format 'o')
+            $project.vscodeWorkspace.stackProfile = $Stack
+            $updated = $true
+            break
+        }
+    }
+
+    if ($updated) {
+        $registry | ConvertTo-Json -Depth 10 | Set-Content $RegistryPath -Encoding UTF8
+    }
+}
+
+# -- Load extensions fragment --
+$fragment = Get-ExtensionsFragment $extensionsFragment
+if ($null -eq $fragment) {
+    Write-Error "Cannot load extensions fragment from $extensionsFragment. Aborting."
+    exit 1
+}
+
+# -- Load registry --
+if (-not (Test-Path $RegistryPath)) {
+    Write-Error "Registry not found at $RegistryPath. Run devkit-sync to register projects first."
+    exit 1
+}
+$registry = Get-Content $RegistryPath -Raw | ConvertFrom-Json
+
+# -- Build project list --
+$projects = if ($ProjectPath) {
+    $registry.projects | Where-Object { $_.path -eq $ProjectPath }
+}
+else {
+    $registry.projects
+}
+
+if (-not $projects) {
+    Write-Warning "No projects found to sync."
+    exit 0
+}
+
+# -- Sync --
+Write-Host ''
+Write-Host '== DevKit Workspace Extension Sync ==' -ForegroundColor Cyan
+if ($WhatIf) {
+    Write-Host '   (dry run -- no changes will be made)' -ForegroundColor Yellow
+}
+Write-Host ''
+
+$stats = @{ clean = 0; updated = 0; missing = 0; errors = 0 }
+
+foreach ($project in $projects) {
+    $root        = $project.path
+    $projectName = Split-Path -Leaf $root
+
+    if (-not (Test-Path $root)) {
+        Write-Host "  [SKIP]    $root (path does not exist)" -ForegroundColor DarkYellow
+        $stats.errors++
+        continue
+    }
+
+    $wsPath = Join-Path $root "$projectName.code-workspace"
+
+    if (-not (Test-Path $wsPath)) {
+        Write-Host "  [MISSING] $wsPath" -ForegroundColor Yellow
+        Write-Host "             -> Run Repair-WorkspaceFiles.ps1 to scaffold"
+        $stats.missing++
+        continue
+    }
+
+    $stack         = Detect-StackProfile $root
+    $expected      = Get-StackExtensions $fragment $stack
+    $current       = Get-WorkspaceRecommendations $wsPath
+
+    # Merge: keep project-specific extensions not in the expected set
+    $projectSpecific = $current | Where-Object { $_ -notin $expected }
+    $merged          = ($expected + $projectSpecific) | Sort-Object -Unique
+
+    $needsUpdate = ($null -eq (Compare-Object $current $merged))  # true = no diff = false
+    $needsUpdate = ($current.Count -ne $merged.Count) -or
+                   (($current | Sort-Object) -join '|') -ne (($merged | Sort-Object) -join '|')
+
+    Write-Host "  $projectName" -NoNewline
+    Write-Host "  (stack: $stack)" -ForegroundColor DarkGray
+
+    if (-not $needsUpdate) {
+        Write-Host "    [CLEAN]   extensions already up to date" -ForegroundColor Green
+        $stats.clean++
+    }
+    else {
+        $added   = $merged | Where-Object { $_ -notin $current }
+        $removed = $current | Where-Object { $_ -notin $merged }
+
+        if ($added)   { foreach ($e in $added)   { Write-Host "    + $e" -ForegroundColor Cyan } }
+        if ($removed) { foreach ($e in $removed) { Write-Host "    - $e" -ForegroundColor Red  } }
+
+        if (-not $WhatIf -and $PSCmdlet.ShouldProcess($wsPath, 'Update extension recommendations')) {
+            try {
+                Set-WorkspaceRecommendations $wsPath $merged
+                Update-Registry $RegistryPath $root $wsPath $stack
+                Write-Host "    [UPDATED] $wsPath" -ForegroundColor Cyan
+                $stats.updated++
+            }
+            catch {
+                Write-Warning "    [ERROR]   Could not update $wsPath : $_"
+                $stats.errors++
+            }
+        }
+        elseif ($WhatIf) {
+            Write-Host "    [WOULD UPDATE] $wsPath" -ForegroundColor Cyan
+            $stats.updated++
+        }
+    }
+}
+
+# -- Summary --
+Write-Host ''
+Write-Host '== Summary ==' -ForegroundColor Cyan
+Write-Host "  Clean:   $($stats.clean)"
+Write-Host "  Updated: $($stats.updated)" -ForegroundColor $(if ($stats.updated -gt 0) { 'Cyan' } else { 'White' })
+Write-Host "  Missing: $($stats.missing)" -ForegroundColor $(if ($stats.missing -gt 0) { 'Yellow' } else { 'White' })
+Write-Host "  Errors:  $($stats.errors)"  -ForegroundColor $(if ($stats.errors -gt 0)  { 'Red'    } else { 'White' })
+Write-Host ''


### PR DESCRIPTION
## Summary

Resolves #20.

- **Convention doc** (`docs/vscode-workspaces.md`): canonical location, stack detection heuristic, settings/extensions merge rules, `.gitignore` policy, on-demand sync decision
- **Template** (`project-templates/workspace.code-workspace`): starter file with instructions
- **Registry schema** (`docs/project-registry-schema.md`): adds `vscodeWorkspace` fields (`path`, `lastSynced`, `stackProfile`)
- **Orphan recovery** (`scripts/Repair-WorkspaceFiles.ps1`): classifies and repairs misplaced/stale/missing workspace files; `-WhatIf` dry-run support
- **Extension sync** (`scripts/Sync-WorkspaceExtensions.ps1`): merges stack fragments into all registered projects, preserves project-specific additions, updates registry; `-WhatIf` and `-ProjectPath` support
- **Skill** (`claude/skills/workspace/`): `/workspace` with four routes — check, scaffold, repair, sync-all
- **README**: skill count 27 → 28

## Test plan

- [ ] `npx markdownlint-cli2 "docs/vscode-workspaces.md" "claude/skills/workspace/**/*.md"` passes (0 errors)
- [ ] `Repair-WorkspaceFiles.ps1 -WhatIf` runs without error and classifies D:\DevSpace\ workspace files correctly
- [ ] `Sync-WorkspaceExtensions.ps1 -WhatIf` runs without error and reports extension diffs for registered projects
- [ ] `/workspace check` route resolves to `workflows/check.md`
- [ ] `/workspace scaffold` route resolves to `workflows/scaffold.md`
- [ ] `/workspace repair` route resolves to `workflows/repair.md`
- [ ] `/workspace sync-all` route resolves to `workflows/sync-all.md`
- [ ] `/workspace skip` exits without action

🤖 Generated with [Claude Code](https://claude.com/claude-code)