### PR TITLE
feat(rules): hot-file guard for parallel agent waves (AP#127, [HOT-FILES])

### DIFF
--- a/claude/rules/autolearn-patterns.md
+++ b/claude/rules/autolearn-patterns.md
@@ -567,6 +567,37 @@ MUI Popper needs `anchorEl` during render. `useRef` + `ref.current` triggers Rea
 **Context:** When a worktree agent returns a truncated response (mid-sentence, no PR created), do NOT re-run from scratch. The agent may have completed all code changes and only failed at the final summary/PR step.
 **Fix:** First inspect the worktree directory at `.claude/worktrees/agent-*/`. Review what files were changed with `git diff main...HEAD` inside the worktree. If substantial work exists, continue via `SendMessage` to the same agent or run a targeted agent for only the missing piece. This can save 70k+ tokens compared to a full re-run.
 
+### Identify hot files before launching a parallel wave
+
+**Context:** Parallel worktree agents work in isolation and cannot see each other's changes. When two agents both encounter the same pre-existing bug (e.g., a failing test) in the same file, both fix it independently. When the first PR merges, the second becomes CONFLICTING on that file. Discovered in samverk: two agents both added `-buildvcs=false` to `validator.go`.
+**Fix:** Before launching N agents in parallel, do a pre-launch hot-file audit:
+
+```bash
+# For each issue being paralleled, predict which files it will touch
+# (read the issue body / acceptance criteria)
+# Find overlaps -- those are hot files
+
+# List files each branch would realistically modify
+# If a file appears in 2+ agents' expected changes: it's hot
+```
+
+Pass the `[HOT-FILES]` block from `subagent-ci-checklist.md` to ALL agents in the wave, listing the hot files. Agents that encounter bugs in hot files should report but not fix them. After all PRs merge sequentially, check that the hot file fix landed exactly once.
+
+Also check for known pre-existing bugs before launching: run `go test ./...` or `pnpm test` on current main and note any failing tests. Tell all agents: "The following tests are already failing on main: [...]. Do not attempt to fix them -- they are pre-existing." This prevents multiple agents from independently applying the same fix.
+
+### Prune stale worktrees after parallel wave before any git push
+
+**Context:** Agent tool calls with `isolation: "worktree"` leave worktree directories behind after the agent finishes. These stale entries appear in `git worktree list`. Pre-push hooks that run `go test ./...` or `go build` may traverse into these non-git temp directories and fail with "error obtaining VCS status: exit status 128".
+**Fix:** After any parallel agent wave completes and before any `git push`:
+
+```bash
+git worktree list           # identify stale entries
+git worktree remove <path> --force   # for each stale worktree
+git worktree prune          # remove stale administrative files
+```
+
+Make this a standard post-wave step in wave orchestration. All agent-created worktrees should be removed before the first push of the merging sequence.
+
 ## 132. Exclude Release-Please CHANGELOG From Markdownlint
 
 **Added:** 2026-03-17 | **Source:** DevKit | **Status:** active

--- a/claude/rules/subagent-ci-checklist.md
+++ b/claude/rules/subagent-ci-checklist.md
@@ -67,6 +67,30 @@ finish. To help:
 - Do NOT remove entries that look unfamiliar -- they belong to another agent
 ```
 
+## Hot File Guard [HOT-FILES] (paste into parallel agent prompts when known hot files exist)
+
+Replace `<file-list>` with the actual paths before pasting.
+
+```text
+## Hot Files -- Do NOT Modify These
+
+The following files are being fixed or modified by a parallel agent in this same wave.
+If you modify them too, your PR will conflict with that agent's PR:
+
+<file-list>
+  - internal/agent/validator.go
+  - web/src/components/Layout.tsx
+
+If you encounter a bug in one of these files that blocks your work:
+1. Note the bug in your PR description under "Discovered but deferred"
+2. Do NOT commit a fix -- the parallel agent is already handling it
+3. Work around it if possible (e.g., add a TODO comment, use a stub)
+
+If one of these files causes a test failure that you cannot work around:
+- Report it in your output and stop -- do not attempt a fix
+- The main context will sequence your work after the hot file PR merges
+```
+
 ## Frontend Agent Checklist [FE-CI] (paste into frontend agent prompts)
 
 ```text

--- a/claude/rules/workflow-preferences.md
+++ b/claude/rules/workflow-preferences.md
@@ -75,6 +75,8 @@ This catches runtime issues (missing embeds, config collisions, broken routes) t
 - Main context reserved for orchestration only (~5-10% usage per plan)
 - Proven on Phase 01-topology: 3 plans, 7 tasks, 10 new files + 5 modified, 37 tests -- all clean on first pass
 - **Wave execution**: Launch up to 3 agents in parallel per wave when files don't overlap. Sort changes into correct branches via stash/pop after all agents complete (see gotcha #25). Proven: v0.4.1 sprint, 2 waves x 3 agents = 6 PRs, 12 issues, all CI-green first pass.
+- **Pre-wave hot-file audit**: Before launching parallel agents, read each issue's acceptance criteria and predict which files each agent will touch. Files that appear in 2+ agents' expected changes are "hot". Pass `[HOT-FILES]` block (from `subagent-ci-checklist.md`) to ALL agents listing hot files -- agents report bugs in hot files but do NOT fix them. Also run tests on current main and tell agents which tests are already failing so multiple agents don't independently fix the same pre-existing failure.
+- **Post-wave worktree cleanup**: After all parallel agents complete, run `git worktree list` and `git worktree remove <path> --force` for each stale entry, then `git worktree prune` -- BEFORE any git push. Stale worktrees from agent isolation cause pre-push hooks to fail (see AP#127).
 
 ## 9. Global CLAUDE.md Scope
 
@@ -128,6 +130,7 @@ Every Task tool invocation for code-writing agents MUST include:
 - Relevant CI checklist from `subagent-ci-checklist.md` ([GO-CI], [FE-CI], or [COMBO-CI])
 - Git Safety block ([GIT-SAFE])
 - Shared File Guard ([SHARED-FILE]) if running parallel agents
+- Hot File Guard ([HOT-FILES]) if any files are touched by 2+ parallel agents -- fill in the file list before pasting
 - Core principles reminder (Tier 0 rules are unconditional)
 - Failure to include checklists is a DevKit policy violation
 


### PR DESCRIPTION
## Summary

Adds systemic prevention for a class of parallel-agent merge conflicts discovered in the samverk wave execution session: two parallel agents independently fixed the same pre-existing bug (`-buildvcs=false` in `validator.go`), causing a merge conflict when the second PR tried to merge.

- **`[HOT-FILES]` block** in `subagent-ci-checklist.md` — a new paste-in block for parallel agent prompts. Orchestrators fill in the list of files being touched by concurrent agents. Agents are instructed to report bugs in hot files but not fix them, avoiding duplicate fixes.
- **AP#127 subsections** in `autolearn-patterns.md` — "Identify hot files before launching a parallel wave" (pre-launch audit pattern + how to communicate hot files) and "Prune stale worktrees after parallel wave before any git push" (post-wave cleanup protocol).
- **Workflow preferences** — pre-wave hot-file audit and post-wave worktree cleanup added as mandatory steps to the wave execution bullet; `[HOT-FILES]` added to the mandatory checklist list.

## Test plan

- [x] `npx markdownlint-cli2` passes on all three files (0 errors)
- [x] `[HOT-FILES]` block follows same format as `[SHARED-FILE]` and `[GIT-SAFE]`
- [x] AP#127 subsections are consistent with existing subsection style
- [x] No entry_count frontmatter to update (subagent-ci-checklist.md has none; AP#127 is a subsection of an existing entry, not a new top-level entry)

Closes #517 #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)