### PR TITLE
chore(rules): stash/WIP-branch pattern and dual-forge gotchas (AP#145-147, KG#178-181)

### DIFF
--- a/claude/rules/autolearn-patterns.md
+++ b/claude/rules/autolearn-patterns.md
@@ -1,8 +1,8 @@
 ---
 description: Learned patterns from past sessions. Read when encountering similar situations.
 tier: 2
-entry_count: 58
-last_updated: "2026-03-21"
+entry_count: 61
+last_updated: "2026-03-22"
 ---
 
 # Learned Patterns
@@ -661,3 +661,70 @@ Each window gets the correct UI with zero navigation overhead. Typical window co
 
 Backend opens a named window: `app.get_webview_window("dashboard").show()`
 **See also:** KG#176 (Tauri 2 API gotchas — getCurrentWindow import path)
+
+## 145. Use WIP Branch Instead of Stash for Branch-Switching Work
+
+**Added:** 2026-03-22 | **Source:** samverk | **Status:** active
+
+**Category:** workflow-pattern
+**Context:** When in-progress work exists and a multi-step task requires switching between multiple branches (e.g., rebasing, merging, resolving stacked PRs), `git stash` carries risk: `git stash drop` is irreversible and easy to run accidentally during cleanup. A WIP branch is safer — it survives branch switches, can be inspected later, and is trivially recoverable.
+**Fix:** Before any multi-branch operation when uncommitted work exists:
+
+```bash
+# Instead of: git stash push -m "..."
+git add -A
+git commit -m "wip: [description] -- branch-switching work in progress"
+# Do your multi-branch work
+# Afterwards, soft-reset to un-commit and restore working state:
+git reset HEAD~1
+```
+
+If you must use stash, inspect before dropping:
+
+```bash
+git stash show -p stash@{0}   # always inspect before dropping
+# prefer git stash pop over git stash drop
+```
+
+**Why:** `git stash drop` permanently deletes staged and tracked-but-modified files with no recovery path. In the samverk migration session, AGENTS.md and CLAUDE.md edits were permanently lost this way.
+
+## 146. Cherry-Pick Only Unique Commits for Stacked PRs
+
+**Added:** 2026-03-22 | **Source:** samverk | **Status:** active
+
+**Category:** workflow-pattern
+**Context:** When parallel feature branches are stacked (branch B was created on top of branch A, so B contains A's commit plus its own), simple rebase fails after A is squash-merged to main. Git cannot recognize the squashed version of A as equivalent to the original commit, causing conflicts.
+**Fix:**
+
+```bash
+# 1. Identify the unique commit in branch B (first line is unique, second is A's)
+git log --oneline origin/feature/B | head -2
+
+# 2. Reset branch B to current main and replay only the unique commit
+git checkout --track origin/feature/B -B feature/B
+git reset --hard origin/main
+git cherry-pick <tip-commit-of-B>
+
+# 3. Push and enable auto-merge
+git push --force origin feature/B
+gh pr merge N --squash --auto
+```
+
+If the cherry-pick still conflicts (A and B both touched the same file), resolve as additive — keep both sides. Conflicts from stacked PRs are always additive, never destructive.
+
+## 147. Sequential Auto-Merge Requires Manual Branch Updates Between Merges
+
+**Added:** 2026-03-22 | **Source:** samverk | **Status:** active
+
+**Category:** workflow-pattern
+**Context:** When N PRs all have auto-merge enabled and one merges, the remaining N-1 PRs enter "BEHIND" state. GitHub's auto-merge does NOT auto-update behind branches — it waits indefinitely even if all CI checks passed on the most recent push.
+**Fix:** After each merge in a batch, manually update remaining behind PRs:
+
+```bash
+# After PR N merges:
+gh pr update-branch <remaining-pr-1>
+gh pr update-branch <remaining-pr-2>
+# ...
+```
+
+This triggers new CI runs via merge commits; auto-merge fires once CI passes. For N sequential PRs, expect O(N²/2) total update-branch calls. If running many PRs, consider a workflow that auto-updates behind branches on push to main.

--- a/claude/rules/known-gotchas.md
+++ b/claude/rules/known-gotchas.md
@@ -1,8 +1,8 @@
 ---
 description: Known gotchas and platform-specific issues. Read when debugging unexpected behavior.
 tier: 2
-entry_count: 37
-last_updated: "2026-03-21"
+entry_count: 41
+last_updated: "2026-03-22"
 ---
 
 # Known Gotchas
@@ -558,3 +558,57 @@ formatter={(value, _name, props) => {
 ```
 
 Applies to both AreaChart and BarChart Tooltip formatters in Recharts 3.x.
+
+## 178. Stacked PR Branches Contain Prior Branch Commits — Cherry-Pick Required
+
+**Added:** 2026-03-22 | **Source:** samverk | **Status:** active
+
+**Platform:** Git / GitHub (all)
+**Issue:** When feature branches are created by stacking (branch B based on branch A, so B contains A's commit + its own), after squash-merging A, a plain `git rebase origin/main` on B fails. Git replays A's original commit, which now conflicts with the squashed version already in main. The PR shows as "dirty" (conflicted) with no obvious cause.
+**Fix:** Identify B's unique commit with `git log --oneline origin/feature/B | head -1`, reset to `origin/main`, then `git cherry-pick <that-commit>`. Force-push. See AP#146.
+
+## 179. Dual-Remote Checkout Ambiguity With Same Branch Names
+
+**Added:** 2026-03-22 | **Source:** samverk | **Status:** active
+
+**Platform:** Git (dual-forge repos)
+**Issue:** In repos with two remotes (e.g., `origin`=GitHub and `gitea`=Gitea) that both track identical branch names, `git checkout feature/foo` fails: `fatal: 'feature/foo' matched multiple (2) remote tracking branches`. Common in dual-forge setups where feature branches are mirrored to both remotes.
+**Fix:** Always specify the remote explicitly: `git checkout --track origin/feature/foo -B feature/foo`. The `-B` flag creates or resets the local branch cleanly.
+
+## 180. Gitea Protected Branch Blocks All Direct Pushes Including Admin Token
+
+**Added:** 2026-03-22 | **Source:** samverk | **Status:** active
+
+**Platform:** Gitea (all)
+**Issue:** Unlike GitHub where admin users can bypass branch protection, Gitea's protection blocks ALL direct pushes — even with an admin token. Error: `Not allowed to push to protected branch main`. This affects migration syncs and emergency patches.
+**Fix:** Temporarily delete the rule, push, then re-create:
+
+```bash
+# Delete
+curl -X DELETE http://GITEA_INTERNAL/api/v1/repos/{owner}/{repo}/branch_protections/main \
+  -H "Authorization: token TOKEN"
+# Push
+git push gitea main
+# Re-create
+curl -X POST http://GITEA_INTERNAL/api/v1/repos/{owner}/{repo}/branch_protections \
+  -H "Authorization: token TOKEN" -H "Content-Type: application/json" \
+  -d '{"branch_name":"main","rule_name":"main","enable_push":false}'
+```
+
+Use internal URL (not Cloudflare tunnel) — tunnel strips the Authorization header. See KG#123.
+
+## 181. Dual-Forge Diverged Mains: Use Merge Commit, Not Force-Push
+
+**Added:** 2026-03-22 | **Source:** samverk | **Status:** active
+
+**Platform:** Git (dual-forge repos)
+**Issue:** When GitHub and Gitea mains diverge (each has unique commits the other lacks), force-pushing one forge's main to the other destroys the unique commits on the receiving side. This is irreversible.
+**Fix:** Use a merge commit — it preserves both sides and is accepted as a fast-forward by the receiving forge (because its current tip becomes a parent of the merge commit):
+
+```bash
+git fetch origin && git fetch gitea
+git merge gitea/main --no-edit   # runs on local main tracking GitHub
+git push gitea main               # fast-forward from Gitea's perspective
+git push origin main              # sync merge commit back to GitHub
+git push gitea v1.2.3            # also push tags if any
+```


### PR DESCRIPTION
## Summary

Implements the skill improvement opportunity identified in the samverk forge migration session (2026-03-22): **replace `git stash` with a WIP branch commit** when multi-branch work is needed, to prevent irreversible `git stash drop` data loss.

Also captures 6 new patterns/gotchas from the same session:

- **AP#145** — Use WIP branch (not stash) for branch-switching work. Root cause of data loss in migration session.
- **AP#146** — Cherry-pick only unique commits for stacked PRs. Rebase fails after squash-merge of a dependency branch.
- **AP#147** — GitHub auto-merge stalls when branches go BEHIND. Manual `gh pr update-branch` required after each merge.
- **KG#178** — Stacked PR branches contain prior commits; cherry-pick required (companion to AP#146).
- **KG#179** — Dual-remote checkout ambiguity when same branch names exist on both remotes.
- **KG#180** — Gitea protected branch blocks all direct pushes including admin token; delete/push/recreate workaround.
- **KG#181** — Dual-forge diverged mains: use merge commit (not force-push) to preserve both sides.

Closes #505 #506 #507 #508 #509 #510

## Test plan

- [x] `npx markdownlint-cli2` passes on both modified files (0 errors)
- [x] Entry counts updated in YAML frontmatter (AP: 58→61, KG: 37→41)
- [x] All entries numbered sequentially with no gaps
- [x] No dangerous patterns (no skip/bypass/suppress without justification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)