### PR TITLE
feat: add cf-access skill with Tier 3 approval gate

### DIFF
--- a/claude/skills/cf-access/SKILL.md
+++ b/claude/skills/cf-access/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: cf-access
+description: Cloudflare Access management with Tier 3 approval gate -- agents diagnose and propose, never execute
+user_invocable: true
+---
+
+# cf-access
+
+<essential_principles>
+
+**Tier 3 -- Human Approval Required. No exceptions.**
+
+Agents must NEVER execute Cloudflare Zero Trust API calls autonomously. This includes:
+
+- Creating, modifying, or deleting Access policies
+- Creating or rotating service tokens
+- Modifying tunnel ingress routes
+- Adding or removing WAF rules
+- Any `curl` or API call to `api.cloudflare.com`
+
+Agents CAN:
+
+- Read diagnostic information (response headers, status codes)
+- Run the check-auth diagnostic runbook
+- Propose changes by filing `agent:human` issues with structured plans
+
+**Why this exists:** Agents have repeatedly removed CF Access policies when encountering 302/403 responses, leaving MCP endpoints (samverk.herbhall.net, synapset.herbhall.net) open to the internet without authentication. Agents cannot distinguish "CF Access is blocking me incorrectly" from "CF Access is correctly blocking an unauthorized request."
+
+**Canonical rule:** Synapset devkit pool memory #788 (CF Zero Trust Tier 3 policy).
+
+**Cloudflare Zero Trust terminology:**
+
+| Term | Meaning |
+|------|---------|
+| Access Application | A policy-protected hostname or path |
+| Access Policy | Allow/block rule within an application (Google OAuth, service token, etc.) |
+| Service Token | Client ID + Secret pair for programmatic (non-browser) access |
+| Tunnel | Cloudflare Tunnel (cloudflared) connecting internal services to CF edge |
+| Ingress Rule | Tunnel config mapping a public hostname to an internal origin |
+| CF-Access-Client-Id | HTTP header carrying the service token client ID |
+| CF-Access-Client-Secret | HTTP header carrying the service token secret |
+| JWT | CF Access issues JWTs after successful authentication; validated by applications |
+
+**Protected endpoints:**
+
+| Endpoint | Internal Origin | Purpose |
+|----------|----------------|---------|
+| `samverk.herbhall.net` | `192.168.1.162:8080` | Samverk server (dashboard + MCP) |
+| `synapset.herbhall.net` | `192.168.1.162:6464` | Synapset memory server (MCP) |
+
+**Authentication layers:**
+
+- **Browser (dashboard):** CF Access Google OAuth -> JWT auto-login
+- **Programmatic (MCP, API):** Service token headers bypass CF Access OAuth
+- **Internal (LAN):** Bearer token only, no CF Access involved
+
+</essential_principles>
+
+<intake>
+
+What do you need help with?
+
+1. **Diagnose auth failure** -- "I can't reach samverk/synapset" or getting 302/403
+2. **Propose Access policy change** -- add, remove, or modify a policy
+3. **Propose service token operation** -- create, rotate, or verify a token
+4. **Propose tunnel route change** -- add, remove, or modify an ingress rule
+
+Type a number, keyword, or **skip** to dismiss.
+
+</intake>
+
+<routing>
+
+| Response | Workflow |
+|----------|----------|
+| 1, "diagnose", "auth", "failure", "can't reach", "302", "403", "blocked" | First read check-auth.md, then workflows/diagnose-auth-failure.md |
+| 2, "policy", "access policy", "add policy", "remove policy" | workflows/propose-policy-change.md |
+| 3, "token", "service token", "rotate", "create token" | workflows/propose-service-token.md |
+| 4, "tunnel", "route", "ingress" | workflows/propose-tunnel-change.md |
+
+If the user types **skip** or **dismiss**, confirm cancellation and end the skill.
+If the input does not match, respond: "cf-access was triggered but your input didn't match a workflow. Options: 1-4. Type skip to dismiss."
+
+**After reading the workflow, follow it exactly.**
+
+**CRITICAL:** Every workflow ends with filing an `agent:human` issue. You must NEVER execute the proposed change yourself.
+
+</routing>
+
+<tool_restrictions>
+
+**Forbidden:**
+
+- `curl` to `api.cloudflare.com` (any method)
+- Any MCP tool that modifies CF Zero Trust configuration
+- `cloudflared` config changes
+- Direct editing of tunnel config files
+
+**Allowed:**
+
+- `curl` to protected endpoints for diagnostic purposes (read-only, status code checks)
+- Reading response headers (`CF-Access-*`, `CF-Ray`, `Location`)
+- `gh issue create` or Samverk MCP `create_issue` to file proposals
+- Reading existing tunnel config files (read-only)
+
+</tool_restrictions>
+
+<references>
+
+- check-auth.md: Diagnostic runbook -- MUST be followed before assuming CF Access is misconfigured
+- Synapset memory #788: Canonical CF Zero Trust Tier 3 policy
+
+</references>
+
+<workflows_index>
+
+- diagnose-auth-failure.md: Triage "I can't reach X" problems without modifying CF config
+- propose-policy-change.md: Structured proposal for Access policy add/remove/modify
+- propose-service-token.md: Structured proposal for service token create/rotate
+- propose-tunnel-change.md: Structured proposal for tunnel ingress route changes
+
+</workflows_index>
+
+## Version
+
+- v1.0.0 (2026-03-22): Initial skill -- Tier 3 gate, 4 workflows, diagnostic runbook
+
+## Changelog
+
+- v1.0.0: Created skill per samverk#200. Covers policy, token, tunnel, and auth diagnosis workflows. Hard Tier 3 gate on all CF modifications.

--- a/claude/skills/cf-access/check-auth.md
+++ b/claude/skills/cf-access/check-auth.md
@@ -1,0 +1,106 @@
+# CF Access Authentication Diagnostic Runbook
+
+Follow these steps IN ORDER before concluding that CF Access is misconfigured. Most auth failures are caused by missing or invalid credentials, not policy problems.
+
+## Step 1: Identify the Request Type
+
+Determine which authentication path applies:
+
+| If you are... | Auth method | Expected headers |
+|---------------|-------------|-----------------|
+| A browser user accessing the dashboard | CF Access Google OAuth | None (CF handles redirect) |
+| An agent/script calling MCP or API | Service token | `CF-Access-Client-Id` + `CF-Access-Client-Secret` |
+| On the LAN calling internal IP directly | Bearer token | `Authorization: Bearer <token>` |
+
+**If you are on the LAN (192.168.1.x):** You do not go through CF Access at all. Use the internal IP directly (e.g., `192.168.1.162:8080`). If this fails, the problem is NOT CF Access.
+
+## Step 2: Verify Service Token Headers Are Present
+
+For programmatic access through CF Access, check that BOTH headers are in the outbound request:
+
+```bash
+# Check that the environment variables exist and are non-empty
+echo "Client ID length: ${#CF_ACCESS_CLIENT_ID}"
+echo "Client Secret length: ${#CF_ACCESS_CLIENT_SECRET}"
+```
+
+- If either is empty or unset, the token is not configured. This is a **configuration problem**, not a CF Access problem.
+- Do NOT attempt to fix this by modifying CF Access policies.
+
+## Step 3: Test With Token
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+  -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+  https://samverk.herbhall.net/healthz
+```
+
+| Result | Meaning | Action |
+|--------|---------|--------|
+| 200 | Token is valid, CF Access is working | No CF change needed. Debug your application. |
+| 302 | Token not recognized, redirecting to OAuth | Token may be expired or wrong. See Step 4. |
+| 403 | Token recognized but denied by policy | See Step 5. |
+| Connection refused / timeout | Tunnel is down or DNS issue | See Step 6. |
+
+## Step 4: Token Not Recognized (302)
+
+The service token exists but CF Access is redirecting to OAuth. Possible causes:
+
+1. **Wrong token for this application** -- each CF Access Application has its own service token
+2. **Token was rotated** -- the stored credentials are from a previous rotation
+3. **Typo in headers** -- header names are case-sensitive: `CF-Access-Client-Id` (not `Client-ID`)
+
+**Action:** File an `agent:human` issue requesting token verification. Include which endpoint and which token name you are using. Do NOT create a new token yourself.
+
+## Step 5: Token Denied (403)
+
+The token is recognized but the Access Policy does not allow it. Possible causes:
+
+1. **Service token policy was removed** from this Access Application
+2. **Policy was narrowed** to exclude this token's scope
+
+**Action:** File an `agent:human` issue with:
+
+- Which endpoint returned 403
+- Which service token name was used
+- The full response headers (especially `CF-Ray` for CF support lookup)
+
+Do NOT modify the Access Policy yourself.
+
+## Step 6: Connection Failure
+
+If `curl` cannot connect at all:
+
+1. **Check DNS:** `nslookup samverk.herbhall.net` -- should resolve to Cloudflare IPs
+2. **Check tunnel:** The tunnel runs on CT 202. If the tunnel is down, the endpoint is unreachable regardless of Access policies
+3. **Check internal service:** `curl http://192.168.1.162:8080/healthz` from a LAN host
+
+**Action:** If DNS resolves but connection times out, the tunnel may be down. This is an infrastructure issue, not a CF Access issue. File accordingly.
+
+## Step 7: File the Issue
+
+If you reached this step, you have diagnostic evidence. File an `agent:human` issue with:
+
+```markdown
+## CF Access Auth Failure Report
+
+**Endpoint:** [which URL]
+**Request type:** [browser / service token / LAN]
+**HTTP status:** [200 / 302 / 403 / timeout]
+**Token present:** [yes/no, which token name]
+**Diagnostic output:** [paste relevant curl output]
+**Conclusion:** [token missing / token invalid / policy issue / tunnel down]
+
+## Requested Action
+
+[What you believe needs to happen -- but do NOT execute it yourself]
+```
+
+## What You Must NOT Do
+
+- Remove or modify any Access Policy
+- Create or rotate service tokens
+- Edit tunnel configuration
+- Bypass CF Access by switching to internal IPs in production config
+- Assume CF Access is wrong -- it is more likely that your request is wrong

--- a/claude/skills/cf-access/workflows/diagnose-auth-failure.md
+++ b/claude/skills/cf-access/workflows/diagnose-auth-failure.md
@@ -1,0 +1,47 @@
+# Diagnose Auth Failure
+
+Use this workflow when an agent or user reports "I can't reach samverk/synapset" or is getting 302/403 responses from a CF-protected endpoint.
+
+## Prerequisites
+
+You MUST have read `check-auth.md` before starting this workflow. If you skipped it, go back and read it now.
+
+## Step 1: Gather Context
+
+Ask or determine:
+
+- Which endpoint is failing? (samverk.herbhall.net, synapset.herbhall.net, or internal IP)
+- What HTTP status code is returned? (302, 403, timeout, connection refused)
+- Is this a browser request or programmatic (MCP/API) request?
+- Is the caller on the LAN or external?
+
+## Step 2: Run Diagnostic Checks
+
+Follow the check-auth.md runbook steps 1-6. Record the results of each step.
+
+For each check, note:
+
+- What you tested
+- What the result was
+- What it means
+
+## Step 3: Classify the Problem
+
+Based on your diagnostics, classify into one of these categories:
+
+| Category | Symptoms | Agent Action |
+|----------|----------|-------------|
+| **Missing credentials** | Token env vars empty/unset | Fix the caller's config, no CF change needed |
+| **Invalid credentials** | 302 with correct headers | File issue: token may need rotation |
+| **Policy gap** | 403 with valid token | File issue: policy review needed |
+| **Tunnel down** | Connection refused/timeout | File issue: infrastructure, not CF Access |
+| **DNS issue** | Cannot resolve hostname | Check Cloudflare DNS, file if broken |
+| **Application error** | 200 from CF but 500 from app | Debug the application, CF Access is fine |
+
+## Step 4: Resolve or File
+
+**If the problem is in the caller's config** (missing credentials, wrong endpoint, using external URL from LAN): fix it directly. No CF change needed.
+
+**If the problem requires a CF change** (policy, token, tunnel): file an `agent:human` issue using the template from check-auth.md Step 7.
+
+**STOP.** Do not attempt to fix CF Access configuration. Your job is diagnosis and filing only.

--- a/claude/skills/cf-access/workflows/propose-policy-change.md
+++ b/claude/skills/cf-access/workflows/propose-policy-change.md
@@ -1,0 +1,74 @@
+# Propose Access Policy Change
+
+Use this workflow to propose adding, removing, or modifying a Cloudflare Access policy. You will produce a structured proposal and file it as an `agent:human` issue. You will NOT execute any changes.
+
+## Step 1: Define the Change
+
+Determine:
+
+- **Which Access Application?** (e.g., samverk.herbhall.net, synapset.herbhall.net)
+- **What type of change?** Add a new policy, remove an existing policy, or modify policy rules
+- **Why is this needed?** What problem does this solve? What breaks without it?
+
+## Step 2: Assess Impact
+
+Before proposing, evaluate:
+
+- **Who is currently protected?** List all policies on the target application
+- **What breaks if this policy is removed?** (If removing)
+- **What new access is granted?** (If adding)
+- **Does this widen the attack surface?** Any change that allows broader access must justify why
+
+## Step 3: Write the Proposal
+
+Use this template:
+
+```markdown
+## CF Access Policy Change Proposal
+
+**Application:** [hostname]
+**Change type:** [add / remove / modify]
+**Priority:** [critical / high / normal]
+
+### Current State
+
+[Describe the current policies on this application]
+
+### Proposed Change
+
+[Exactly what should change -- be specific about policy name, action, include/exclude rules]
+
+### Justification
+
+[Why this change is needed. Reference the triggering incident or requirement.]
+
+### Impact Assessment
+
+- **Access widened:** [yes/no -- if yes, explain what new access is granted]
+- **Access narrowed:** [yes/no -- if yes, explain what access is removed]
+- **Affected users/services:** [who is impacted]
+
+### Rollback Procedure
+
+To revert this change:
+1. [Step-by-step reversal instructions]
+2. [Verify reversal with specific curl command]
+
+### Verification
+
+After applying, verify with:
+1. [Specific curl command to confirm the change works]
+2. [Specific curl command to confirm nothing else broke]
+```
+
+## Step 4: File the Issue
+
+File an `agent:human` issue in the appropriate project repo with:
+
+- Title: `cf-access: [add/remove/modify] [policy name] on [application]`
+- Label: `agent:human`, `priority:[level]`
+- Body: The proposal from Step 3
+
+## STOP
+
+Do NOT execute the change. Do NOT call the Cloudflare API. Your job is the proposal only.

--- a/claude/skills/cf-access/workflows/propose-service-token.md
+++ b/claude/skills/cf-access/workflows/propose-service-token.md
@@ -1,0 +1,71 @@
+# Propose Service Token Operation
+
+Use this workflow to propose creating, rotating, or verifying a Cloudflare Access service token. You will produce a structured proposal and file it as an `agent:human` issue. You will NOT execute any changes.
+
+## Step 1: Define the Operation
+
+Determine:
+
+- **Which operation?** Create new token, rotate existing token, or verify token is working
+- **Which service token?** Name and which Access Application it belongs to
+- **Why is this needed?** Token expired, compromised, new service needs access, or diagnostic
+
+## Step 2: Identify Affected Services
+
+Service tokens are used by programmatic callers. Identify:
+
+- Which services currently use this token (MCP connectors, CI/CD, scripts)
+- Where the token credentials are stored (env vars, secrets manager, config files)
+- What breaks during rotation (services lose access until updated)
+
+## Step 3: Write the Proposal
+
+Use this template:
+
+```markdown
+## CF Access Service Token Proposal
+
+**Operation:** [create / rotate / verify]
+**Token name:** [name or "new"]
+**Application:** [which CF Access Application]
+**Priority:** [critical / high / normal]
+
+### Current State
+
+[Describe the current token status -- working, expired, unknown]
+
+### Proposed Operation
+
+[Exactly what should happen]
+
+### Affected Services
+
+| Service | Location | Credential Storage | Update Method |
+|---------|----------|-------------------|---------------|
+| [name] | [host/container] | [env var / secret] | [how to update] |
+
+### Rollback Procedure
+
+If the new/rotated token does not work:
+1. [How to revert -- e.g., restore previous token from backup]
+2. [Verify services recover]
+
+### Post-Operation Checklist
+
+After the token operation:
+- [ ] Update credentials in all affected services (see table above)
+- [ ] Verify each service can authenticate: `curl -s -o /dev/null -w "%{http_code}" -H "CF-Access-Client-Id: ..." -H "CF-Access-Client-Secret: ..." https://[endpoint]/healthz`
+- [ ] Confirm old token (if rotated) no longer works
+```
+
+## Step 4: File the Issue
+
+File an `agent:human` issue with:
+
+- Title: `cf-access: [create/rotate/verify] service token [name] for [application]`
+- Label: `agent:human`, `priority:[level]`
+- Body: The proposal from Step 3
+
+## STOP
+
+Do NOT create or rotate tokens. Do NOT call the Cloudflare API. Your job is the proposal only.

--- a/claude/skills/cf-access/workflows/propose-tunnel-change.md
+++ b/claude/skills/cf-access/workflows/propose-tunnel-change.md
@@ -1,0 +1,82 @@
+# Propose Tunnel Route Change
+
+Use this workflow to propose adding, removing, or modifying a Cloudflare Tunnel ingress rule. You will produce a structured proposal and file it as an `agent:human` issue. You will NOT execute any changes.
+
+## Step 1: Define the Change
+
+Determine:
+
+- **Which tunnel?** (e.g., tunnel ID `e86ba6e3` on CT 202)
+- **What type of change?** Add new ingress rule, remove existing rule, or modify origin
+- **Which hostname?** The public hostname being routed (e.g., `samverk.herbhall.net`)
+- **Which origin?** The internal service and port (e.g., `http://localhost:8080`)
+
+## Step 2: Assess Impact
+
+Before proposing, evaluate:
+
+- **Is an Access Application needed?** New public hostnames MUST have a CF Access Application protecting them. Never expose an origin without auth.
+- **Does DNS exist?** The hostname needs a CNAME record pointing to the tunnel
+- **What about the catch-all rule?** Tunnel configs have a catch-all (`*` or `http_status:404`). New rules must be placed ABOVE it.
+- **Existing services on this hostname?** Changing an ingress rule redirects ALL traffic for that hostname.
+
+## Step 3: Write the Proposal
+
+Use this template:
+
+````markdown
+## CF Tunnel Route Change Proposal
+
+**Tunnel:** [tunnel ID or name]
+**Change type:** [add / remove / modify]
+**Hostname:** [public hostname]
+**Origin:** [internal service URL]
+**Priority:** [critical / high / normal]
+
+### Current Ingress Rules
+
+[List current ingress rules for this tunnel, in order]
+
+### Proposed Change
+
+[Exactly what should change -- include the full ingress rule YAML]
+
+```yaml
+# Example: adding a new route
+ingress:
+  - hostname: newservice.herbhall.net
+    service: http://localhost:9090
+  # ... existing rules ...
+  - service: http_status:404
+```
+
+### Prerequisites
+
+- [ ] DNS CNAME record for [hostname] pointing to [tunnel-id].cfargotunnel.com
+- [ ] CF Access Application protecting [hostname] (or justification for no auth)
+- [ ] Internal service running and healthy at [origin]
+
+### Justification
+
+[Why this change is needed]
+
+### Rollback Procedure
+
+To revert:
+
+1. [Remove/restore the ingress rule]
+2. [Restart cloudflared: `systemctl restart cloudflared`]
+3. [Verify with: `curl -s -o /dev/null -w "%{http_code}" https://[hostname]/healthz`]
+````
+
+## Step 4: File the Issue
+
+File an `agent:human` issue with:
+
+- Title: `cf-access: [add/remove/modify] tunnel route for [hostname]`
+- Label: `agent:human`, `priority:[level]`
+- Body: The proposal from Step 3
+
+## STOP
+
+Do NOT modify tunnel configuration. Do NOT edit cloudflared config files. Do NOT restart cloudflared. Your job is the proposal only.


### PR DESCRIPTION
## Summary

- Adds `cf-access` DevKit skill that gives agents a structured workflow for CF Zero Trust changes
- Hard Tier 3 gate: agents diagnose and propose, never execute CF API calls autonomously
- Includes diagnostic runbook (`check-auth.md`) agents must follow before assuming misconfiguration
- 4 workflows: diagnose auth failure, propose policy/token/tunnel changes

Closes samverk#200

## Impact on Existing Behaviors

- [ ] Authenticated users: no change -- skill is advisory, does not modify any running service
- [ ] API clients: no change
- [ ] After service restart: N/A -- this is a DevKit skill, not a runtime component

## Test plan

- [ ] Verify skill appears in `/skills-dashboard`
- [ ] Run `/cf-access` and confirm intake menu renders with 4 options
- [ ] Test option 1 (diagnose) routes through check-auth.md first
- [ ] Verify `<tool_restrictions>` block prevents CF API calls
- [ ] Run `/devkit-sync push` and confirm skill propagates to `~/.devkit-stable/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)